### PR TITLE
Implement key builder using the filters

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -39,7 +39,7 @@ func (e *PrefixEncoder) encodeKey(doc map[string]interface{}, prefix string, pri
 	if len(primaryKeyParts) == 0 {
 		return nil, ulog.CE("missing primary key column(s)")
 	}
-	return keys.NewKey(prefix, primaryKeyParts), nil
+	return keys.NewKey(prefix, primaryKeyParts...), nil
 }
 
 func (e *PrefixEncoder) BuildKey(doc map[string]interface{}, collection schema.Collection) (keys.Key, error) {

--- a/keys/key.go
+++ b/keys/key.go
@@ -26,7 +26,7 @@ type prefixEncodedKey struct {
 }
 
 // NewKey returns the Key
-func NewKey(prefix string, primaryKeys []interface{}) Key {
+func NewKey(prefix string, primaryKeys ...interface{}) Key {
 	return &prefixEncodedKey{
 		prefix:      prefix,
 		primaryKeys: primaryKeys,

--- a/query/filter/comparison.go
+++ b/query/filter/comparison.go
@@ -36,6 +36,9 @@ type Comparable interface {
 // Value is our value object that implements comparable so that two values can be compared.
 type Value interface {
 	Comparable
+
+	// Get to return the value
+	Get() interface{}
 }
 
 // NewValue returns Value object if it is able to create otherwise nil at this point the caller ensures that
@@ -77,6 +80,10 @@ func (i *IntValue) CompareTo(v Value) (int, error) {
 	}
 }
 
+func (i *IntValue) Get() interface{} {
+	return int64(*i)
+}
+
 func (i *IntValue) String() string {
 	if i == nil {
 		return ""
@@ -104,6 +111,10 @@ func (s *StringValue) CompareTo(v Value) (int, error) {
 	} else {
 		return 1, nil
 	}
+}
+
+func (s *StringValue) Get() interface{} {
+	return string(*s)
 }
 
 func (s *StringValue) String() string {
@@ -135,6 +146,10 @@ func (b *BoolValue) CompareTo(v Value) (int, error) {
 	return 0, nil
 }
 
+func (b *BoolValue) Get() interface{} {
+	return bool(*b)
+}
+
 func (b *BoolValue) String() string {
 	if b == nil {
 		return ""
@@ -150,6 +165,9 @@ type ValueMatcher interface {
 
 	// Type return the type of the value matcher, syntactic sugar for logging, etc
 	Type() string
+
+	// GetValue returns the value on which the Matcher is operating
+	GetValue() Value
 }
 
 // NewMatcher returns ValueMatcher that is derived from the key
@@ -182,6 +200,10 @@ func NewEqualityMatcher(v Value) *EqualityMatcher {
 	}
 }
 
+func (e *EqualityMatcher) GetValue() Value {
+	return e.Value
+}
+
 func (e *EqualityMatcher) Matches(input Value) bool {
 	res, _ := e.Value.CompareTo(input)
 	return res == 0
@@ -205,6 +227,11 @@ func NewGreaterThanMatcher(v Value) *GreaterThanMatcher {
 		Value: v,
 	}
 }
+
+func (g *GreaterThanMatcher) GetValue() Value {
+	return g.Value
+}
+
 
 func (g *GreaterThanMatcher) Matches(input Value) bool {
 	res, _ := g.Value.CompareTo(input)

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -69,6 +69,7 @@ func ParseFilter(value *structpb.Struct) (expression.Expr, error) {
 	var err error
 	var expr []expression.Expr
 	for key, value := range value.GetFields() {
+		// Range is only used to extract objects from this struct, there will only be a single object in one value
 		switch key {
 		case string(AndOP):
 			if expr, err = expression.ParseList(value.GetListValue(), ParseFilter); err != nil {

--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -1,0 +1,148 @@
+package filter
+
+import (
+	"github.com/tigrisdata/tigrisdb/keys"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// KeyBuilder is responsible for building internal Keys. A composer is caller by the builder to build the internal keys
+// based on the Composer logic.
+type KeyBuilder struct {
+	composer KeyComposer
+}
+
+// NewKeyBuilder returns a KeyBuilder
+func NewKeyBuilder(composer KeyComposer) *KeyBuilder {
+	return &KeyBuilder{
+		composer: composer,
+	}
+}
+
+// Build is responsible for building the internal keys from the user filter and using the keys defined in the schema
+// and passed by the caller in this method. The build is doing a level by level traversal to build the internal Keys.
+// On each level multiple keys can be formed because the user can specify ranges. The builder is not deciding the logic
+// of key generation, the builder is simply traversing on the filters and calling compose where the logic resides.
+func (k *KeyBuilder) Build(filters []Filter, userDefinedKeys []string) ([]keys.Key, error) {
+	var queue []Filter
+	var singleLevel []*Selector
+	var allKeys []keys.Key
+	for _, f := range filters {
+		if ss, ok := f.(*Selector); ok {
+			singleLevel = append(singleLevel, ss)
+		} else {
+			queue = append(queue, f)
+		}
+	}
+	if len(singleLevel) > 0 {
+		// if we have something on top level
+		iKeys, err := k.composer.Compose(singleLevel, userDefinedKeys, AndOP)
+		if err != nil {
+			return nil, err
+		}
+		allKeys = append(allKeys, iKeys...)
+	}
+
+	for len(queue) > 0 {
+		element := queue[0]
+		if e, ok := element.(LogicalFilter); ok {
+			var singleLevel []*Selector
+			for _, ee := range e.GetFilters() {
+				if ss, ok := ee.(*Selector); ok {
+					singleLevel = append(singleLevel, ss)
+				} else {
+					queue = append(queue, ee)
+				}
+			}
+
+			iKeys, err := k.composer.Compose(singleLevel, userDefinedKeys, e.Type())
+			if err != nil {
+				return nil, err
+			}
+			allKeys = append(allKeys, iKeys...)
+		}
+		queue = queue[1:]
+	}
+
+	return allKeys, nil
+}
+
+// KeyComposer needs to be implemented to have a custom Compose method with different constraints.
+type KeyComposer interface {
+	Compose(level []*Selector, userDefinedKeys []string, parent LogicalOP) ([]keys.Key, error)
+}
+
+// StrictEqKeyComposer is to generate internal keys only if the condition is equality on the fields that are part of
+// the schema and all these fields are present in the filters. The following rules are applied for StrictEqKeyComposer
+//  - The userDefinedKeys(indexes defined in the schema) passed in parameter should be present in the filter
+//  - For AND filters it is possible to build internal keys for composite indexes, for OR it is not possible.
+// So for OR filter an error is returned if it is used for indexes that are composite.
+type StrictEqKeyComposer struct {
+	Prefix string
+}
+
+func NewStrictEqKeyComposer(prefix string) *StrictEqKeyComposer {
+	return &StrictEqKeyComposer{
+		Prefix: prefix,
+	}
+}
+
+// Compose is implementing the logic of composing keys
+func (s *StrictEqKeyComposer) Compose(selectors []*Selector, userDefinedKeys []string, parent LogicalOP) ([]keys.Key, error) {
+	var compositeKeys = make([][]*Selector, 1) // allocate just for the first keyParts
+	for _, k := range userDefinedKeys {
+		var repeatedFields []*Selector
+		for _, sel := range selectors {
+			if k == sel.Field {
+				repeatedFields = append(repeatedFields, sel)
+			}
+			if sel.Matcher.Type() != EQ {
+				return nil, status.Errorf(codes.InvalidArgument, "filters only supporting $eq comparison, found '%s'", sel.Matcher.Type())
+			}
+		}
+
+		if len(repeatedFields) == 0 {
+			// nothing found or a gap
+			return nil, status.Errorf(codes.InvalidArgument, "filters doesn't contains primary key fields")
+		}
+		if len(repeatedFields) > 1 && parent == AndOP {
+			// with AND there is no use of EQ on the same field
+			return nil, status.Errorf(codes.InvalidArgument, "reusing same fields for conditions on equality")
+		}
+
+		compositeKeys[0] = append(compositeKeys[0], repeatedFields[0])
+		// as we found some repeated fields in the filter so clone the first set of keys and add this prefix to all the
+		// repeated fields, cloning is only needed if there are more than one repeated fields
+		for j := 1; j < len(repeatedFields); j++ {
+			keyPartsCopy := make([]*Selector, len(compositeKeys[0])-1)
+			copy(keyPartsCopy, compositeKeys[0][0:len(compositeKeys[0])-1])
+			keyPartsCopy = append(keyPartsCopy, repeatedFields[j])
+			compositeKeys = append(compositeKeys, keyPartsCopy)
+		}
+	}
+
+	// keys building is dependent on the filter type
+	var allKeys []keys.Key
+	for _, k := range compositeKeys {
+		switch parent {
+		case AndOP:
+			var primaryKeyParts []interface{}
+			for _, s := range k {
+				primaryKeyParts = append(primaryKeyParts, s.Matcher.GetValue().Get())
+			}
+
+			allKeys = append(allKeys, keys.NewKey(s.Prefix, primaryKeyParts...))
+		case OrOP:
+			for _, sel := range k {
+				if len(userDefinedKeys) > 1 {
+					// this means OR can't build independently these keys
+					return nil, status.Errorf(codes.InvalidArgument, "OR is not supported with composite primary keys")
+				}
+
+				allKeys = append(allKeys, keys.NewKey(s.Prefix, sel.Matcher.GetValue().Get()))
+			}
+		}
+	}
+
+	return allKeys, nil
+}

--- a/query/filter/key_builder_test.go
+++ b/query/filter/key_builder_test.go
@@ -1,0 +1,104 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	api "github.com/tigrisdata/tigrisdb/api/server/v1"
+	"github.com/tigrisdata/tigrisdb/keys"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func testFilters(t testing.TB, input []byte) []Filter {
+	var r = &api.ReadRequest{}
+	require.NoError(t, protojson.Unmarshal(input, r))
+
+	filters, err := Build(r.Filter)
+	require.NoError(t, err)
+	require.NotNil(t, filters)
+
+	return filters
+}
+
+func TestKeyBuilder(t *testing.T) {
+	cases := []struct {
+		userKeys  []string
+		userInput []byte
+		expError  error
+		expKeys   []keys.Key
+	}{
+		{
+			// fewer fields in user input
+			[]string{"a", "c", "b"},
+			[]byte(`{"filter": [{"a": 10}, {"c": 10}]}`),
+			status.Errorf(codes.InvalidArgument, "filters doesn't contains primary key fields"),
+			nil,
+		},
+		{
+			// some fields are not with eq
+			[]string{"a", "c", "b"},
+			[]byte(`{"filter": [{"a": 10}, {"b": {"$eq": 10}}, {"c": {"$gt": 15}}]}`),
+			status.Errorf(codes.InvalidArgument, "filters only supporting $eq comparison, found '$gt'"),
+			nil,
+		},
+		{
+			// some fields are repeated
+			[]string{"a", "b"},
+			[]byte(`{"filter": [{"a": 10}, {"b": {"$eq": 10}}, {"b": 15}]}`),
+			status.Errorf(codes.InvalidArgument, "reusing same fields for conditions on equality"),
+			nil,
+		},
+		{
+			// single user defined key
+			[]string{"a"},
+			[]byte(`{"filter": [{"b": 10}, {"a": {"$eq": 1}}]}`),
+			nil,
+			[]keys.Key{keys.NewKey("", int64(1))},
+		},
+		{
+			// composite user defined key
+			[]string{"a", "b", "c"},
+			[]byte(`{"filter": [{"b": 10}, {"a": {"$eq": true}}, {"c": "foo"}]}`),
+			nil,
+			[]keys.Key{keys.NewKey("", true, int64(10), "foo")},
+		},
+		{
+			// single with AND/OR filter
+			[]string{"a"},
+			[]byte(`{"filter": [{"$or": [{"a": 1}, {"$and": [{"a":2}, {"f1": 3}]}]}, {"$and": [{"a": 4}, {"$or": [{"a":5}, {"f2": 6}]}, {"$or": [{"a":5}, {"a": 6}]}]}]}`),
+			nil,
+			[]keys.Key{keys.NewKey("", int64(1)), keys.NewKey("", int64(4)), keys.NewKey("", int64(2)), keys.NewKey("", int64(5)), keys.NewKey("", int64(5)), keys.NewKey("", int64(6))},
+		},
+		{
+			// composite with AND filter
+			[]string{"a", "b"},
+			[]byte(`{"filter":[{"$and":[{"a":1},{"b":"aaa"},{"$and":[{"a":2},{"c":5},{"b":"bbb"}]}]},{"$and":[{"a":4},{"c":10},{"b":"ccc"}]}]}`),
+			nil,
+			[]keys.Key{keys.NewKey("", int64(1), "aaa"), keys.NewKey("", int64(4), "ccc"), keys.NewKey("", int64(2), "bbb")},
+		}, {
+			[]string{"a"},
+			[]byte(`{"filter":[{"b":10},{"a":1},{"c":"ccc"},{"$or":[{"f1":10},{"a":2}]}]}`),
+			nil,
+			[]keys.Key{keys.NewKey("", int64(1)), keys.NewKey("", int64(2))},
+		},
+	}
+	for _, c := range cases {
+		b := NewKeyBuilder(NewStrictEqKeyComposer(""))
+		filters := testFilters(t, c.userInput)
+		buildKeys, err := b.Build(filters, c.userKeys)
+		require.Equal(t, c.expError, err)
+		require.Equal(t, c.expKeys, buildKeys)
+	}
+}
+
+func BenchmarkStrictEqKeyComposer_Compose(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		kb := NewKeyBuilder(NewStrictEqKeyComposer(""))
+		filters := testFilters(b, []byte(`{"filter": [{"b": 10}, {"a": {"$eq": 10}}, {"c": "foo"}]}`))
+		_, err := kb.Build(filters, []string{"a", "b", "c"})
+		require.NoError(b, err)
+	}
+	b.ReportAllocs()
+}

--- a/query/filter/logical.go
+++ b/query/filter/logical.go
@@ -33,6 +33,7 @@ const (
 //    {"$or": [{"f1":1}, {"f2": 3}]}
 type LogicalFilter interface {
 	GetFilters() []Filter
+	Type() LogicalOP
 }
 
 // AndFilter performs a logical AND operation on an array of two or more expressions. The and filter looks like this,
@@ -61,6 +62,11 @@ func (a *AndFilter) validate() error {
 
 	return nil
 }
+
+func (a *AndFilter) Type() LogicalOP {
+	return AndOP
+}
+
 
 // Matches returns true if the input doc matches this filter.
 func (a *AndFilter) Matches(doc *structpb.Struct) bool {
@@ -112,6 +118,10 @@ func (o *OrFilter) validate() error {
 	}
 
 	return nil
+}
+
+func (o *OrFilter) Type() LogicalOP {
+	return OrOP
 }
 
 // Matches returns true if the input doc matches this filter.


### PR DESCRIPTION
This diff introduces a key builder. The key builder uses filters to build internal keys. The current diff introduce a equality based composer from the filters i.e. a filter should have all the fields as defined in the schema. 