### PR TITLE
feat: implement trace sampling

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -53,12 +53,13 @@ type CdcConfig struct {
 }
 
 type TracingConfig struct {
-	Enabled             bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
-	CodeHotspotsEnabled bool   `mapstructure:"codehotspots_enabled" yaml:"codehotspots_enabled" json:"codehotspots_enabled"`
-	EndpointsEnabled    bool   `mapstructure:"endpoints_enabled" yaml:"endpoints_enabled" json:"endpoints_enabled"`
-	WithUDS             string `mapstructure:"agent_socket" yaml:"agent_socket" json:"agent_socket"`
-	WithAgentAddr       string `mapstructure:"agent_addr" yaml:"agent_addr" json:"agent_addr"`
-	WithDogStatsdAddr   string `mapstructure:"dogstatsd_addr" yaml:"dogstatsd_addr" json:"dogstatsd_addr"`
+	Enabled             bool    `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	SampleRate          float64 `mapstructure:"sample_rate" yaml:"sample_rate" json:"sample_rate"`
+	CodeHotspotsEnabled bool    `mapstructure:"codehotspots_enabled" yaml:"codehotspots_enabled" json:"codehotspots_enabled"`
+	EndpointsEnabled    bool    `mapstructure:"endpoints_enabled" yaml:"endpoints_enabled" json:"endpoints_enabled"`
+	WithUDS             string  `mapstructure:"agent_socket" yaml:"agent_socket" json:"agent_socket"`
+	WithAgentAddr       string  `mapstructure:"agent_addr" yaml:"agent_addr" json:"agent_addr"`
+	WithDogStatsdAddr   string  `mapstructure:"dogstatsd_addr" yaml:"dogstatsd_addr" json:"dogstatsd_addr"`
 }
 
 type ProfilingConfig struct {
@@ -119,6 +120,7 @@ var DefaultConfig = Config{
 	},
 	Tracing: TracingConfig{
 		Enabled:             false,
+		SampleRate:          0.01,
 		CodeHotspotsEnabled: true,
 		EndpointsEnabled:    true,
 	},

--- a/server/tracing/tracing.go
+++ b/server/tracing/tracing.go
@@ -9,9 +9,11 @@ import (
 
 func getTracingOptions(c *config.Config) []tracer.StartOption {
 	var opts []tracer.StartOption
+	rules := []tracer.SamplingRule{tracer.ServiceRule(util.Service, c.Tracing.SampleRate)}
 	opts = append(opts, tracer.WithTraceEnabled(c.Tracing.Enabled))
 	opts = append(opts, tracer.WithProfilerEndpoints(c.Tracing.EndpointsEnabled))
 	opts = append(opts, tracer.WithProfilerCodeHotspots(c.Tracing.CodeHotspotsEnabled))
+	opts = append(opts, tracer.WithSamplingRules(rules))
 	opts = append(opts, tracer.WithService(util.Service))
 	opts = append(opts, tracer.WithEnv(config.GetEnvironment()))
 	opts = append(opts, tracer.WithServiceVersion(util.Version))


### PR DESCRIPTION
Sets a default sampling rate of 1% but also makes it configurable for tracing and profiling. Logging will be tied to and implement via a separate PR.