### PR TITLE
fix: fix make test error

### DIFF
--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -64,6 +64,7 @@ case "${OS}" in
 		brew install protobuf
 		;;
 	"Linux")
+		sudo apt-get update
 		sudo apt-get install -y protobuf-compiler
 		;;
 esac


### PR DESCRIPTION
Running make test results in a not found package error.

```
#0 7.453 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_5.15.0-37.39_amd64.deb  404  Not Found [IP: 91.189.91.38 80]
#0 7.453 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Running apt-get update fixes it.