### PR TITLE
Key encoding implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/jhump/protoreflect v1.11.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.14.1 // indirect
+	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/valyala/fasthttp v1.33.0 // indirect
+	github.com/valyala/fasthttp v1.34.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
@@ -74,7 +74,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,9 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.14.1 h1:hLQYb23E8/fO+1u53d02A97a8UnsddcvYzq4ERRU4ds=
 github.com/klauspost/compress v1.14.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
+github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -381,6 +384,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.33.0 h1:mHBKd98J5NcXuBddgjvim1i3kWzlng1SzLhrnBOU9g8=
 github.com/valyala/fasthttp v1.33.0/go.mod h1:KJRK/MXx0J+yd0c5hlR+s1tIHD72sniU8ZJjl97LIw4=
+github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=
+github.com/valyala/fasthttp v1.34.0/go.mod h1:epZA5N+7pY6ZaEKRmstzOuYJx9HI8DI1oaCGZpdH4h0=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
@@ -427,6 +432,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/server/metadata/encoding/key.go
+++ b/server/metadata/encoding/key.go
@@ -1,0 +1,378 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encoding
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	api "github.com/tigrisdata/tigrisdb/api/server/v1"
+	"github.com/tigrisdata/tigrisdb/keys"
+	"github.com/tigrisdata/tigrisdb/server/transaction"
+	"github.com/tigrisdata/tigrisdb/store/kv"
+	"google.golang.org/grpc/codes"
+)
+
+// There are three subspaces(tables) introduced by this package. The first is reserved to which is used for two things
+// mainly, the first is to reserve a value against a namespace which needs to be unique and passed by the caller and the
+// other use case is to maintain a counter.
+//
+// The reserved subspace structure looks like below,
+//   [“reserved”, "namespace", "namespace1", "created"] = x
+//   where,
+//     "reserved", "namespace", and "created" are keywords and "namespace1" is a namespace.
+//
+// The second subspace is the "encoding" which is used to assign dictionary encoded values for the database, collection
+// and any index names. Values assigned are monotonically incremental counter and are local to this cluster and doesn't
+// need to be unique across the TigrisDB ecosystem.
+//
+// The structure for encoding subspace looks like below,
+//    ["encoding", 0x01, x, "db", "db-1", "created"] = 0x01
+//  where,
+//    - encoding is the keyword for this table.
+//    - 0x01 is the encoding version
+//    - x is the value assigned for the namespace
+//    - "db", "created" are keywords and "db-1" is the name of the database.
+//    - 0x01 is the value assigned to this database.
+
+// Based on the above, The below is an example of how operations are mapped to these values.
+// Request: To Create a New Database
+// The value would be derived from the counter value stored in the reserved subspace. If the counter is not yet issued
+// then it will start from 0x01.
+//    ["encoding", 0x01, x "db", "db-1", "created"] = 0x01
+//    ["encoding", 0x01, x, "db", "db-2", "created"] = 0x02
+//
+// Request: To Create a New Collection
+// The value would be derived from the counter value stored in the reserved table. It can't be empty as there must be
+// a database already created so a value is already assigned to it.
+//    ["encoding", 0x01, x, 0x01, "coll", "coll-1", "created"] = 0x03
+//
+// Request: To Add an Index
+//    ["encoding", 0x01, x, 0x01, 0x03, "index", "pkey", "created"] = 0x04
+//    ["encoding", 0x01, x, 0x01, 0x03, "index", "email_index", "created"] = 0x05
+//
+// Request: To drop an Index
+//   ["encoding", 0x01, x, 0x01, 0x03, "index", "pkey", "dropped"] = 0x04
+//
+// The schemas' subspace will be storing the actual schema of the user for a collection. The schema subspace will
+// look like below
+//    ["schemas", 0x01, x, 0x01, 0x03, "created", 0x01] => {
+//      properties: {"a": int},
+//      primary_key: ["a"],
+//      indexes: [
+//        {name: “primary”, code: 2, columns: [“id”]},
+//        {name: “email_index”, code: 3, columns: [“email”], unique:true},
+//        {name: “created_at_index”, code: 4, columns: [“created_at”]},
+//      ]
+//    }
+//
+const (
+	namespaceKey  = "namespace"
+	dbKey         = "db"
+	collectionKey = "coll"
+	counterKey    = "counter"
+	indexKey      = "index"
+	keyEnd        = "created"
+)
+
+// subspaces
+const (
+	reservedSubspaceKey = "reserved"
+	encodingSubspaceKey = "encoding"
+)
+
+var (
+	// versions
+	encVersion = []byte{0x01}
+
+	invalidId         = uint32(0)
+	reservedBaseValue = uint32(1)
+)
+
+// reservedSubspace struct is used to manage reserved subspace.
+type reservedSubspace struct {
+	sync.RWMutex
+
+	allocated map[uint32]string
+}
+
+func newReservedSubspace() *reservedSubspace {
+	return &reservedSubspace{
+		allocated: make(map[uint32]string),
+	}
+}
+
+func (r *reservedSubspace) reload(ctx context.Context, tx transaction.Tx) error {
+	key := keys.NewKey(reservedSubspaceKey)
+	it, err := tx.Read(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	for it.More() {
+		row, err := it.Next()
+		if err != nil {
+			return err
+		}
+
+		if len(row.Key) < 3 {
+			return api.Errorf(codes.Internal, "not a valid key %v", row.Key)
+		}
+
+		allocatedTo := row.Key[len(row.Key)-2]
+		if _, ok := allocatedTo.(string); !ok {
+			return api.Errorf(codes.Internal, "unable to deduce the encoded key from fdb key %T", allocatedTo)
+		}
+
+		r.Lock()
+		r.allocated[ByteToUInt32(row.Value)] = allocatedTo.(string)
+		r.Unlock()
+	}
+
+	return nil
+}
+
+func (r *reservedSubspace) reserveNamespace(ctx context.Context, tx transaction.Tx, namespace string, id uint32) error {
+	if len(namespace) == 0 {
+		return api.Errorf(codes.InvalidArgument, "namespace is empty")
+	}
+
+	if err := r.reload(ctx, tx); err != nil {
+		return err
+	}
+
+	r.RLock()
+	defer r.RUnlock()
+	if allocatedTo, ok := r.allocated[id]; ok {
+		if allocatedTo == namespace {
+			return nil
+		} else {
+			return api.Errorf(codes.AlreadyExists, "id is already assigned to the namespace '%s'", allocatedTo)
+		}
+	}
+
+	key := keys.NewKey(reservedSubspaceKey, namespaceKey, namespace, keyEnd)
+	// now do insert because we need strict insert functionality here
+	if err := tx.Insert(ctx, key, UInt32ToByte(id)); err != nil {
+		log.Debug().Interface("key", key).Uint32("value", id).Err(err).Msg("reserving namespace failed")
+		return err
+	}
+
+	log.Debug().Interface("key", key).Uint32("value", id).Msg("reserving namespace succeed")
+	return nil
+}
+
+func (r *reservedSubspace) allocateToken(ctx context.Context, tx transaction.Tx, keyName string) (uint32, error) {
+	key := keys.NewKey(reservedSubspaceKey, keyName, counterKey, keyEnd)
+	it, err := tx.Read(ctx, key)
+	if err != nil {
+		return 0, err
+	}
+
+	newReservedValue := reservedBaseValue
+	if it.More() {
+		row, err := it.Next()
+		if err != nil {
+			return 0, err
+		}
+
+		newReservedValue = ByteToUInt32(row.Value) + 1
+	}
+
+	if err := tx.Replace(ctx, key, UInt32ToByte(newReservedValue)); err != nil {
+		return 0, err
+	}
+
+	log.Debug().Interface("key", key).Uint32("value", newReservedValue).Msg("reserved new value")
+
+	return newReservedValue, nil
+}
+
+type KeyEncoder struct {
+	reservedSb *reservedSubspace
+}
+
+func NewKeyEncoder() *KeyEncoder {
+	return &KeyEncoder{
+		reservedSb: newReservedSubspace(),
+	}
+}
+
+// ReserveNamespace is the first step in the encoding and the mapping is passed the caller. As this is the first encoded
+// integer the caller needs to make sure a unique value is assigned to this namespace.
+func (k *KeyEncoder) ReserveNamespace(ctx context.Context, tx transaction.Tx, namespace string, id uint32) error {
+	return k.reservedSb.reserveNamespace(ctx, tx, namespace, id)
+}
+
+func (k *KeyEncoder) EncodeDatabaseName(ctx context.Context, tx transaction.Tx, dbName string, namespaceId uint32) (uint32, error) {
+	if err := k.validNamespaceId(namespaceId); err != nil {
+		return invalidId, err
+	}
+	if len(dbName) == 0 {
+		return invalidId, api.Errorf(codes.InvalidArgument, "database name is empty")
+	}
+
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), dbKey, dbName, keyEnd)
+	return k.encode(ctx, tx, key, dbKey)
+}
+
+func (k *KeyEncoder) EncodeCollectionName(ctx context.Context, tx transaction.Tx, collection string, namespaceId uint32, dbId uint32) (uint32, error) {
+	if err := k.validNamespaceId(namespaceId); err != nil {
+		return invalidId, err
+	}
+	if err := k.validDatabaseId(dbId); err != nil {
+		return invalidId, err
+	}
+	if len(collection) == 0 {
+		return invalidId, api.Errorf(codes.InvalidArgument, "collection name is empty")
+	}
+
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), UInt32ToByte(dbId), collectionKey, collection, keyEnd)
+	return k.encode(ctx, tx, key, collectionKey)
+}
+
+func (k *KeyEncoder) EncodeIndexName(ctx context.Context, tx transaction.Tx, indexName string, namespaceId uint32, dbId uint32, collId uint32) (uint32, error) {
+	if err := k.validNamespaceId(namespaceId); err != nil {
+		return invalidId, err
+	}
+	if err := k.validDatabaseId(dbId); err != nil {
+		return invalidId, err
+	}
+	if err := k.validCollectionId(collId); err != nil {
+		return invalidId, err
+	}
+	if len(indexName) == 0 {
+		return invalidId, api.Errorf(codes.InvalidArgument, "index name is empty")
+	}
+
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), UInt32ToByte(dbId), UInt32ToByte(collId), indexKey, indexName, keyEnd)
+	return k.encode(ctx, tx, key, indexKey)
+}
+
+func (k *KeyEncoder) encode(ctx context.Context, tx transaction.Tx, key keys.Key, encName string) (uint32, error) {
+	reserveToken, err := k.reservedSb.allocateToken(ctx, tx, encodingSubspaceKey)
+	if err != nil {
+		return invalidId, err
+	}
+
+	// now do insert because we need to fail if token is already assigned
+	if err := tx.Insert(ctx, key, UInt32ToByte(reserveToken)); err != nil {
+		log.Debug().Interface("key", key).Uint32("value", reserveToken).Err(err).Str("type", encName).Msg("encoding failed")
+		return invalidId, err
+	}
+	log.Debug().Interface("key", key).Uint32("value", reserveToken).Str("type", encName).Msg("encoding succeed")
+
+	return reserveToken, nil
+}
+
+func (k *KeyEncoder) validNamespaceId(id uint32) error {
+	if id == invalidId {
+		return api.Errorf(codes.InvalidArgument, "invalid namespace id")
+	}
+	return nil
+}
+
+func (k *KeyEncoder) validDatabaseId(id uint32) error {
+	if id == invalidId {
+		return api.Errorf(codes.InvalidArgument, "invalid database id")
+	}
+	return nil
+}
+
+func (k *KeyEncoder) validCollectionId(id uint32) error {
+	if id == invalidId {
+		return api.Errorf(codes.InvalidArgument, "invalid collection id")
+	}
+	return nil
+}
+
+func (k *KeyEncoder) getDatabaseId(ctx context.Context, tx transaction.Tx, dbName string, namespaceId uint32) (uint32, error) {
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), dbKey, dbName, keyEnd)
+	return k.getId(ctx, tx, key)
+}
+
+func (k *KeyEncoder) getCollectionId(ctx context.Context, tx transaction.Tx, collName string, namespaceId uint32, dbId uint32) (uint32, error) {
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), UInt32ToByte(dbId), collectionKey, collName, keyEnd)
+	return k.getId(ctx, tx, key)
+}
+
+func (k *KeyEncoder) getIndexId(ctx context.Context, tx transaction.Tx, indexName string, namespaceId uint32, dbId uint32, collId uint32) (uint32, error) {
+	key := keys.NewKey(encodingSubspaceKey, encVersion, UInt32ToByte(namespaceId), UInt32ToByte(dbId), UInt32ToByte(collId), indexKey, indexName, keyEnd)
+	return k.getId(ctx, tx, key)
+}
+
+func (k *KeyEncoder) getId(ctx context.Context, tx transaction.Tx, key keys.Key) (uint32, error) {
+	it, err := tx.Read(ctx, key)
+	if err != nil {
+		return invalidId, err
+	}
+
+	if it.More() {
+		row, err := it.Next()
+		if err != nil {
+			return 0, err
+		}
+
+		return ByteToUInt32(row.Value), nil
+	}
+
+	return invalidId, api.Errorf(codes.NotFound, "not found %v", key)
+}
+
+// decode is currently only use for debugging purpose, once we have a layer on top of this encoding then we leverage this
+// method
+func (k *KeyEncoder) decode(_ context.Context, fdbKey kv.Key) (map[string]interface{}, error) {
+	var decoded = make(map[string]interface{})
+	if len(fdbKey) > 0 {
+		decoded["version"] = fdbKey[0]
+	}
+	if len(fdbKey) > 1 {
+		decoded[namespaceKey] = ByteToUInt32(fdbKey[1].([]byte))
+	}
+	if end, ok := fdbKey[len(fdbKey)-1].(string); !ok || end != keyEnd {
+		return nil, fmt.Errorf("key is not from encoding subspace")
+	}
+
+	switch len(fdbKey) {
+	case 5:
+		// if it is the format <version,namespace-id,db,dbName,keyEnd>
+		decoded[dbKey] = fdbKey[3].(string)
+	case 6:
+		// if it is the format <version,namespace-id,db-id,coll,coll-name,keyEnd>
+		decoded[dbKey] = ByteToUInt32(fdbKey[2].([]byte))
+		decoded[collectionKey] = fdbKey[4].(string)
+	case 7:
+		// if it is the format <version,namespace-id,db-id,coll-id,indexName,index-name,keyEnd>
+		decoded[dbKey] = ByteToUInt32(fdbKey[2].([]byte))
+		decoded[collectionKey] = ByteToUInt32(fdbKey[3].([]byte))
+		decoded[indexKey] = fdbKey[5].(string)
+	}
+
+	return decoded, nil
+}
+
+func ByteToUInt32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}
+
+func UInt32ToByte(v uint32) []byte {
+	b := make([]byte, 4)
+
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}

--- a/server/metadata/encoding/key_test.go
+++ b/server/metadata/encoding/key_test.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encoding
+
+import (
+	"context"
+	api "github.com/tigrisdata/tigrisdb/api/server/v1"
+	"google.golang.org/grpc/codes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigrisdb/server/config"
+	"github.com/tigrisdata/tigrisdb/server/transaction"
+	"github.com/tigrisdata/tigrisdb/store/kv"
+)
+
+func TestKeyEncoding(t *testing.T) {
+	fdbCfg, err := config.GetTestFDBConfig()
+	require.NoError(t, err)
+
+	kv, err := kv.NewFoundationDB(fdbCfg)
+	require.NoError(t, err)
+
+	tm := transaction.NewManager(kv)
+	k := NewKeyEncoder()
+
+	ctx := context.TODO()
+	tx, err := tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", 1234))
+	require.NoError(t, tx.Commit(ctx))
+
+	tx, err = tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	dbId, err := k.EncodeDatabaseName(ctx, tx, "db-1", 1234)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	tx, err = tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	collId, err := k.EncodeCollectionName(ctx, tx, "coll-1", 1234, 1)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	tx, err = tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	indexId, err := k.EncodeIndexName(ctx, tx, "pkey", 1234, 1, 2)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	tx, err = tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	v, err := k.getDatabaseId(ctx, tx, "db-1", 1234)
+	require.NoError(t, err)
+	require.Equal(t, v, dbId)
+
+	v, err = k.getCollectionId(ctx, tx, "coll-1", 1234, dbId)
+	require.NoError(t, err)
+	require.Equal(t, v, collId)
+
+	v, err = k.getIndexId(ctx, tx, "pkey", 1234, dbId, collId)
+	require.NoError(t, err)
+	require.Equal(t, v, indexId)
+
+	// try assigning the same namespace id to some other namespace
+	tx, err = tm.StartTxWithoutTracking(context.TODO())
+	require.NoError(t, err)
+	require.Error(t, k.ReserveNamespace(context.TODO(), tx, "proj2-org-1", 1234))
+}
+
+func TestKeyEncoding_Error(t *testing.T) {
+	fdbCfg, err := config.GetTestFDBConfig()
+	require.NoError(t, err)
+
+	kv, err := kv.NewFoundationDB(fdbCfg)
+	require.NoError(t, err)
+
+	tm := transaction.NewManager(kv)
+	k := NewKeyEncoder()
+
+	ctx := context.TODO()
+	tx, err := tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	dbId, err := k.EncodeDatabaseName(ctx, tx, "db-1", 0)
+	require.Error(t, api.Errorf(codes.InvalidArgument, "invalid namespace id"), err)
+	require.Equal(t, invalidId, dbId)
+
+	collId, err := k.EncodeCollectionName(ctx, tx, "coll-1", 1234, 0)
+	require.Error(t, api.Errorf(codes.InvalidArgument, "invalid database id"), err)
+	require.Equal(t, invalidId, collId)
+
+	indexId, err := k.EncodeIndexName(ctx, tx, "pkey", 1234, 1, 0)
+	require.Error(t, api.Errorf(codes.InvalidArgument, "invalid collection id"), err)
+	require.Equal(t, invalidId, indexId)
+	require.NoError(t, tx.Rollback(context.TODO()))
+}
+
+func TestReservedNamespace(t *testing.T) {
+	fdbCfg, err := config.GetTestFDBConfig()
+	require.NoError(t, err)
+
+	kv, err := kv.NewFoundationDB(fdbCfg)
+	require.NoError(t, err)
+
+	tm := transaction.NewManager(kv)
+	r := newReservedSubspace()
+
+	ctx := context.TODO()
+	tx, err := tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	require.NoError(t, r.reserveNamespace(ctx, tx, "p1-o1", 123))
+	require.NoError(t, tx.Commit(ctx))
+
+	// check in the allocated id is assigned
+	tx, err = tm.StartTxWithoutTracking(ctx)
+	require.NoError(t, err)
+	require.NoError(t, r.reload(ctx, tx))
+	require.Equal(t, "p1-o1", r.allocated[123])
+
+	// try assigning the same namespace id to some other namespace
+	tx, err = tm.StartTxWithoutTracking(context.TODO())
+	require.NoError(t, err)
+	expError := api.Errorf(codes.AlreadyExists, "id is already assigned to the namespace 'p1-o1'")
+	require.Equal(t, expError, r.reserveNamespace(context.TODO(), tx, "p2-o2", 123))
+}
+
+func TestDecode(t *testing.T) {
+	k := kv.BuildKey(encVersion, UInt32ToByte(1234), dbKey, "db-1", keyEnd)
+	mp, err := NewKeyEncoder().decode(context.TODO(), k)
+	require.NoError(t, err)
+	require.Equal(t, mp[dbKey], "db-1")
+}

--- a/server/transaction/session.go
+++ b/server/transaction/session.go
@@ -111,7 +111,7 @@ func (s *session) insert(ctx context.Context, key keys.Key, value []byte) error 
 	defer s.Unlock()
 
 	if err := s.validateSession(); err != nil {
-		return nil
+		return err
 	}
 
 	return s.kTx.Insert(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...), value)
@@ -122,7 +122,7 @@ func (s *session) replace(ctx context.Context, key keys.Key, value []byte) error
 	defer s.Unlock()
 
 	if err := s.validateSession(); err != nil {
-		return nil
+		return err
 	}
 
 	return s.kTx.Replace(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...), value)
@@ -133,7 +133,7 @@ func (s *session) update(ctx context.Context, key keys.Key, apply func([]byte) (
 	defer s.Unlock()
 
 	if err := s.validateSession(); err != nil {
-		return nil
+		return err
 	}
 
 	return s.kTx.Update(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...), apply)
@@ -144,10 +144,21 @@ func (s *session) delete(ctx context.Context, key keys.Key) error {
 	defer s.Unlock()
 
 	if err := s.validateSession(); err != nil {
-		return nil
+		return err
 	}
 
 	return s.kTx.Delete(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...))
+}
+
+func (s *session) read(ctx context.Context, key keys.Key) (kv.Iterator, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return nil, err
+	}
+
+	return s.kTx.Read(ctx, key.Prefix(), kv.BuildKey(key.PrimaryKeys()...))
 }
 
 func (s *session) commit(ctx context.Context) error {

--- a/test/v1/server/collection_test.go
+++ b/test/v1/server/collection_test.go
@@ -18,12 +18,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/tigrisdata/tigrisdb/test/config"
-	"gopkg.in/gavv/httpexpect.v1"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/tigrisdata/tigrisdb/test/config"
+	"gopkg.in/gavv/httpexpect.v1"
 )
 
 var testCreateSchema = map[string]interface{}{

--- a/test/v1/server/database_test.go
+++ b/test/v1/server/database_test.go
@@ -18,12 +18,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/tigrisdata/tigrisdb/test/config"
-	"gopkg.in/gavv/httpexpect.v1"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/tigrisdata/tigrisdb/test/config"
+	"gopkg.in/gavv/httpexpect.v1"
 )
 
 type DatabaseSuite struct {


### PR DESCRIPTION
- introducing reserved subspace to reserve namespace which can be any identifier passed to the server.
- introducing encoding subspace to encode database, collection, indexes
- Added some helper methods for decoding

ToDos
- Merge the outside encoding package with this new one
- There needs to be a Cache implementation on top of this so that all access to get encoded value is from Cache not from storage. 