### PR TITLE
fix: add grpc service name to grpc metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -40,7 +40,7 @@ var (
 func GetGlobalTags() map[string]string {
 	return map[string]string{
 		"service": config.DefaultConfig.Tags.Service,
-		"env":     config.GetEnvironment(),
+		"env":     config.DefaultConfig.Tags.Environment,
 		"version": config.DefaultConfig.Tags.Version,
 	}
 }

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -34,17 +34,17 @@ func newRequestEndpointMetadata(serviceName string, methodInfo grpc.MethodInfo) 
 
 func (g *RequestEndpointMetadata) GetPreInitializedTags() map[string]string {
 	return map[string]string{
-		"method": g.methodInfo.Name,
-		//"service": g.serviceName,
+		"method":       g.methodInfo.Name,
+		"grpc_service": g.serviceName,
 	}
 }
 
 func (g *RequestEndpointMetadata) GetSpecificErrorTags(source string, code string) map[string]string {
 	return map[string]string{
-		"method": g.methodInfo.Name,
-		//"service": g.serviceName,
-		"source": source,
-		"code":   code,
+		"method":       g.methodInfo.Name,
+		"grpc_service": g.serviceName,
+		"source":       source,
+		"code":         code,
 	}
 }
 

--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -58,11 +58,13 @@ func TestGRPCMetrics(t *testing.T) {
 	t.Run("Test GetPreinitializedTagsFromFullMethod", func(t *testing.T) {
 		unaryTags := unaryEndPointMetadata.GetPreInitializedTags()
 		assert.Equal(t, unaryTags, map[string]string{
-			"method": unaryMethodInfo.Name,
+			"method":       unaryMethodInfo.Name,
+			"grpc_service": "tigrisdata.v1.Tigris",
 		})
 		streamTags := streamingEndpointMetadata.GetPreInitializedTags()
 		assert.Equal(t, streamTags, map[string]string{
-			"method": streamingMethodInfo.Name,
+			"method":       streamingMethodInfo.Name,
+			"grpc_service": "tigrisdata.v1.Tigris",
 		})
 	})
 
@@ -87,12 +89,10 @@ func TestGRPCMetrics(t *testing.T) {
 		tags := unaryEndPointMetadata.GetPreInitializedTags()
 		for tagName, tagValue := range tags {
 			switch tagName {
-			case "tigris_server_request_method":
+			case "method":
 				assert.Equal(t, tagValue, "TestUnaryMethod")
-			case "tigris_server_request_service_name":
+			case "grpc_service":
 				assert.Equal(t, tagValue, "tigrisdata.v1.Tigris")
-			case "tigris_server_request_type":
-				assert.Equal(t, tagValue, "unary")
 			}
 		}
 	})
@@ -101,12 +101,10 @@ func TestGRPCMetrics(t *testing.T) {
 		tags := streamingEndpointMetadata.GetPreInitializedTags()
 		for tagName, tagValue := range tags {
 			switch tagName {
-			case "tigris_server_request_method":
+			case "method":
 				assert.Equal(t, tagValue, "TestStreamingMethod")
-			case "tigris_server_request_service_name":
+			case "grpc_service":
 				assert.Equal(t, tagValue, "tigrisdata.v1.Tigris")
-			case "tigris_server_request_type":
-				assert.Equal(t, tagValue, "stream")
 			}
 		}
 	})


### PR DESCRIPTION
Load the environment from tags, add grpc_service to grpc request metric tags.