### PR TITLE
feat: initialize GRPC metrics on startup

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metrics
 
 import (
@@ -9,9 +23,26 @@ import (
 	promreporter "github.com/uber-go/tally/prometheus"
 )
 
+type ServerRequestCounter struct {
+	Name    string
+	Tags    map[string]string
+	Counter tally.Counter
+}
+
+type ServerRequestHistogram struct {
+	Name      string
+	Tags      map[string]string
+	Histogram tally.Histogram
+}
+
 var (
 	Root     tally.Scope
 	Reporter promreporter.Reporter
+	// Both counters and histograms are initialized during server startup in muxer.go
+	// method name and counter name
+	ServerRequestCounters map[string]map[string]*ServerRequestCounter
+	// method name and histogram name
+	ServerRequestHistograms map[string]map[string]*ServerRequestHistogram
 )
 
 func InitializeMetrics() io.Closer {
@@ -24,5 +55,7 @@ func InitializeMetrics() io.Closer {
 		CachedReporter: Reporter,
 		Separator:      promreporter.DefaultSeparator,
 	}, 1*time.Second)
+	ServerRequestCounters = make(map[string]map[string]*ServerRequestCounter)
+	ServerRequestHistograms = make(map[string]map[string]*ServerRequestHistogram)
 	return closer
 }

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -1,0 +1,131 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/uber-go/tally"
+	"google.golang.org/grpc"
+)
+
+const (
+	ServerRequestsReceivedTotal      = "server_requests_received_total"
+	ServerRequestsHandledTotal       = "server_requests_handled_total"
+	ServerRequestsErrorTotal         = "server_requests_error_total"
+	ServerRequestsOkTotal            = "server_requests_ok_total"
+	ServerRequestsHandlingTimeBucket = "server_requests_handling_time_bucket"
+)
+
+var (
+	ServerRequestsCounterNames = []string{
+		ServerRequestsReceivedTotal,
+		ServerRequestsHandledTotal,
+		ServerRequestsErrorTotal,
+		ServerRequestsOkTotal,
+	}
+	ServerRequestsHistogramNames = []string{
+		ServerRequestsHandlingTimeBucket,
+	}
+)
+
+type ServerEndpointMetadata struct {
+	grpcServiceName string
+	grpcMethodName  string
+	grpcTypeName    string
+}
+
+func newServerEndpointMetadata(grpcServiceName string, grpcMethodName string, grpcTypeName string) ServerEndpointMetadata {
+	return ServerEndpointMetadata{grpcServiceName: grpcServiceName, grpcMethodName: grpcMethodName, grpcTypeName: grpcTypeName}
+}
+
+func (g *ServerEndpointMetadata) getTags() map[string]string {
+	return map[string]string{
+		"method":  g.grpcMethodName,
+		"service": g.grpcServiceName,
+		"type":    g.grpcTypeName,
+	}
+}
+
+func (g *ServerEndpointMetadata) getFullMethod() string {
+	return fmt.Sprintf("/%s/%s", g.grpcServiceName, g.grpcMethodName)
+}
+
+func getGrpcEndPointMetadata(svcName string, methodInfo grpc.MethodInfo) ServerEndpointMetadata {
+	var endpointMetadata ServerEndpointMetadata
+	if methodInfo.IsServerStream {
+		endpointMetadata = newServerEndpointMetadata(svcName, methodInfo.Name, "stream")
+	} else {
+		endpointMetadata = newServerEndpointMetadata(svcName, methodInfo.Name, "unary")
+	}
+	return endpointMetadata
+
+}
+
+func InitServerRequestCounters(svcName string, methodInfo grpc.MethodInfo) {
+	endpointMetadata := getGrpcEndPointMetadata(svcName, methodInfo)
+	fullMethodName := endpointMetadata.getFullMethod()
+	tags := endpointMetadata.getTags()
+
+	for _, counterName := range ServerRequestsCounterNames {
+		counter := ServerRequestCounter{
+			Name:    counterName,
+			Tags:    tags,
+			Counter: Root.Tagged(tags).Counter(counterName),
+		}
+		if _, ok := ServerRequestCounters[fullMethodName]; !ok {
+			child := make(map[string]*ServerRequestCounter)
+			ServerRequestCounters[fullMethodName] = child
+		}
+		ServerRequestCounters[fullMethodName][counterName] = &counter
+	}
+
+}
+
+func InitServerRequestHistograms(svcName string, methodInfo grpc.MethodInfo) {
+	endpointMetadata := getGrpcEndPointMetadata(svcName, methodInfo)
+	fullMethodName := endpointMetadata.getFullMethod()
+	tags := endpointMetadata.getTags()
+
+	for _, histogramName := range ServerRequestsHistogramNames {
+		histogram := ServerRequestHistogram{
+			Name:      histogramName,
+			Tags:      tags,
+			Histogram: Root.Tagged(tags).Histogram(histogramName, tally.DefaultBuckets),
+		}
+		if _, ok := ServerRequestHistograms[fullMethodName]; !ok {
+			child := make(map[string]*ServerRequestHistogram)
+			ServerRequestHistograms[fullMethodName] = child
+		}
+		ServerRequestHistograms[fullMethodName][histogramName] = &histogram
+	}
+}
+
+func InitRequestMetricsForServer(s *grpc.Server) {
+	for svcName, info := range s.GetServiceInfo() {
+		for _, method := range info.Methods {
+			InitServerRequestCounters(svcName, method)
+			InitServerRequestHistograms(svcName, method)
+		}
+	}
+}
+
+func GetServerRequestCounter(fullMethod string, counterName string) *ServerRequestCounter {
+	return ServerRequestCounters[fullMethod][counterName]
+}
+
+func GetServerRequestHistogram(fullMethod string, histogramName string) *ServerRequestHistogram {
+	return ServerRequestHistograms[fullMethod][histogramName]
+}

--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -1,0 +1,109 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestGRPCMetrics(t *testing.T) {
+	InitializeMetrics()
+	svcName := "tigrisdata.v1.Tigris"
+	unaryMethodName := "TestUnaryMethod"
+	streamingMethodName := "TestStreamingMethod"
+
+	unaryMethodInfo := grpc.MethodInfo{
+		Name:           unaryMethodName,
+		IsServerStream: false,
+		IsClientStream: false,
+	}
+	streamingMethodInfo := grpc.MethodInfo{
+		Name:           streamingMethodName,
+		IsServerStream: true,
+		IsClientStream: false,
+	}
+
+	unaryEndPointMetadata := getGrpcEndPointMetadata(svcName, unaryMethodInfo)
+	streamingEndpointMetadata := getGrpcEndPointMetadata(svcName, streamingMethodInfo)
+
+	t.Run("Test unary endpoint metadata", func(t *testing.T) {
+		assert.Equal(t, unaryEndPointMetadata.grpcServiceName, svcName)
+		assert.Equal(t, unaryEndPointMetadata.grpcMethodName, unaryMethodName)
+		assert.Equal(t, unaryEndPointMetadata.grpcTypeName, "unary")
+	})
+
+	t.Run("Test streaming endpoint metadata", func(t *testing.T) {
+		assert.Equal(t, streamingEndpointMetadata.grpcServiceName, svcName)
+		assert.Equal(t, streamingEndpointMetadata.grpcMethodName, streamingMethodName)
+		assert.Equal(t, streamingEndpointMetadata.grpcTypeName, "stream")
+	})
+
+	t.Run("Test tags", func(t *testing.T) {
+		tags := unaryEndPointMetadata.getTags()
+		for tagName, tagValue := range tags {
+			switch tagName {
+			case "grpc_method":
+				assert.Equal(t, tagValue, "TestUnaryMethod")
+			case "grpc_service":
+				assert.Equal(t, tagValue, "tigrisdata.v1.Tigris")
+			case "grpc_type":
+				assert.Equal(t, tagValue, "unary")
+			}
+		}
+	})
+
+	t.Run("Test streaming tags", func(t *testing.T) {
+		tags := streamingEndpointMetadata.getTags()
+		for tagName, tagValue := range tags {
+			switch tagName {
+			case "grpc_method":
+				assert.Equal(t, tagValue, "TestStreamingMethod")
+			case "grpc_service":
+				assert.Equal(t, tagValue, "tigrisdata.v1.Tigris")
+			case "grpc_type":
+				assert.Equal(t, tagValue, "stream")
+			}
+		}
+	})
+
+	t.Run("Test unary metrics", func(t *testing.T) {
+		InitServerRequestCounters(svcName, unaryMethodInfo)
+		InitServerRequestHistograms(svcName, unaryMethodInfo)
+
+		for _, counterName := range ServerRequestsCounterNames {
+			GetServerRequestCounter(unaryEndPointMetadata.getFullMethod(), counterName)
+		}
+
+		for _, histogramName := range ServerRequestsHistogramNames {
+			GetServerRequestHistogram(unaryEndPointMetadata.getFullMethod(), histogramName)
+		}
+	})
+
+	t.Run("Test streaming metrics", func(t *testing.T) {
+		InitServerRequestCounters(svcName, streamingMethodInfo)
+		InitServerRequestHistograms(svcName, streamingMethodInfo)
+
+		for _, counterName := range ServerRequestsCounterNames {
+			GetServerRequestCounter(streamingEndpointMetadata.getFullMethod(), counterName)
+		}
+
+		for _, histogramName := range ServerRequestsHistogramNames {
+			GetServerRequestHistogram(streamingEndpointMetadata.getFullMethod(), histogramName)
+		}
+	})
+}

--- a/server/midddleware/metrics_test.go
+++ b/server/midddleware/metrics_test.go
@@ -18,28 +18,31 @@ import (
 	"testing"
 
 	"github.com/tigrisdata/tigris/server/metrics"
+	"google.golang.org/grpc"
 )
 
-func TestGRPCMetrics(t *testing.T) {
+func TestGrpcMetrics(t *testing.T) {
 	metrics.InitializeMetrics()
-	callData := newGrpcReqMetrics("/tigrisdata.v1.Tigris/TestMethod", "unary")
+	svcName := "tigrisdata.v1.Tigris"
+	methodName := "TestMethod"
+	methodInfo := grpc.MethodInfo{
+		Name:           methodName,
+		IsServerStream: false,
+		IsClientStream: false,
+	}
+	fullMethodName := "/tigrisdata.v1.Tigris/TestMethod"
 
-	t.Run("Increase test_counter", func(t *testing.T) {
-		testCounter := callData.getGrpcCounter("test_counter")
-		callData.increaseGrpcCounter(testCounter, 1)
-	})
+	metrics.InitServerRequestCounters(svcName, methodInfo)
+	metrics.InitServerRequestHistograms(svcName, methodInfo)
 
-	t.Run("Test message counters", func(t *testing.T) {
-		callData.receiveMessage()
-		callData.handleMessage()
-		callData.errorMessage()
-		callData.okMessage()
+	t.Run("Test counters", func(t *testing.T) {
+		receiveMessage(fullMethodName)
+		handleMessage(fullMethodName)
+		errorMessage(fullMethodName)
+		okMessage(fullMethodName)
 	})
 
 	t.Run("Test histogram", func(t *testing.T) {
-		testHistogram := callData.getTimeHistogram()
-		stopWatch := testHistogram.Start()
-		stopWatch.Stop()
+		getTimeHistogram(fullMethodName)
 	})
-
 }

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/soheilhy/cmux"
 	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metrics"
 	v1 "github.com/tigrisdata/tigris/server/services/v1"
 	"github.com/tigrisdata/tigris/store/kv"
 	"github.com/tigrisdata/tigris/store/search"
@@ -51,6 +52,8 @@ func (m *Muxer) RegisterServices(kvStore kv.KeyValueStore, searchStore search.St
 		for _, v := range m.servers {
 			if s, ok := v.(*GRPCServer); ok {
 				_ = r.RegisterGRPC(s.Server)
+				// Initialize the metrics for each GRPC service
+				metrics.InitRequestMetricsForServer(s.Server)
 			} else if s, ok := v.(*HTTPServer); ok {
 				_ = r.RegisterHTTP(s.Router, s.Inproc)
 			}
@@ -70,6 +73,5 @@ func (m *Muxer) Start(host string, port int16) error {
 	for _, s := range m.servers {
 		_ = s.Start(cm)
 	}
-
 	return cm.Serve()
 }


### PR DESCRIPTION
Initialize all GRPC metrics with tags at server startup (on GRPC server creation). 