### PR TITLE
chore: initial Docker file for fdb arm64 builds

### DIFF
--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -37,6 +37,16 @@ RUN git clone ${SOURCE} && \
 RUN mkdir build_output
 ENV CXX_FLAGS="--param ggc-min-expand=20"
 RUN cmake -S foundationdb -B build_output -G Ninja
-RUN ninja -j4 -C build_output
-RUN cd build_output && cpack -G DEB
+RUN ninja -j3 -C build_output
 
+FROM devel as pkg
+ADD ~/packages /packages
+RUN cd build_output && cpack -G DEB
+RUN cp build_output/packages/*.deb* /packages
+
+FROM --platform=linux/arm64/v8 ubuntu:latest as release
+ADD ~/packages /packages
+RUN dpkg -i ~/packages/foundationdb-clients*.deb
+RUN mkdir /var/lib/foundationdb
+RUN chown foundationdb:foundationdb /var/lib/foundationdb
+RUN dpkg -i ~/packages/foundationdb-server.deb

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/arm64/v8 ubuntu:latest as build
 
-ENV SOURCE=https://github.com/apple/foundationdb/
-ENV VERSION=7.1.7
+ENV SOURCE=https://github.com/rbarabas/foundationdb
+ENV VERSION=rb/7.1.7_arm64
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Setup TZ
@@ -25,6 +25,8 @@ RUN apt update && apt install -y \
     python3 \
     ruby-dev
 
+FROM build as devel
+
 # Check out repository
 RUN git clone ${SOURCE} && \
     cd foundationdb && \
@@ -33,6 +35,8 @@ RUN git clone ${SOURCE} && \
 
 # Build
 RUN mkdir build_output
+ENV CXX_FLAGS="--param ggc-min-expand=20"
 RUN cmake -S foundationdb -B build_output -G Ninja
-RUN ninja -C build_output
+RUN ninja -j4 -C build_output
+RUN cd build_output && cpack -G DEB
 

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -1,0 +1,36 @@
+FROM --platform=linux/arm64/v8 ubuntu:latest as build
+
+ENV SOURCE=https://github.com/apple/foundationdb/
+ENV VERSION=7.1.7
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup TZ
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+
+# Install requirements
+RUN apt update && apt install -y \
+    git \
+    vim \
+    clang \
+    cmake \
+    golang \
+    liblz4-dev \
+    libssl-dev \
+    mono-devel \
+    ninja-build \
+    openjdk-11-jdk \
+    openssl \
+    python3 \
+    ruby-dev
+
+# Check out repository
+RUN git clone ${SOURCE} && \
+    cd foundationdb && \
+    git checkout ${VERSION} && \
+    cd -
+
+# Build
+RUN mkdir build_output
+RUN cmake -S foundationdb -B build_output -G Ninja
+RUN ninja -C build_output
+

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -15,6 +15,7 @@ RUN apt update && apt install -y \
     cmake \
     golang \
     libjemalloc2 \
+    libjemalloc-dev \
     liblz4-dev \
     libssl-dev \
     mono-devel \

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update && apt install -y \
     clang \
     cmake \
     golang \
+    libjemalloc2 \
     liblz4-dev \
     libssl-dev \
     mono-devel \

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -40,13 +40,16 @@ RUN cmake -S foundationdb -B build_output -G Ninja
 RUN ninja -j3 -C build_output
 
 FROM devel as pkg
-ADD ~/packages /packages
+COPY --from=devel /build_output /build_output
 RUN cd build_output && cpack -G DEB
+RUN mkdir /packages
 RUN cp build_output/packages/*.deb* /packages
 
 FROM --platform=linux/arm64/v8 ubuntu:latest as release
-ADD ~/packages /packages
+RUN mkdir /packages
+COPY --from=devel /build_output/packages/* /packages
 RUN dpkg -i ~/packages/foundationdb-clients*.deb
 RUN mkdir /var/lib/foundationdb
 RUN chown foundationdb:foundationdb /var/lib/foundationdb
 RUN dpkg -i ~/packages/foundationdb-server.deb
+RUN rm -rf /packages

--- a/build/fdb/Dockerfile
+++ b/build/fdb/Dockerfile
@@ -1,13 +1,7 @@
+# Build setup
 FROM --platform=linux/arm64/v8 ubuntu:latest as build
-
-ENV SOURCE=https://github.com/rbarabas/foundationdb
-ENV VERSION=rb/7.1.7_arm64
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Setup TZ
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
-
-# Install requirements
 RUN apt update && apt install -y \
     git \
     vim \
@@ -25,31 +19,27 @@ RUN apt update && apt install -y \
     python3 \
     ruby-dev
 
-FROM build as devel
 
-# Check out repository
+# Compiling and packaging
+FROM build as compile
+ENV SOURCE=https://github.com/rbarabas/foundationdb
+ENV VERSION=rb/7.1.7_arm64
 RUN git clone ${SOURCE} && \
     cd foundationdb && \
     git checkout ${VERSION} && \
     cd -
+RUN mkdir build && cmake -S foundationdb -B build -G Ninja
+WORKDIR build
+RUN ninja -j3
+RUN cpack -G DEB
 
-# Build
-RUN mkdir build_output
-ENV CXX_FLAGS="--param ggc-min-expand=20"
-RUN cmake -S foundationdb -B build_output -G Ninja
-RUN ninja -j3 -C build_output
 
-FROM devel as pkg
-COPY --from=devel /build_output /build_output
-RUN cd build_output && cpack -G DEB
-RUN mkdir /packages
-RUN cp build_output/packages/*.deb* /packages
-
+# Release container
 FROM --platform=linux/arm64/v8 ubuntu:latest as release
-RUN mkdir /packages
-COPY --from=devel /build_output/packages/* /packages
-RUN dpkg -i ~/packages/foundationdb-clients*.deb
+COPY --from=compile /build/packages/foundationdb-clients*.deb .
+COPY --from=compile /build/packages/foundationdb-server*.deb .
 RUN mkdir /var/lib/foundationdb
+RUN dpkg -i ./foundationdb-clients*.deb
 RUN chown foundationdb:foundationdb /var/lib/foundationdb
-RUN dpkg -i ~/packages/foundationdb-server.deb
-RUN rm -rf /packages
+RUN dpkg -i ./foundationdb-server*.deb
+RUN rm -rf *.deb

--- a/build/fdb/README.md
+++ b/build/fdb/README.md
@@ -1,0 +1,7 @@
+# Simplified FoundationDB docker build
+Unofficial build: for development purposes only!
+
+To build:
+```
+$ cd tigris/build/fdb && DOCKER_BUILDKIT=0 docker build .
+```


### PR DESCRIPTION
Adds a simplified FDB docker build process.

This enables us to build support images for platforms that are currently not supported by upstream and provide FDB docker images for M1 (arm64) processors.

Upstream uses CentOS 7 which does not yet support arm64 with the proper kernel page sizes so this build uses Ubuntu for the sake of simplicity.

This is just an initial commit. More layers will be added soon to optimize the build for deployment.