### PR TITLE
feat: Add workflow for building debug images

### DIFF
--- a/.github/workflows/publish-debug-image.yaml
+++ b/.github/workflows/publish-debug-image.yaml
@@ -1,0 +1,71 @@
+name: publish debug image
+
+on:
+  pull_request:
+    types:
+      - labeled
+  push:
+  workflow_call:
+    secrets:
+      GH_DOCKER_ACCESS_USER:
+        required: true
+      GH_DOCKER_ACCESS_TOKEN:
+        required: true
+
+env:
+  DOCKER_REPOSITORY: "tigrisdata/tigris-debug"
+
+jobs:
+  build-and-push-debug-image:
+    if: ${{ github.event.label.name == 'debug image' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Fetch tags
+        run: |
+          git fetch --prune --unshallow --tags
+
+      - name: Login to Docker Hub
+        id: login-docker-hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.GH_DOCKER_ACCESS_USER }}
+          password: ${{ secrets.GH_DOCKER_ACCESS_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.DOCKER_REPOSITORY }}
+          # generate Docker tags based on the following events/attributes
+          # we generate the latest tag off the alpha branch
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Pull submodules
+        run: git submodule update --init --recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds a new workflow that will allow us to publish ad-hoc debug images for deployment validation and integration tests.

This workflow will create images if the PR is labeled with `debug image`. The resultant image will be published to `tigrisdata/tigris-debug`.

Before label:

![Screen Shot 2022-07-05 at 6 48 09 PM](https://user-images.githubusercontent.com/8724965/177429559-0f8d2b5e-85ea-493c-906a-549fbef23a3d.png)

After label:

![Screen Shot 2022-07-05 at 6 49 02 PM](https://user-images.githubusercontent.com/8724965/177429625-13c09d02-b208-4193-ad0f-91e64ad93e3e.png)

See [DockerHub](https://hub.docker.com/repository/docker/tigrisdata/tigrisdebug) for an example image that was created during #331, triggered using the branch name.