### PR TITLE
feat: namespace tag in grpc request metrics

### DIFF
--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -36,6 +36,7 @@ func (g *RequestEndpointMetadata) GetPreInitializedTags() map[string]string {
 	return map[string]string{
 		"method":       g.methodInfo.Name,
 		"grpc_service": g.serviceName,
+		"namespace":    "default_namespace",
 	}
 }
 
@@ -45,6 +46,7 @@ func (g *RequestEndpointMetadata) GetSpecificErrorTags(source string, code strin
 		"grpc_service": g.serviceName,
 		"source":       source,
 		"code":         code,
+		"namespace":    "default_namespace",
 	}
 }
 

--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -60,11 +60,13 @@ func TestGRPCMetrics(t *testing.T) {
 		assert.Equal(t, unaryTags, map[string]string{
 			"method":       unaryMethodInfo.Name,
 			"grpc_service": "tigrisdata.v1.Tigris",
+			"namespace":    "default_namespace",
 		})
 		streamTags := streamingEndpointMetadata.GetPreInitializedTags()
 		assert.Equal(t, streamTags, map[string]string{
 			"method":       streamingMethodInfo.Name,
 			"grpc_service": "tigrisdata.v1.Tigris",
+			"namespace":    "default_namespace",
 		})
 	})
 

--- a/server/midddleware/metrics.go
+++ b/server/midddleware/metrics.go
@@ -17,6 +17,7 @@ package middleware
 import (
 	"context"
 	"errors"
+	ulog "github.com/tigrisdata/tigris/util/log"
 	"github.com/uber-go/tally"
 	"strconv"
 
@@ -30,30 +31,50 @@ import (
 // loaded if the metrics are not enabled. It is more efficient this way, but if we want dynamic reloading,
 // we may want to change this in the future.
 
-func countOkMessage(fullMethod string, methodType string) {
+func getOkMethodTags(ctx context.Context, methodName string, methodType string) map[string]string {
+	tags := metrics.GetPreinitializedTagsFromFullMethod(methodName, methodType)
+	namespace, err := GetNamespace(ctx)
+	if err != nil {
+		ulog.E(err)
+	}
+	tags["namespace"] = namespace
+	return tags
+}
+
+func getErrorMethodTags(ctx context.Context, fullMethod string, methodType string, errSource string, errCode string) map[string]string {
+	metaData := metrics.GetGrpcEndPointMetadataFromFullMethod(fullMethod, methodType)
+	tags := metaData.GetSpecificErrorTags(errSource, errCode)
+	namespace, err := GetNamespace(ctx)
+	if err != nil {
+		ulog.E(err)
+	}
+	tags["namespace"] = namespace
+	return tags
+}
+
+func countOkMessage(ctx context.Context, fullMethod string, methodType string) {
 	// tigris_server_requests_ok
-	tags := metrics.GetPreinitializedTagsFromFullMethod(fullMethod, methodType)
+	tags := getOkMethodTags(ctx, fullMethod, methodType)
 	metrics.Requests.Tagged(tags).Counter("ok").Inc(1)
 }
 
-func countUnknownErrorMessage(fullMethod string, methodType string) {
+func countUnknownErrorMessage(ctx context.Context, fullMethod string, methodType string) {
 	// tigris_server_requests_error
-	tags := metrics.GetPreinitializedTagsFromFullMethod(fullMethod, methodType)
+	tags := getOkMethodTags(ctx, fullMethod, methodType)
 	metrics.ErrorRequests.Tagged(tags).Counter("unknown").Inc(1)
 }
 
-func countSpecificErrorMessage(fullMethod string, methodType, errSource string, errCode string) {
+func countSpecificErrorMessage(ctx context.Context, fullMethod string, methodType, errSource string, errCode string) {
 	// tigris_server_requests_error
 	// For specific errors the tags are not pre-initialized because it has the error code in it
-	metaData := metrics.GetGrpcEndPointMetadataFromFullMethod(fullMethod, methodType)
-	tags := metaData.GetSpecificErrorTags(errSource, errCode)
+	tags := getErrorMethodTags(ctx, fullMethod, methodType, errSource, errCode)
 	metrics.ErrorRequests.Tagged(tags).Counter("specific").Inc(1)
 }
 
 func metricsUnaryServerInterceptorResponseTime() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		methodType := "unary"
-		tags := metrics.GetPreinitializedTagsFromFullMethod(info.FullMethod, methodType)
+		tags := getOkMethodTags(ctx, info.FullMethod, methodType)
 		defer metrics.RequestsRespTime.Tagged(tags).Histogram("histogram", tally.DefaultBuckets).Start().Stop()
 		resp, err := handler(ctx, req)
 		return resp, err
@@ -68,14 +89,14 @@ func metricsUnaryServerInterceptorCounters() func(ctx context.Context, req inter
 			var terr *api.TigrisError
 			var ferr fdb.Error
 			if errors.As(err, &terr) {
-				countSpecificErrorMessage(info.FullMethod, methodType, "tigris_server", terr.Code.String())
+				countSpecificErrorMessage(ctx, info.FullMethod, methodType, "tigris_server", terr.Code.String())
 			} else if errors.As(err, &ferr) {
-				countSpecificErrorMessage(info.FullMethod, methodType, "fdb_server", strconv.Itoa(ferr.Code))
+				countSpecificErrorMessage(ctx, info.FullMethod, methodType, "fdb_server", strconv.Itoa(ferr.Code))
 			} else {
-				countUnknownErrorMessage(info.FullMethod, methodType)
+				countUnknownErrorMessage(ctx, info.FullMethod, methodType)
 			}
 		} else {
-			countOkMessage(info.FullMethod, methodType)
+			countOkMessage(ctx, info.FullMethod, methodType)
 		}
 		return resp, err
 	}
@@ -84,7 +105,8 @@ func metricsUnaryServerInterceptorCounters() func(ctx context.Context, req inter
 func metricsStreamServerInterceptorResponseTime() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		methodType := "stream"
-		tags := metrics.GetPreinitializedTagsFromFullMethod(info.FullMethod, methodType)
+		ctx := stream.Context()
+		tags := getOkMethodTags(ctx, info.FullMethod, methodType)
 		defer metrics.RequestsRespTime.Tagged(tags).Histogram("histogram", tally.DefaultBuckets).Start().Stop()
 		wrapper := &recvWrapper{stream}
 		err := handler(srv, wrapper)
@@ -95,20 +117,21 @@ func metricsStreamServerInterceptorResponseTime() grpc.StreamServerInterceptor {
 func metricsStreamServerInterceptorCounter() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		wrapper := &recvWrapper{stream}
+		ctx := stream.Context()
 		err := handler(srv, wrapper)
 		methodType := "stream"
 		if err != nil {
 			var terr *api.TigrisError
 			var ferr fdb.Error
 			if errors.As(err, &terr) {
-				countSpecificErrorMessage(info.FullMethod, methodType, "tigris_server", terr.Code.String())
+				countSpecificErrorMessage(ctx, info.FullMethod, methodType, "tigris_server", terr.Code.String())
 			} else if errors.As(err, &ferr) {
-				countSpecificErrorMessage(info.FullMethod, methodType, "fdb_server", strconv.Itoa(ferr.Code))
+				countSpecificErrorMessage(ctx, info.FullMethod, methodType, "fdb_server", strconv.Itoa(ferr.Code))
 			} else {
-				countUnknownErrorMessage(info.FullMethod, methodType)
+				countUnknownErrorMessage(ctx, info.FullMethod, methodType)
 			}
 		} else {
-			countOkMessage(info.FullMethod, methodType)
+			countOkMessage(ctx, info.FullMethod, methodType)
 		}
 		return err
 	}

--- a/server/midddleware/metrics_test.go
+++ b/server/midddleware/metrics_test.go
@@ -15,28 +15,23 @@
 package middleware
 
 import (
+	"context"
 	"testing"
 
 	"github.com/tigrisdata/tigris/server/metrics"
-	"google.golang.org/grpc"
 )
 
 func TestGrpcMetrics(t *testing.T) {
 	metrics.InitializeMetrics()
-	svcName := "tigrisdata.v1.Tigris"
-	methodName := "TestMethod"
 	methodType := "unary"
-	methodInfo := grpc.MethodInfo{
-		Name:           methodName,
-		IsServerStream: false,
-		IsClientStream: false,
-	}
 	fullMethodName := "/tigrisdata.v1.Tigris/TestMethod"
-	metrics.InitServerRequestMetrics(svcName, methodInfo)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, RequestMetadataCtxKey{}, "test_namespace")
 
 	t.Run("Test tigris server counters", func(t *testing.T) {
-		countUnknownErrorMessage(fullMethodName, methodType)
-		countOkMessage(fullMethodName, methodType)
-		countSpecificErrorMessage(fullMethodName, methodType, "test_source", "test_code")
+		countUnknownErrorMessage(ctx, fullMethodName, methodType)
+		countOkMessage(ctx, fullMethodName, methodType)
+		countSpecificErrorMessage(ctx, fullMethodName, methodType, "test_source", "test_code")
 	})
 }

--- a/server/midddleware/middleware.go
+++ b/server/midddleware/middleware.go
@@ -59,6 +59,7 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 		forwarderStreamServerInterceptor(),
 		grpc_ratelimit.StreamServerInterceptor(&RateLimiter{}),
 		grpc_auth.StreamServerInterceptor(authFunction),
+		namespaceInitializer.NamespaceSetterStreamServerInterceptor(),
 		grpctrace.StreamServerInterceptor(grpctrace.WithServiceName(config.Tags.Service)),
 		grpc_logging.StreamServerInterceptor(grpc_zerolog.InterceptorLogger(log.Logger), []grpc_logging.Option{}...),
 		validatorStreamServerInterceptor(),
@@ -76,7 +77,6 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 		grpc_opentracing.StreamServerInterceptor(),
 		grpc_recovery.StreamServerInterceptor(),
 		headersStreamServerInterceptor(),
-		namespaceInitializer.NamespaceSetterStreamServerInterceptor(),
 	}...)
 	stream := middleware.ChainStreamServer(streamInterceptors...)
 
@@ -91,6 +91,7 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 		pprofUnaryServerInterceptor(),
 		grpc_ratelimit.UnaryServerInterceptor(&RateLimiter{}),
 		grpc_auth.UnaryServerInterceptor(authFunction),
+		namespaceInitializer.NamespaceSetterUnaryServerInterceptor(),
 		grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(config.Tags.Service)),
 		//grpc_logging.UnaryServerInterceptor(grpc_zerolog.InterceptorLogger(log.Logger)),
 		validatorUnaryServerInterceptor(),
@@ -109,7 +110,6 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 		grpc_opentracing.UnaryServerInterceptor(),
 		grpc_recovery.UnaryServerInterceptor(),
 		headersUnaryServerInterceptor(),
-		namespaceInitializer.NamespaceSetterUnaryServerInterceptor(),
 	}...)
 	unary := middleware.ChainUnaryServer(unaryInterceptors...)
 

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -16,13 +16,13 @@ package muxer
 
 import (
 	"fmt"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"net"
 
 	"github.com/rs/zerolog/log"
 	"github.com/soheilhy/cmux"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
-	"github.com/tigrisdata/tigris/server/metrics"
 	v1 "github.com/tigrisdata/tigris/server/services/v1"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"


### PR DESCRIPTION
Add namespace as part of the tags. When the metrics are initialised at server startup, those are using `default_namespace`.

Example:
```
server_requests_ok{env="",grpc_service="tigrisdata.v1.Tigris",method="ListDatabases",namespace="default_namespace",service="tigris-server",version="065426c"} 15
```
