### PR TITLE
fix: use service address for search

### DIFF
--- a/deployment/manifests/base/server.yaml
+++ b/deployment/manifests/base/server.yaml
@@ -15,6 +15,10 @@
 server:
   port: 8080
 
+search:
+  host: tigris-search
+  port: 80
+
 log:
   level: info
 


### PR DESCRIPTION
Use the service address to communicate with search in the Kubernetes deployment example.