### PR TITLE
fix: Avoid env collisions between viper and k8s service

### DIFF
--- a/deployment/manifests/base/service.yaml
+++ b/deployment/manifests/base/service.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/name: tigris-server
     app.kubernetes.io/part-of: tigris
     app.kubernetes.io/component: server
-  name: tigris-server
+  name: tigris-http
 spec:
   type: NodePort
   ports:

--- a/deployment/manifests/base/service_grpc.yaml
+++ b/deployment/manifests/base/service_grpc.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/component: server-grpc
   annotations:
     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
-  name: tigris-server-grpc
+  name: tigris-grpc
 spec:
   type: NodePort
   ports:

--- a/deployment/manifests/base/service_search.yaml
+++ b/deployment/manifests/base/service_search.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/name: tigris-server
     app.kubernetes.io/part-of: tigris
     app.kubernetes.io/component: search
-  name: tigris-server-search
+  name: tigris-search
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
This PR fixes an issue where environment variables the Tigris configuration (`spf13/viper`) collide with environment variables injected by Kubernetes for its `Service`-es.

The problem is that `spf13/viper` would expect the configuration for `Search.Port` to be of type `Int`:

https://github.com/tigrisdata/tigris/blob/d5de7997561e6a61b2d085d7abf6c43ea1a173b1/server/config/options.go#L71-L77

However, if a Kubernetes Service is deployed with the name `search` in the Tigris Server group, as outlined in our deployment example, the following environment variables will be injected in each `tigris-server` pod:

```
root@tigris-search-867c5b8d56-zr8nx:/# env | grep -i search
TIGRIS_SERVER_SEARCH_PORT_80_TCP_PORT=80
TIGRIS_SERVER_SEARCH_PORT=tcp://172.20.84.196:80
HOSTNAME=tigris-search-867c5b8d56-zr8nx
TIGRIS_SERVER_SEARCH_PORT_80_TCP=tcp://172.20.84.196:80
TIGRIS_SERVER_SEARCH_SERVICE_HOST=172.20.84.196
TIGRIS_SERVER_SEARCH_SERVICE_PORT_HTTP=80
TIGRIS_SERVER_SEARCH_PORT_80_TCP_ADDR=172.20.84.196
TIGRIS_SERVER_SEARCH_SERVICE_PORT=80
TIGRIS_SERVER_SEARCH_PORT_80_TCP_PROTO=tcp
```

As you can see, `TIGRIS_SERVER_SEARCH_PORT=tcp://172.20.84.196:80` is set but its value will collide with the `spf13/viper` environment variable for `Search.Port` which expects it to be a simple `Int` as discussed previously.

Deployments yield the following error:

```
{"level":"fatal","error":"1 error(s) decoding:\n\n* cannot parse 'Search.Port' as int: strconv.ParseInt: parsing \"tcp://172.20.66.131:80\": invalid syntax","time":"2022-06-15T14:06:32Z","message":"error unmarshalling config"}
```

This change will change the name of the colliding Kubernetes injected variables to be `TIGRIS_SEARCH_PORT` and we can still harvest `TIGRIS_SEARCH_SERVICE_HOST` and `TIGRIS_SEARCH_SERVICE_PORT` to obtain the address and port of the Kubernetes service during deployments.