### PR TITLE
Fix docker-compose file for local

### DIFF
--- a/docker/local/docker-compose.yaml
+++ b/docker/local/docker-compose.yaml
@@ -25,6 +25,15 @@ services:
     ports:
       - "4500:4500"
 
+  tigris_search:
+    container_name: tigris_search
+    image: typesense/typesense:0.23.0
+    environment:
+      - TYPESENSE_DATA_DIR=/tmp
+      - TYPESENSE_API_KEY=ts_test_key
+    ports:
+      - "8108:8108"
+
   tigris_server:
     container_name: tigris_server
     image: tigrisdata/tigris:alpha

--- a/docker/local/docker-compose.yaml
+++ b/docker/local/docker-compose.yaml
@@ -17,11 +17,11 @@ version: '3.3'
 services:
   tigris_fdb:
     container_name: tigris_fdb
-    image: foundationdb/foundationdb:6.3.23
+    image: tigrisdata/foundationdb:7.1.7
     volumes:
       - type: volume
         source: fdbdata
-        target: /var/fdb/
+        target: /var/lib/foundationdb/
     ports:
       - "4500:4500"
 


### PR DESCRIPTION
The docker compose file in local is outdated. 

The container and volume target for fdb need to be updated to work with the newer, M1 friendly image of FoundationDB.

Also, as search became a crucial component for Tigris the local compose file needs to bring the search container up as well.