### PR TITLE
feat: Add namespace tags to FDB metrics

### DIFF
--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -15,9 +15,10 @@
 package metrics
 
 import (
-	"github.com/tigrisdata/tigris/server/config"
+	"context"
+	"github.com/tigrisdata/tigris/server/request"
+	ulog "github.com/tigrisdata/tigris/util/log"
 	"github.com/uber-go/tally"
-	"strconv"
 )
 
 var (
@@ -38,52 +39,43 @@ var (
 		"Update",
 		"UpdateRange",
 		"BeginTx",
-		"GetInternalDatabase",
 	}
 )
 
-func GetFdbReqTags(reqMethodName string, tx bool) map[string]string {
+func getFdbReqTags(reqMethodName string) map[string]string {
 	return map[string]string{
-		"method": reqMethodName,
-		"tx":     strconv.FormatBool(tx),
+		"method":        reqMethodName,
+		"tigris_tenant": DefaultReportedTigrisTenant,
 	}
 }
 
-func GetFdbReqSpecificErrorTags(reqMethodName string, code string, tx bool) map[string]string {
+func getFdbReqSpecificErrorTags(reqMethodName string, code string) map[string]string {
 	return map[string]string{
-		"method":     reqMethodName,
-		"error_code": code,
-		"tx":         strconv.FormatBool(tx),
+		"method":        reqMethodName,
+		"error_code":    code,
+		"tigris_tenant": DefaultReportedTigrisTenant,
 	}
+}
+
+func addTigrisTenantToTags(ctx context.Context, tags map[string]string) map[string]string {
+	namespace, err := request.GetNamespace(ctx)
+	if ulog.E(err) {
+		tags["tigris_tenant"] = DefaultReportedTigrisTenant
+	} else {
+		tags["tigris_tenant"] = namespace
+	}
+	return tags
+}
+
+func GetFdbTags(ctx context.Context, reqMethodName string) map[string]string {
+	return addTigrisTenantToTags(ctx, getFdbReqTags(reqMethodName))
+}
+
+func GetFdbSpecificErrorTags(ctx context.Context, reqMethodName string, code string) map[string]string {
+	return addTigrisTenantToTags(ctx, getFdbReqSpecificErrorTags(reqMethodName, code))
 }
 
 func InitializeFdbScopes() {
 	FdbRequests = FdbMetrics.SubScope("requests")
 	FdbErrorRequests = FdbRequests.SubScope("error")
-}
-
-func InitializeFdbMetrics() {
-	for _, reqMethodName := range MeasuredFdbRequests {
-		nonTxTags := GetFdbReqTags(reqMethodName, false)
-		txTags := GetFdbReqTags(reqMethodName, true)
-		// TODO: metrics_fix
-		if config.DefaultConfig.Metrics.Fdb.Enabled && config.DefaultConfig.Metrics.Fdb.Counters {
-			// Counter for ok requests
-			FdbRequests.Tagged(nonTxTags).Counter("ok")
-			FdbRequests.Tagged(txTags).Counter("ok")
-
-			// Counter for unknown errors
-			FdbErrorRequests.Tagged(nonTxTags).Counter("unknown")
-			FdbErrorRequests.Tagged(txTags).Counter("unknown")
-
-			// Counters for known errors are only initialized for the first occurrence.
-			// The error code is part of the tags.
-		}
-
-		if config.DefaultConfig.Metrics.Fdb.Enabled && config.DefaultConfig.Metrics.Fdb.ResponseTime {
-			// Response time histograms
-			FdbRequests.Tagged(nonTxTags).Histogram("histogram", tally.DefaultBuckets)
-			FdbRequests.Tagged(txTags).Histogram("histogram", tally.DefaultBuckets)
-		}
-	}
 }

--- a/server/metrics/fdb_test.go
+++ b/server/metrics/fdb_test.go
@@ -15,24 +15,29 @@
 package metrics
 
 import (
+	"context"
+	"testing"
+
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/uber-go/tally"
-	"testing"
 )
 
 func TestFdbMetrics(t *testing.T) {
 	config.DefaultConfig.Metrics.Fdb.Enabled = true
 	InitializeMetrics()
+
+	ctx := context.Background()
+
 	testNormalTags := []map[string]string{
-		GetFdbReqTags("Commit", false),
-		GetFdbReqTags("Insert", false),
-		GetFdbReqTags("Insert", true),
+		GetFdbTags(ctx, "Commit"),
+		GetFdbTags(ctx, "Insert"),
+		GetFdbTags(ctx, "Insert"),
 	}
 
 	testKnownErrorTags := []map[string]string{
-		GetFdbReqSpecificErrorTags("Commit", "1", false),
-		GetFdbReqSpecificErrorTags("Insert", "2", false),
-		GetFdbReqSpecificErrorTags("Insert", "3", true),
+		GetFdbSpecificErrorTags(ctx, "Commit", "1"),
+		GetFdbSpecificErrorTags(ctx, "Insert", "2"),
+		GetFdbSpecificErrorTags(ctx, "Insert", "3"),
 	}
 
 	config.DefaultConfig.Metrics.Fdb.Counters = true
@@ -48,7 +53,7 @@ func TestFdbMetrics(t *testing.T) {
 
 	config.DefaultConfig.Metrics.Fdb.ResponseTime = true
 	t.Run("Test FDB histograms", func(t *testing.T) {
-		testHistogramTags := GetFdbReqTags("Insert", true)
+		testHistogramTags := GetFdbTags(ctx, "Insert")
 		defer FdbMetrics.Tagged(testHistogramTags).Histogram("histogram", tally.DefaultBuckets).Start().Stop()
 	})
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -18,13 +18,16 @@ import (
 	"io"
 	"time"
 
-	"github.com/tigrisdata/tigris/server/config"
-	"github.com/tigrisdata/tigris/util"
-
 	prom "github.com/m3db/prometheus_client_golang/prometheus"
 	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/util"
 	"github.com/uber-go/tally"
 	promreporter "github.com/uber-go/tally/prometheus"
+)
+
+const (
+	DefaultReportedTigrisTenant string = "unknown"
 )
 
 var (
@@ -62,13 +65,11 @@ func InitializeMetrics() io.Closer {
 	// metric names: tigris_server
 	if config.DefaultConfig.Metrics.Grpc.Enabled {
 		InitializeRequestScopes()
-		// Request level metrics are initialized during GRPC server registration
 	}
 	// FDB level metrics
 	if config.DefaultConfig.Metrics.Fdb.Enabled {
 		FdbMetrics = root.SubScope("fdb")
 		InitializeFdbScopes()
-		InitializeFdbMetrics()
 	}
 	return closer
 }

--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -16,10 +16,10 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/tigrisdata/tigris/server/config"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigris/server/config"
 	"google.golang.org/grpc"
 )
 
@@ -58,15 +58,15 @@ func TestGRPCMetrics(t *testing.T) {
 	t.Run("Test GetPreinitializedTagsFromFullMethod", func(t *testing.T) {
 		unaryTags := unaryEndPointMetadata.GetPreInitializedTags()
 		assert.Equal(t, unaryTags, map[string]string{
-			"method":       unaryMethodInfo.Name,
-			"grpc_service": "tigrisdata.v1.Tigris",
-			"namespace":    "default_namespace",
+			"method":        unaryMethodInfo.Name,
+			"grpc_service":  "tigrisdata.v1.Tigris",
+			"tigris_tenant": DefaultReportedTigrisTenant,
 		})
 		streamTags := streamingEndpointMetadata.GetPreInitializedTags()
 		assert.Equal(t, streamTags, map[string]string{
-			"method":       streamingMethodInfo.Name,
-			"grpc_service": "tigrisdata.v1.Tigris",
-			"namespace":    "default_namespace",
+			"method":        streamingMethodInfo.Name,
+			"grpc_service":  "tigrisdata.v1.Tigris",
+			"tigris_tenant": DefaultReportedTigrisTenant,
 		})
 	})
 
@@ -109,16 +109,5 @@ func TestGRPCMetrics(t *testing.T) {
 				assert.Equal(t, tagValue, "tigrisdata.v1.Tigris")
 			}
 		}
-	})
-
-	t.Run("Test metrics initialization", func(t *testing.T) {
-		InitServerRequestMetrics(svcName, unaryMethodInfo)
-		InitServerRequestMetrics(svcName, streamingMethodInfo)
-	})
-
-	t.Run("Test specific error tags", func(t *testing.T) {
-		error_tags := unaryEndPointMetadata.GetSpecificErrorTags("test_source", "test_code")
-		assert.Equal(t, error_tags["source"], "test_source")
-		assert.Equal(t, error_tags["code"], "test_code")
 	})
 }

--- a/server/midddleware/metrics_test.go
+++ b/server/midddleware/metrics_test.go
@@ -27,13 +27,6 @@ func TestGrpcMetrics(t *testing.T) {
 	fullMethodName := "/tigrisdata.v1.Tigris/TestMethod"
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, RequestMetadataCtxKey{}, &RequestMetadata{
-		accessToken: &AccessToken{
-			Namespace: "test-namespace-1",
-			Sub:       "test@tigrisdata.com",
-		},
-		namespace: "test-namespace-1",
-	})
 
 	t.Run("Test tigris server counters", func(t *testing.T) {
 		countUnknownErrorMessage(ctx, fullMethodName, methodType)

--- a/server/midddleware/middleware.go
+++ b/server/midddleware/middleware.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tigrisdata/tigris/server/config"
 	tigrisconfig "github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/request"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/util"
 	"google.golang.org/grpc"
@@ -49,7 +50,7 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 	excludedMethods.Insert("/tigrisdata.admin.v1.Admin/listNamespaces")
 	namespaceInitializer := NamespaceSetter{
 		tenantManager:      tenantMgr,
-		namespaceExtractor: &AccessTokenNamespaceExtractor{},
+		namespaceExtractor: &request.AccessTokenNamespaceExtractor{},
 		excludedMethods:    excludedMethods,
 		config:             config,
 	}

--- a/server/midddleware/namespace.go
+++ b/server/midddleware/namespace.go
@@ -8,29 +8,30 @@ import (
 	"github.com/tigrisdata/tigris/lib/set"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/request"
 	"google.golang.org/grpc"
 )
 
 type NamespaceSetter struct {
 	tenantManager      *metadata.TenantManager
-	namespaceExtractor NamespaceExtractor
+	namespaceExtractor request.NamespaceExtractor
 	excludedMethods    set.HashSet
 	config             *config.Config
 }
 
 func (r *NamespaceSetter) NamespaceSetterUnaryServerInterceptor() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if !r.config.Auth.EnableNamespaceIsolation {
-			return handler(setNamespace(ctx, metadata.DefaultNamespaceName), req)
+		if !r.config.Auth.EnableNamespaceIsolation || r.excludedMethods.Contains(info.FullMethod) {
+			return handler(request.SetNamespace(ctx, metadata.DefaultNamespaceName), req)
 		} else {
 			namespace, err := r.namespaceExtractor.Extract(ctx)
 			if err != nil {
 				return nil, err
 			}
 			if namespace == "" {
-				return handler(setNamespace(ctx, "unknown"), req)
+				return handler(request.SetNamespace(ctx, "unknown"), req)
 			}
-			return handler(setNamespace(ctx, namespace), req)
+			return handler(request.SetNamespace(ctx, namespace), req)
 		}
 	}
 }
@@ -39,7 +40,7 @@ func (r *NamespaceSetter) NamespaceSetterStreamServerInterceptor() grpc.StreamSe
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !r.config.Auth.EnableNamespaceIsolation {
 			wrapped := middleware.WrapServerStream(stream)
-			wrapped.WrappedContext = setNamespace(stream.Context(), metadata.DefaultNamespaceName)
+			wrapped.WrappedContext = request.SetNamespace(stream.Context(), metadata.DefaultNamespaceName)
 			return handler(srv, wrapped)
 		} else {
 			namespace, err := r.namespaceExtractor.Extract(stream.Context())
@@ -50,7 +51,7 @@ func (r *NamespaceSetter) NamespaceSetterStreamServerInterceptor() grpc.StreamSe
 				return api.Errorf(api.Code_INVALID_ARGUMENT, "Could not find namespace")
 			}
 			wrapped := middleware.WrapServerStream(stream)
-			wrapped.WrappedContext = setNamespace(stream.Context(), namespace)
+			wrapped.WrappedContext = request.SetNamespace(stream.Context(), namespace)
 			return handler(srv, wrapped)
 		}
 	}

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -16,7 +16,6 @@ package muxer
 
 import (
 	"fmt"
-	"github.com/tigrisdata/tigris/server/metrics"
 	"net"
 
 	"github.com/rs/zerolog/log"
@@ -50,8 +49,6 @@ func (m *Muxer) RegisterServices(kvStore kv.KeyValueStore, searchStore search.St
 				if err := r.RegisterGRPC(s.Server); err != nil {
 					ulog.E(err)
 				}
-				// Initialize the metrics for each GRPC service
-				metrics.InitRequestMetricsForServer(s.Server)
 			} else if s, ok := v.(*HTTPServer); ok {
 				if err := r.RegisterHTTP(s.Router, s.Inproc); err != nil {
 					ulog.E(err)

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -1,4 +1,4 @@
-package middleware
+package request
 
 import (
 	"context"
@@ -30,6 +30,8 @@ type NamespaceExtractor interface {
 type AccessTokenNamespaceExtractor struct {
 }
 
+var ErrNamespaceNotFound = api.Errorf(api.Code_NOT_FOUND, "namespace not found")
+
 func GetRequestMetadata(ctx context.Context) (*RequestMetadata, error) {
 	// read token
 	value := ctx.Value(RequestMetadataCtxKey{})
@@ -41,7 +43,7 @@ func GetRequestMetadata(ctx context.Context) (*RequestMetadata, error) {
 	return nil, api.Errorf(api.Code_NOT_FOUND, "RequestMetadata not found")
 }
 
-func setAccessToken(ctx context.Context, token *AccessToken) context.Context {
+func SetAccessToken(ctx context.Context, token *AccessToken) context.Context {
 	requestMetadata, _ := GetRequestMetadata(ctx)
 	if requestMetadata == nil {
 		requestMetadata = &RequestMetadata{}
@@ -53,7 +55,7 @@ func setAccessToken(ctx context.Context, token *AccessToken) context.Context {
 	}
 }
 
-func setNamespace(ctx context.Context, namespace string) context.Context {
+func SetNamespace(ctx context.Context, namespace string) context.Context {
 	requestMetadata, err := GetRequestMetadata(ctx)
 	var result = ctx
 	if err != nil && requestMetadata == nil {
@@ -63,6 +65,7 @@ func setNamespace(ctx context.Context, namespace string) context.Context {
 	requestMetadata.namespace = namespace
 	return result
 }
+
 func GetAccessToken(ctx context.Context) (*AccessToken, error) {
 	// read token
 	value := ctx.Value(RequestMetadataCtxKey{})
@@ -73,6 +76,7 @@ func GetAccessToken(ctx context.Context) (*AccessToken, error) {
 	}
 	return nil, api.Errorf(api.Code_NOT_FOUND, "Access token not found")
 }
+
 func GetNamespace(ctx context.Context) (string, error) {
 	// read token
 	value := ctx.Value(RequestMetadataCtxKey{})
@@ -81,7 +85,7 @@ func GetNamespace(ctx context.Context) (string, error) {
 			return requestMetadata.namespace, nil
 		}
 	}
-	return "", api.Errorf(api.Code_NOT_FOUND, "Namespace not found")
+	return "", ErrNamespaceNotFound
 }
 
 func (tokenNamespaceExtractor *AccessTokenNamespaceExtractor) Extract(ctx context.Context) (string, error) {

--- a/server/request/request_test.go
+++ b/server/request/request_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package middleware
+package request
 
 import (
 	"context"

--- a/server/services/v1/sessions.go
+++ b/server/services/v1/sessions.go
@@ -25,7 +25,8 @@ import (
 	"github.com/tigrisdata/tigris/server/cdc"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
-	"github.com/tigrisdata/tigris/server/midddleware"
+	middleware "github.com/tigrisdata/tigris/server/midddleware"
+	"github.com/tigrisdata/tigris/server/request"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
 	"github.com/tigrisdata/tigris/store/search"
@@ -69,7 +70,7 @@ func NewSessionManager(txMgr *transaction.Manager, tenantMgr *metadata.TenantMan
 // It first creates or get a tenant, read the metadata version and based on that reload the tenant cache and then finally
 // create a transaction which will be used to execute all the query in this session.
 func (sessMgr *SessionManager) Create(ctx context.Context, reloadVerOutside bool, track bool) (*QuerySession, error) {
-	namespaceForThisSession, err := middleware.GetNamespace(ctx)
+	namespaceForThisSession, err := request.GetNamespace(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/store/kv/kv_test.go
+++ b/store/kv/kv_test.go
@@ -617,7 +617,7 @@ func testSetVersionstampedValue(t *testing.T, kv baseKVStore) {
 }
 
 func testMeasureLow() {
-	metrics.InitializeFdbMetrics()
+	ctx := context.Background()
 
 	testFunctions := []func() error{
 		func() error {
@@ -632,10 +632,10 @@ func testMeasureLow() {
 	}
 
 	for _, f := range testFunctions {
-		measureLow("Commit", f, true)
-		measureLow("Insert", f, true)
-		measureLow("Insert", f, false)
-		measureLow("BeginTx", f, true)
+		measureLow(ctx, "Commit", f)
+		measureLow(ctx, "Insert", f)
+		measureLow(ctx, "Insert", f)
+		measureLow(ctx, "BeginTx", f)
 	}
 }
 


### PR DESCRIPTION
Add namespace tags to FDB metrics. The GetInternalDatabase() call (used by CDC) will always be tagged as default_namepsace. 