### PR TITLE
chore: unify make targets for architectures

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -27,8 +27,7 @@ jobs:
       - name: Pull build docker images
         if: env.need_rebuild
         run: |
-          docker pull debian:bullseye-slim
-          docker pull golang:1.18-bullseye
+          docker pull ubuntu:jammy-20220531
 
       - name: Pull submodules
         run: git submodule update --init --recursive
@@ -37,11 +36,14 @@ jobs:
         if: env.need_rebuild
         run: |
           make docker_compose_build
-          docker image rm debian:bullseye-slim golang:1.18-bullseye
+          docker image rm ubuntu:jammy-20220531
           docker image prune -f
 
       - name: Run tests
-        run: TEST_PARAM="-coverprofile=coverage.out -covermode=atomic" make docker_test_no_build || ( docker-compose -f test/docker/docker-compose.yml logs && false )
+        run: make docker_test_no_build || ( docker-compose -f test/docker/docker-compose.yml logs && false )
+        env:
+          PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/bin
+          TEST_PARAM: "-coverprofile=coverage.out -covermode=atomic"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -74,26 +74,6 @@ The docker volume `fdbdata` is mounted at:
   which is the default location where the client will search for the cluster
   file
 
-### Building and Testing on Apple M1
-
-Due to various issues with Docker on Apple M1, it is recommended to install
-FoundationDB on the host and run the server on the host directly as well.
-
-To run the server on the host, required dependencies need to be installed by
-running:
-
-```shell
-sh scripts/install_build_deps.sh
-sh scripts/install_test_deps.sh
-```
-
-Once the dependencies are installed, you can start up the server on the host as
-follows:
-
-```shell
-make osx_run
-```
-
 You can run the test on your local machine as follows:
 
 ```shell

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,24 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18-bullseye AS build
+FROM ubuntu:jammy-20220531 AS build
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https sudo
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gcc \
+    git \
+    golang \
+    make \
+    sudo
 
 RUN mkdir /build
 
 #Download deps once, during docker build. Rebuild only on go.mod change
+ENV PATH="${PATH}:/root/go/bin"
 COPY scripts/install_build_deps.sh /build
-RUN sh /build/install_build_deps.sh
 COPY go.mod /build
 WORKDIR /build
 RUN go mod download
-
 COPY . /build
-
+RUN sh /build/install_build_deps.sh
 RUN --mount=type=cache,target=/root/.cache/go-build rm -f server/service && make bins
 
-FROM debian:bullseye-slim
+
+FROM ubuntu:jammy-20220531 AS server
 
 # Remove apt configuration
 RUN rm -rf /etc/apt/*

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Tigris Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,11 +12,63 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 set -ex
 
-export GO111MODULE=on
+# Settings
+FDB_VERSION=7.1.7
 
+### Prereqs checks ###
+# Check if architecture and OS is supported
+# and set environment specifics
+ARCH=$(uname -m)
+OS=$(uname -s)
+case "${OS}-${ARCH}" in
+	"Darwin-arm64")
+		BINARIES="brew curl go"
+		FDB_SHA=b456a1d03580f81394502e1b066006ec38bf6a3a17a9904e6d7a88badbea4b4a08b9dbf69fbb0057b46dd5043f23de9ec3ff7a77d767c23f872425eb73fdee18
+		;;
+	"Darwin-x86_64")
+		BINARIES="brew curl go"
+		FDB_SHA=0e9d147410eede58d121fdc9208ea7b04a7c74c8f3776f56cfc00233cfb3a358a0e2f992122718ef9c639928b081801da542e9c4b07a539c8fd73361ab43beec
+		;;
+	"Linux-aarch64")
+		BINARIES="apt-get curl go"
+		FDB_SHA=8173952f0aa8dabfc7da9cb23b8eff4de08831a02a3fce846fc7f996f0d3bed33588caf6f7d837ffde71ecf4b512e5e17e3af7e4c52acf838f10b3131656274e
+		;;
+	"Linux-arm64")
+		BINARIES="apt-get curl go"
+		FDB_SHA=8173952f0aa8dabfc7da9cb23b8eff4de08831a02a3fce846fc7f996f0d3bed33588caf6f7d837ffde71ecf4b512e5e17e3af7e4c52acf838f10b3131656274e
+		;;
+	"Linux-x86_64")
+		BINARIES="apt-get curl go"
+		FDB_SHA=03b1b0705ae8297aa5da8ff7ae2f982208a25a7c6604c4029ff37b19856136528092788ea93b9ffc4deea604b07ab863cdc6f8152f76133ad04aba8794041185
+		;;
+	*)
+		echo "Unsupported architecture ${ARCH} or operating system ${OS}."
+		exit 1
+esac
+
+# Check if required binaries are available in PATH
+for bin in $(echo "${BINARIES}"); do
+	binpath=$(which "${bin}")
+	if [ -z "${binpath}" ] || ! test -x "${binpath}"; then
+		echo "Please ensure that $bin binary is installed and in PATH."
+		exit 1
+	fi
+done
+
+# Install protobuf compiler via package manager
+case "${OS}" in
+	"Darwin")
+		brew install protobuf
+		;;
+	"Linux")
+		sudo apt-get install -y protobuf-compiler
+		;;
+esac
+
+# Install protobuf
+export GO111MODULE=on
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1
 go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2
@@ -24,23 +76,20 @@ go install github.com/google/gnostic/cmd/protoc-gen-openapi@v0 #generate openapi
 go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1 #generate go http client
 go install github.com/mikefarah/yq/v4@latest # used to fix OpenAPI spec in scripts/fix_openapi.sh
 
-FDB_VERSION=6.3.23
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	if command -v brew > /dev/null 2>&1; then
-		brew install protobuf
-	fi
-
-	FDB_PACKAGE_PATH="$(mktemp -d)/FoundationDB-$FDB_VERSION.pkg"
-	FDB_SHA512=d7b89e82dae332af09637543371c58bcaaab2c818a3ea49f56e22587d1a6adfc255e154e6c4feca90f407e37d63d8a3cd2e7cfa0b996c2865c9d74fd5dc1b0ba
-	curl -Lo "$FDB_PACKAGE_PATH" "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/FoundationDB-${FDB_VERSION}.pkg"
-	echo "$FDB_SHA512  $FDB_PACKAGE_PATH" | shasum -a 512 -c
-	sudo installer -pkg "$FDB_PACKAGE_PATH" -target /
-
-else
-	FDB_PACKAGE_PATH="$(mktemp -p /tmp/ -u)-foundationdb-clients_$FDB_VERSION-1_amd64.deb"
-	FDB_SHA512=06ae7fc9e404118f0a707094eafe709e7a918483e8694abe7e601c1e46d1fdeed9fd9c538d8a8252f50f284a573dd735ba81ab54d9aba65b00690b8be90f0b43
-	wget https://github.com/apple/foundationdb/releases/download/$FDB_VERSION/foundationdb-clients_$FDB_VERSION-1_amd64.deb -O "$FDB_PACKAGE_PATH"
-	echo "$FDB_SHA512 $FDB_PACKAGE_PATH" | sha512sum -c
-	sudo dpkg -i "$FDB_PACKAGE_PATH" # provides /lib/libfdb_c.so shared library in the docker for CGO
-	sudo apt-get install -y protobuf-compiler
-fi
+# Install FoundationDB package
+case "${OS}" in
+	"Darwin")
+		FDB_PACKAGE_NAME="FoundationDB-${FDB_VERSION}_${ARCH}.pkg"
+		FDB_PACKAGE_PATH="$(mktemp -d)/${FDB_PACKAGE_NAME}"
+		curl --create-dirs -Lo "$FDB_PACKAGE_PATH" "https://tigrisdata-pub.s3.us-west-2.amazonaws.com/${FDB_PACKAGE_NAME}"
+		echo "$FDB_SHA  $FDB_PACKAGE_PATH" | shasum -a 512 -c
+		sudo installer -pkg "$FDB_PACKAGE_PATH" -target /
+		;;
+	"Linux")
+		FDB_PACKAGE_NAME="FoundationDB-${FDB_VERSION}_${ARCH}.deb"
+		FDB_PACKAGE_PATH="$(mktemp -p /tmp/ -u)/${FDB_PACKAGE_NAME}"
+		curl --create-dirs -Lo "$FDB_PACKAGE_PATH" "https://tigrisdata-pub.s3.us-west-2.amazonaws.com/${FDB_PACKAGE_NAME}"
+		echo "$FDB_SHA  $FDB_PACKAGE_PATH" | sha512sum -c
+		sudo dpkg -i "$FDB_PACKAGE_PATH" # provides /lib/libfdb_c.so shared library in the docker for CGO
+		;;
+esac

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Tigris Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ export GO111MODULE=on
 go install github.com/golang/mock/mockgen@v1
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.46.2
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [ "$(uname -s)" = "Darwin" ]; then
   if command -v brew > /dev/null 2>&1; then
     brew install shellcheck
   fi

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -12,14 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18-bullseye
+FROM ubuntu:jammy-20220531
 
-RUN apt-get update && apt-get install -y apt-transport-https
-RUN apt-get install -y sudo
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gcc \
+    git \
+    golang \
+    make \
+    sudo
 
 RUN mkdir -p /go/src/tigris
 
 #this is to install dependencies once, during docker build
+ENV PATH="${PATH}:/root/go/bin"
 COPY scripts/install_build_deps.sh /go/src/tigris
 COPY scripts/install_test_deps.sh /go/src/tigris
 RUN sh /go/src/tigris/install_build_deps.sh

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -17,11 +17,11 @@ version: '3.3'
 services:
   tigris_fdb:
     container_name: tigris_fdb
-    image: foundationdb/foundationdb:6.3.23
+    image: tigrisdata/foundationdb:7.1.7
     volumes:
       - type: volume
         source: fdbdata
-        target: /var/fdb/
+        target: /var/lib/foundationdb/
     ports:
       - "4500:4500"
 


### PR DESCRIPTION
Unifies make targets for the various architectures and upgrades FDB to 7.1.7 to support M1 natively. 