### PR TITLE
feat: better tracing defaults

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -84,7 +84,6 @@ var DefaultConfig = Config{
 	},
 	Tracing: TracingConfig{
 		Enabled: true,
-		WithUDS: "/var/run/datadog/apm.socket",
 	},
 }
 


### PR DESCRIPTION
Removes the UNIX domain socket for tracer to let the Datadog trace agent default to environment variable based discovery. 

We should prefer containerized installations but the UNIX domain socket would be prevalent in host based installations. Note that this is simply a convenience feature and the different configuration options can still be passed explicitly as required.

I expect this change to make Kubernetes based deployments simpler where simply setting `DD_AGENT_HOST` will make the client pick up the correct target.