### PR TITLE
Add rest custom error code to customize the error message and to not return gRPC message to http clients

### DIFF
--- a/api/server/v1/error.go
+++ b/api/server/v1/error.go
@@ -1,0 +1,113 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/protobuf/ptypes/any"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// RestError is our Tigris HTTP counterpart of grpc status. All the APIs should use this Error to return as a user facing
+// error. RestError will return grpcStatus to the muxer so that grpc client can see grpcStatus as the final output. For
+// HTTP clients see the **MarshalStatus** method where we are returning the response by not the grpc code as that is not
+// needed for HTTP clients.
+type RestError struct {
+	// The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code]. We don't need to marshal
+	// this code for HTTP clients.
+	Code codes.Code `json:"-,omitempty"`
+	// A developer-facing error message.
+	Message string `json:"message,omitempty"`
+	// A list of messages that carry the error details. This is mainly to send our internal codes and messages.
+	Details []*ErrorDetails `json:"details,omitempty"`
+}
+
+// Error to return the underlying error message
+func (e *RestError) Error() string {
+	return e.Message
+}
+
+// GRPCStatus converts the RestError and return status.Status. This is used to return grpc status to the grpc clients
+func (e *RestError) GRPCStatus() *status.Status {
+	s := &spb.Status{
+		Code:    int32(e.Code),
+		Message: e.Message,
+	}
+
+	if len(e.Details) == 0 {
+		return status.FromProto(s)
+	}
+
+	var details []*any.Any
+	for _, d := range e.Details {
+		var a = &any.Any{}
+		err := anypb.MarshalFrom(a, d, proto.MarshalOptions{})
+		if err == nil {
+			details = append(details, a)
+		}
+	}
+
+	s.Details = details
+	return status.FromProto(s)
+}
+
+// WithDetails a helper method for adding details to the RestError
+func (e *RestError) WithDetails(details ...*ErrorDetails) *RestError {
+	e.Details = details
+	return e
+}
+
+// MarshalStatus marshal status object
+func MarshalStatus(status *spb.Status) ([]byte, error) {
+	var resp = &RestError{}
+	resp.Message = status.Message
+	if len(status.Details) > 0 {
+		var internalDetails []*ErrorDetails
+		for _, d := range status.Details {
+			var ed = &ErrorDetails{}
+			err := anypb.UnmarshalTo(d, ed, proto.UnmarshalOptions{})
+			if err != nil {
+				return nil, err
+			}
+			internalDetails = append(internalDetails, ed)
+		}
+		resp.Details = internalDetails
+	}
+
+	return json.Marshal(resp)
+}
+
+// Errorf returns Error(c, fmt.Sprintf(format, a...)).
+func Errorf(c codes.Code, format string, a ...interface{}) *RestError {
+	return Error(c, fmt.Sprintf(format, a...))
+}
+
+// Error returns an error representing c and msg.  If c is OK, returns nil.
+func Error(c codes.Code, msg string) *RestError {
+	if c == codes.OK {
+		return nil
+	}
+
+	return &RestError{
+		Code:    c,
+		Message: msg,
+	}
+}

--- a/api/server/v1/user.go
+++ b/api/server/v1/user.go
@@ -40,6 +40,7 @@ const (
 
 type Request interface {
 	proto.Message
+
 	Validator
 }
 

--- a/api/server/v1/user.proto
+++ b/api/server/v1/user.proto
@@ -22,6 +22,11 @@ option go_package = "github.com/tigrisdata/tigrisdb/api";
 // BUG: gnostic protoc-gen-openapi doesn't support enum generation
 // https://github.com/google/gnostic/issues/255
 
+message ErrorDetails {
+  uint32 code = 1;
+  string msg = 2;
+}
+
 message WriteOption {
   TransactionCtx tx_ctx = 1;
 }

--- a/api/server/v1/validator.go
+++ b/api/server/v1/validator.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type Validator interface {
@@ -53,7 +52,7 @@ func (x *InsertRequest) Validate() error {
 	}
 
 	if len(x.GetDocuments()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "empty documents received")
+		return Errorf(codes.InvalidArgument, "empty documents received")
 	}
 	return nil
 }
@@ -64,7 +63,7 @@ func (x *ReplaceRequest) Validate() error {
 	}
 
 	if len(x.GetDocuments()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "empty documents received")
+		return Errorf(codes.InvalidArgument, "empty documents received")
 	}
 	return nil
 }
@@ -75,7 +74,7 @@ func (x *UpdateRequest) Validate() error {
 	}
 
 	if x.Filter == nil {
-		return status.Errorf(codes.InvalidArgument, "filter is a required field")
+		return Errorf(codes.InvalidArgument, "filter is a required field")
 	}
 	return nil
 }
@@ -86,7 +85,7 @@ func (x *DeleteRequest) Validate() error {
 	}
 
 	if x.Filter == nil {
-		return status.Errorf(codes.InvalidArgument, "filter is a required field")
+		return Errorf(codes.InvalidArgument, "filter is a required field")
 	}
 	return nil
 }
@@ -105,12 +104,12 @@ func (x *CreateCollectionRequest) Validate() error {
 	}
 
 	if x.Schema == nil {
-		return status.Errorf(codes.InvalidArgument, "schema is a required during collection creation")
+		return Errorf(codes.InvalidArgument, "schema is a required during collection creation")
 	}
 
 	if !IsTxSupported(x) {
 		if transaction := GetTransaction(x); transaction != nil {
-			return status.Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
+			return Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
 		}
 	}
 
@@ -124,7 +123,7 @@ func (x *DropCollectionRequest) Validate() error {
 
 	if !IsTxSupported(x) {
 		if transaction := GetTransaction(x); transaction != nil {
-			return status.Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
+			return Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
 		}
 	}
 
@@ -138,7 +137,7 @@ func (x *AlterCollectionRequest) Validate() error {
 
 	if !IsTxSupported(x) {
 		if transaction := GetTransaction(x); transaction != nil {
-			return status.Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
+			return Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
 		}
 	}
 
@@ -152,7 +151,7 @@ func (x *TruncateCollectionRequest) Validate() error {
 
 	if !IsTxSupported(x) {
 		if transaction := GetTransaction(x); transaction != nil {
-			return status.Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
+			return Errorf(codes.InvalidArgument, "interactive tx not supported but transaction token found")
 		}
 	}
 
@@ -161,7 +160,7 @@ func (x *TruncateCollectionRequest) Validate() error {
 
 func isValidCollection(name string) error {
 	if len(name) == 0 {
-		return status.Errorf(codes.InvalidArgument, "invalid collection name %s", name)
+		return Error(codes.InvalidArgument, "invalid collection name")
 	}
 
 	return nil
@@ -169,7 +168,7 @@ func isValidCollection(name string) error {
 
 func isValidDatabase(name string) error {
 	if len(name) == 0 {
-		return status.Errorf(codes.InvalidArgument, "invalid database name %s", name)
+		return Error(codes.InvalidArgument, "invalid database name")
 	}
 
 	return nil

--- a/server/services/v1/query_lifecycle.go
+++ b/server/services/v1/query_lifecycle.go
@@ -17,8 +17,9 @@ package v1
 import (
 	"context"
 
+	api "github.com/tigrisdata/tigrisdb/api/server/v1"
+
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // QueryLifecycleFactory is responsible for returning queryLifecycle objects
@@ -43,10 +44,10 @@ func newQueryLifecycle() *queryLifecycle {
 
 func (q *queryLifecycle) run(ctx context.Context, req *Request) (*Response, error) {
 	if req == nil {
-		return nil, status.Errorf(codes.Internal, "empty request")
+		return nil, api.Errorf(codes.Internal, "empty request")
 	}
 	if req.queryRunner == nil {
-		return nil, status.Errorf(codes.Internal, "query runner is missing")
+		return nil, api.Errorf(codes.Internal, "query runner is missing")
 	}
 
 	return req.queryRunner.Run(ctx, req)


### PR DESCRIPTION
- To not return gRPC error codes to HTTP clients
- Unify both error code handling by introducing RestError struct in our code
- Remove validator interceptor and rather do it in the server layer as interceptor returns gRPC error code