### PR TITLE
feat: ability to specify config as an argument

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/pflag"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/metrics"
@@ -30,9 +29,7 @@ import (
 )
 
 func main() {
-	pflag.String("api.port", "", "set port server listens on")
-
-	config.LoadConfig("server", &config.DefaultConfig)
+	config.LoadConfig(&config.DefaultConfig)
 
 	ulog.Configure(config.DefaultConfig.Log)
 


### PR DESCRIPTION
Allows one to specify the configuration file to use with server. This makes it easy to specify custom configuration files for unique deployment scenarios.

***NOTE*** I removed an the old pflag.String() cruft that I believe was not in use. Please let me know if that's not the case! 

***SYNOPSIS***
```
$ ./server/service --help
Usage of ./server/service:
  -c, --config string   server configuration file
pflag: help requested

$ ./server/service -c config/server.dev.yaml
```