### PR TITLE
fix: load environment during config init

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -75,6 +75,8 @@ func LoadEnvironment() {
 }
 
 func LoadConfig(config interface{}) {
+	LoadEnvironment()
+
 	pflag.StringVarP(&configFile, "config", "c", "", "server configuration file")
 	ulog.E(viper.BindPFlags(pflag.CommandLine))
 	pflag.Parse()


### PR DESCRIPTION
The message on the tin can says it all.