### PR TITLE
feat: enable codehotspots and endpoints in DD tracing

### DIFF
--- a/.github/workflows/publish-debug-image.yaml
+++ b/.github/workflows/publish-debug-image.yaml
@@ -66,6 +66,6 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event.label.name == 'debug image' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -53,10 +53,12 @@ type CdcConfig struct {
 }
 
 type TracingConfig struct {
-	Enabled           bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
-	WithUDS           string `mapstructure:"agent_socket" yaml:"agent_socket" json:"agent_socket"`
-	WithAgentAddr     string `mapstructure:"agent_addr" yaml:"agent_addr" json:"agent_addr"`
-	WithDogStatsdAddr string `mapstructure:"dogstatsd_addr" yaml:"dogstatsd_addr" json:"dogstatsd_addr"`
+	Enabled             bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	CodeHotspotsEnabled bool   `mapstructure:"codehotspots_enabled" yaml:"codehotspots_enabled" json:"codehotspots_enabled"`
+	EndpointsEnabled    bool   `mapstructure:"endpoints_enabled" yaml:"endpoints_enabled" json:"endpoints_enabled"`
+	WithUDS             string `mapstructure:"agent_socket" yaml:"agent_socket" json:"agent_socket"`
+	WithAgentAddr       string `mapstructure:"agent_addr" yaml:"agent_addr" json:"agent_addr"`
+	WithDogStatsdAddr   string `mapstructure:"dogstatsd_addr" yaml:"dogstatsd_addr" json:"dogstatsd_addr"`
 }
 
 type ProfilingConfig struct {
@@ -101,7 +103,9 @@ var DefaultConfig = Config{
 		WriteEnabled: true,
 	},
 	Tracing: TracingConfig{
-		Enabled: false,
+		Enabled:             false,
+		CodeHotspotsEnabled: true,
+		EndpointsEnabled:    true,
 	},
 	Profiling: ProfilingConfig{
 		Enabled:    false,

--- a/server/tracing/tracing.go
+++ b/server/tracing/tracing.go
@@ -9,6 +9,8 @@ import (
 func getTracingOptions(config *config.Config) []tracer.StartOption {
 	var opts []tracer.StartOption
 	opts = append(opts, tracer.WithTraceEnabled(config.Tracing.Enabled))
+	opts = append(opts, tracer.WithProfilerEndpoints(config.Tracing.EndpointsEnabled))
+	opts = append(opts, tracer.WithProfilerCodeHotspots(config.Tracing.CodeHotspotsEnabled))
 	opts = append(opts, tracer.WithService(config.Tags.Service))
 	opts = append(opts, tracer.WithEnv(config.Tags.Environment))
 	opts = append(opts, tracer.WithServiceVersion(config.Tags.Version))


### PR DESCRIPTION
Enables code hot spots and endpoints in Datadog traces.

Individually, also fixes the push condition for publishing debug images.