### PR TITLE
feat: add search container to example deployment

### DIFF
--- a/deployment/manifests/base/search-deployment.yaml
+++ b/deployment/manifests/base/search-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: tigris-search
+    app.kubernetes.io/part-of: tigris
+    app.kubernetes.io/component: search
+  name: tigris-search
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tigris-search
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tigris-search
+    spec:
+      containers:
+        - name: tigris-search
+          env:
+            - name: TYPESENSE_DATA_DIR
+              value: /tmp
+            - name: TYPESENSE_API_KEY
+              value: ts_test_key
+          image: typesense/typesense:0.23.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8108

--- a/deployment/manifests/base/service_search.yaml
+++ b/deployment/manifests/base/service_search.yaml
@@ -12,16 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deployment.yaml
-  - search-deployment.yaml
-  - service.yaml
-  - service_grpc.yaml
-  - service_search.yaml
-  - network-policy.yaml
-configMapGenerator:
-  - name: tigris-server-config
-    files:
-      - server.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tigris-server
+    app.kubernetes.io/part-of: tigris
+    app.kubernetes.io/component: search
+  name: tigris-server-search
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      name: http
+      protocol: TCP
+      targetPort: 8108
+  selector:
+    app.kubernetes.io/name: tigris-search
+          


### PR DESCRIPTION
Adds Search to the deployment example required for `alpha.20` deployments.