### PR TITLE
Implement custom marshaling/unmarshalling to avoid deserializing/serializing user payload

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+// MarshalJSON on read response avoid any encoding/decoding on x.Doc. With this approach we are not doing any extra
+// marshaling/unmarshalling in returning the data from the database. The document returned from the database is stored
+// in x.Doc and will return as-is.
+//
+// Note: This also means any changes in ReadResponse proto needs to make sure that we add that here and similarly
+// the openAPI specs needs to be specify Doc as object instead of bytes.
+func (x *ReadResponse) MarshalJSON() ([]byte, error) {
+	b := []byte(`{"doc":`)
+	b = append(b, x.Doc...)
+	b = append(b, []byte(`}`)...)
+	return b, nil
+}
+
+// UnmarshalJSON on ReadRequest avoids unmarshalling filter and instead this way we can write a custom struct to do
+// the unmarshalling and will be avoiding any extra allocation/copying.
+func (x *ReadRequest) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "db":
+			if err := jsoniter.Unmarshal(value, &x.Db); err != nil {
+				return err
+			}
+		case "collection":
+			if err := jsoniter.Unmarshal(value, &x.Collection); err != nil {
+				return err
+			}
+		case "filter":
+			// not decoding it here and let it decode during filter parsing
+			x.Filter = value
+		case "keys":
+			if err := jsoniter.Unmarshal(value, &x.Keys); err != nil {
+				return err
+			}
+		case "options":
+			if err := jsoniter.Unmarshal(value, &x.Options); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON on InsertRequest avoids unmarshalling user document. We only need to extract primary/index keys from
+// the document and want to store the document as-is in the database. This way there is no exta cost of serialization/deserialization
+// and also less error prone because we are not touching the user document.
+func (x *InsertRequest) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "db":
+			if err := jsoniter.Unmarshal(value, &x.Db); err != nil {
+				return err
+			}
+		case "collection":
+			if err := jsoniter.Unmarshal(value, &x.Collection); err != nil {
+				return err
+			}
+		case "documents":
+			if err := jsoniter.Unmarshal(value, &x.Documents); err != nil {
+				return err
+			}
+		case "options":
+			if err := jsoniter.Unmarshal(value, &x.Options); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON is a custom unmarshaler implemented for the Document struct. The req handler needs to extract out
+// the relevant keys from this document and should pass it as-is to the underlying engine.
+func (x *Document) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+
+	for key, value := range mp {
+		switch key {
+		case "doc":
+			// no need to decode
+			x.Doc = value
+		case "options":
+			if err := jsoniter.Unmarshal(value, &x.Options); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/api/server/v1/marshaler_test.go
+++ b/api/server/v1/marshaler_test.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocument(t *testing.T) {
+	// ToDo: add marshaler tests
+	inputDoc := []byte(`{"pkey_int": 1, "int_value": 2, "str_value": "foo"}`)
+	b, err := json.Marshal(inputDoc)
+	require.NoError(t, err)
+
+	var bb []byte
+	require.NoError(t, json.Unmarshal(b, &bb))
+}

--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -14,10 +14,6 @@
 
 package api
 
-import (
-	"google.golang.org/protobuf/types/known/structpb"
-)
-
 func IsTxSupported(req Request) bool {
 	switch RequestType(req) {
 	case Insert, Replace, Update, Delete, Read:
@@ -39,9 +35,13 @@ func GetTransaction(req Request) *TransactionCtx {
 	}
 }
 
-func GetFilter(req Request) []*structpb.Struct {
+func GetFilter(req Request) []byte {
 	switch r := req.(type) {
 	case *ReadRequest:
+		return r.GetFilter()
+	case *UpdateRequest:
+		return r.GetFilter()
+	case *DeleteRequest:
 		return r.GetFilter()
 	default:
 		return nil

--- a/api/server/v1/user.proto
+++ b/api/server/v1/user.proto
@@ -36,10 +36,6 @@ message WriteResponseHeader {
   string msg = 2;
 }
 
-message Filter {
-  repeated google.protobuf.Struct value = 1;
-}
-
 message WriteOption {
   TransactionCtx tx_ctx = 1;
 }
@@ -55,7 +51,7 @@ message DropDatabaseOption {}
 message DocOption {}
 
 message Document {
-  google.protobuf.Struct doc = 1;
+  bytes doc = 1;
   DocOption options = 2;
 }
 
@@ -97,7 +93,7 @@ message InsertResponse {
 message DeleteRequest {
   string db = 1;
   string collection = 2;
-  repeated Filter filter = 3;
+  bytes filter = 3;
   WriteOption options = 4;
 }
 
@@ -119,8 +115,8 @@ message ReplaceResponse {
 message UpdateRequest {
   string db = 1;
   string collection = 2;
-  google.protobuf.Struct fields = 3;
-  repeated Filter filter = 4;
+  bytes fields = 3;
+  bytes filter = 4;
   WriteOption options = 5;
 }
 
@@ -137,7 +133,7 @@ message ReadRequest {
 }
 
 message ReadResponse {
-  google.protobuf.Struct doc = 1;
+  bytes doc = 1;
 }
 
 message CreateDatabaseRequest {

--- a/go.mod
+++ b/go.mod
@@ -34,9 +34,12 @@ require (
 	github.com/go-openapi/swag v0.19.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jhump/protoreflect v1.5.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -407,9 +408,11 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=

--- a/server/services/v1/users.go
+++ b/server/services/v1/users.go
@@ -68,7 +68,7 @@ func newUserService(kv kv.KV) *userService {
 }
 
 func (s *userService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel) error {
-	mux := runtime.NewServeMux(runtime.WithMarshalerOption(string(JSON), &runtime.JSONBuiltin{}))
+	mux := runtime.NewServeMux(runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONBuiltin{}))
 
 	if err := api.RegisterTigrisDBHandlerClient(context.TODO(), mux, api.NewTigrisDBClient(inproc)); err != nil {
 		return err


### PR DESCRIPTION
- Implementing custom marshaling/unmarshalling for user document, input requests, read response, etc. With this approach we are not doing any extra serialization and storing and returning the data as-is from the database.
- In this diff, also moving filtering logic to custom unmarshalling
- Moving all write/read APIs options to only use bytes instead of structpb