### PR TITLE
feat: Added basic restriction for collection field names

### DIFF
--- a/schema/fields.go
+++ b/schema/fields.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"regexp"
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
@@ -61,6 +62,30 @@ var FieldNames = [...]string{
 	ArrayType:    "array",
 	ObjectType:   "object",
 }
+
+var (
+	MsgFieldNameAsLanguageKeyword = "Invalid collection field name, It contains language keyword for fieldName = '%s'"
+	MsgFieldNameInvalidPattern    = "Invalid collection field name, field name can only contain [a-zA-Z0-9_$] and it can only start with [a-zA-Z_$] for fieldName = '%s'"
+	LanguageKeywords              = set.New("abstract", "add", "alias", "and", "any", "args", "arguments", "array",
+		"as", "as?", "ascending", "assert", "async", "await", "base", "bool", "boolean", "break", "by", "byte",
+		"callable", "case", "catch", "chan", "char", "checked", "class", "clone", "const", "constructor", "continue",
+		"debugger", "decimal", "declare", "def", "default", "defer", "del", "delegate", "delete", "descending", "die",
+		"do", "double", "dynamic", "echo", "elif", "else", "elseif", "empty", "enddeclare", "endfor", "endforeach",
+		"endif", "endswitch", "endwhile", "enum", "equals", "eval", "event", "except", "exception", "exit", "explicit",
+		"export", "extends", "extern", "fallthrough", "false", "final", "finally", "fixed", "float", "fn", "for",
+		"foreach", "from", "fun", "func", "function", "get", "global", "go", "goto", "group", "if", "implements",
+		"implicit", "import", "in", "include", "include_once", "init", "instanceof", "insteadof", "int", "integer",
+		"interface", "internal", "into", "is", "isset", "join", "lambda", "let", "list", "lock", "long", "managed",
+		"map", "match", "module", "nameof", "namespace", "native", "new", "nint", "none", "nonlocal", "not", "notnull",
+		"nuint", "null", "number", "object", "of", "on", "operator", "or", "orderby", "out", "override", "package",
+		"params", "partial", "pass", "print", "private", "protected", "public", "raise", "range", "readonly", "record",
+		"ref", "remove", "require", "require_once", "return", "sbyte", "sealed", "select", "set", "short", "sizeof",
+		"stackalloc", "static", "strictfp", "string", "struct", "super", "switch", "symbol", "synchronized", "this",
+		"throw", "throws", "trait", "transient", "true", "try", "type", "typealias", "typeof", "uint", "ulong",
+		"unchecked", "unmanaged", "unsafe", "unset", "use", "ushort", "using", "val", "value", "var", "virtual", "void",
+		"volatile", "when", "where", "while", "with", "xor", "yield")
+	ValidFieldNamePattern = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
+)
 
 const (
 	jsonSpecNull   = "null"
@@ -285,9 +310,20 @@ func (f *FieldBuilder) Validate(v []byte) error {
 	return nil
 }
 
-func (f *FieldBuilder) Build() (*Field, error) {
+func (f *FieldBuilder) Build(isArrayElement bool) (*Field, error) {
 	if IsReservedField(f.FieldName) {
 		return nil, api.Errorf(api.Code_INVALID_ARGUMENT, "following reserved fields are not allowed %q", ReservedFields)
+	}
+
+	// check for language keywords
+	if LanguageKeywords.Contains(strings.ToLower(f.FieldName)) {
+		return nil, api.Errorf(api.Code_INVALID_ARGUMENT, MsgFieldNameAsLanguageKeyword, f.FieldName)
+	}
+
+	// for array elements, items will have field name empty so skip the test for that.
+	// make sure they start with [a-z], [A-Z], $, _ and can only contain [a-z], [A-Z], $, _, [0-9]
+	if !isArrayElement && !ValidFieldNamePattern.MatchString(f.FieldName) {
+		return nil, api.Errorf(api.Code_INVALID_ARGUMENT, MsgFieldNameInvalidPattern, f.FieldName)
 	}
 
 	fieldType := ToFieldType(f.Type, f.Encoding, f.Format)

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,7 +62,7 @@ func TestFieldBuilder_Build(t *testing.T) {
 			},
 		}
 		for _, c := range cases {
-			_, err := c.builder.Build()
+			_, err := c.builder.Build(false)
 			require.Equal(t, c.expError, err)
 		}
 	})
@@ -98,7 +99,36 @@ func TestFieldBuilder_Build(t *testing.T) {
 	})
 	t.Run("test reserved fields", func(t *testing.T) {
 		builder := &FieldBuilder{FieldName: "created_at", Type: "date-time"}
-		_, err := builder.Build()
+		_, err := builder.Build(false)
 		require.Error(t, err)
+	})
+
+	t.Run("test programming language keywords as field name", func(t *testing.T) {
+		keywords := []string{"abstract", "integer", "yield"}
+		for _, keyword := range keywords {
+			_, err := (&FieldBuilder{FieldName: keyword, Type: "string"}).Build(false) // one time builder, thrown away after test concluded
+			require.Equal(t, err, api.Errorf(api.Code_INVALID_ARGUMENT,
+				fmt.Sprintf("Invalid collection field name, It contains language keyword for fieldName = '%s'", keyword)))
+		}
+	})
+
+	t.Run("test invalid field name pattern", func(t *testing.T) {
+		invalidFieldNames := []string{"0id", "0ID", "("}
+		for _, invalidFieldName := range invalidFieldNames {
+			_, err := (&FieldBuilder{FieldName: invalidFieldName, Type: "string"}).Build(false) // one time builder, thrown away after test concluded
+			require.Equal(t, err,
+				api.Errorf(api.Code_INVALID_ARGUMENT,
+					"Invalid collection field name, field name can only contain [a-zA-Z0-9_$] and it can only start"+
+						" with [a-zA-Z_$] for fieldName = '%s'",
+					invalidFieldName))
+		}
+	})
+
+	t.Run("test valid field name pattern", func(t *testing.T) {
+		validFieldNames := []string{"a1", "$a1", "$_a1", "$_", "A1", "Z1"}
+		for _, validFieldName := range validFieldNames {
+			_, err := (&FieldBuilder{FieldName: validFieldName, Type: "string"}).Build(false) // one time builder, thrown away after test concluded
+			require.NoError(t, err)
+		}
 	})
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -218,7 +218,7 @@ func deserializeProperties(properties jsoniter.RawMessage, primaryKeysSet set.Ha
 			} else {
 				// if it is simple item type
 				var f *Field
-				if f, err = builder.Items.Build(); err != nil {
+				if f, err = builder.Items.Build(true); err != nil {
 					return err
 				}
 				builder.Fields = append(nestedFields, f)
@@ -240,7 +240,7 @@ func deserializeProperties(properties jsoniter.RawMessage, primaryKeysSet set.Ha
 		}
 
 		var f *Field
-		f, err = builder.Build()
+		f, err = builder.Build(false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- basic restriction for collection field names (language keywords not allowed and fixed pattern)
- field name can start with `[a-zA-Z_$]` and then contain zero or more `[a-zA-Z0-9_$]` 

The motivation here is to future proof various programming language's models. 

TODO

 - we can allow user to disable programming language keyword restriction on field names optionally (not by default) in case if they know they are never going to work with some programming language, there is no point of restricting them for that scenario.
 - Add similar restriction for collection and database name.
 - Fine tune these restriction to make more tighter as we learn iteratively.