### PR TITLE
refactor: all tags and non-error specific counters pre created

### DIFF
--- a/server/midddleware/metrics_test.go
+++ b/server/midddleware/metrics_test.go
@@ -25,6 +25,7 @@ func TestGrpcMetrics(t *testing.T) {
 	metrics.InitializeMetrics()
 	svcName := "tigrisdata.v1.Tigris"
 	methodName := "TestMethod"
+	methodType := "unary"
 	methodInfo := grpc.MethodInfo{
 		Name:           methodName,
 		IsServerStream: false,
@@ -32,17 +33,13 @@ func TestGrpcMetrics(t *testing.T) {
 	}
 	fullMethodName := "/tigrisdata.v1.Tigris/TestMethod"
 
-	metrics.InitServerRequestCounters(svcName, methodInfo)
-	metrics.InitServerRequestHistograms(svcName, methodInfo)
+	metrics.InitServerRequestMetrics(svcName, methodInfo)
 
 	t.Run("Test counters", func(t *testing.T) {
-		receiveMessage(fullMethodName)
-		handleMessage(fullMethodName)
-		errorMessage(fullMethodName)
-		okMessage(fullMethodName)
-	})
-
-	t.Run("Test histogram", func(t *testing.T) {
-		getTimeHistogram(fullMethodName)
+		countReceivedMessage(fullMethodName, methodType)
+		countHandledMessage(fullMethodName, methodType)
+		countUnknownErrorMessage(fullMethodName, methodType)
+		countOkMessage(fullMethodName, methodType)
+		countSpecificErrorMessage(fullMethodName, methodType, "test_source", "test_code")
 	})
 }


### PR DESCRIPTION
All non-error specific counters and histograms are pre-created at the tally level.
Error specific counter's tags are pre-created, the specific error codes are part of the counter's name. 