### PR TITLE
fix: increase linter timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ V=v1
 GEN_DIR=${API_DIR}/server/${V}
 PROTO_DIR=${API_DIR}/proto/server/${V}
 DATA_PROTO_DIR=internal
+LINT_TIMEOUT=5m
 
 # Needed to be able to build amd64 binaries on MacOS M1
 DOCKER_DIR=test/docker
@@ -40,7 +41,7 @@ lint: generate
 	yq --exit-status 'tag == "!!map" or tag== "!!seq"' .github/workflows/*.yaml config/*.yaml
 	shellcheck scripts/*
 	shellcheck test/docker/grafana/*
-	golangci-lint run
+	golangci-lint --timeout=$(LINT_TIMEOUT) run
 
 docker_compose_build:
 	$(DOCKER_COMPOSE) build


### PR DESCRIPTION
The linter was fixed to be more comprehensive but with the expanded run time it now times out sporadically. This PR increases its timeout to `5m` in the `Makefile`.

Last experienced the timeout on #337:
![Screen Shot 2022-07-06 at 2 24 02 PM](https://user-images.githubusercontent.com/8724965/177618480-46e18999-5123-4cbe-a35b-01e07a918fbf.png)
 