### PR TITLE
fix: Hits and Facets cannot be null

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -427,6 +427,13 @@ func (x *SearchResponse) MarshalJSON() ([]byte, error) {
 		Facets: x.Facets,
 		Meta:   x.Meta,
 	}
+
+	if resp.Hits == nil {
+		resp.Hits = make([]*SearchHit, 0)
+	}
+	if resp.Facets == nil {
+		resp.Facets = make(map[string]*SearchFacet)
+	}
 	return json.Marshal(resp)
 }
 
@@ -461,6 +468,9 @@ func (x *SearchFacet) MarshalJSON() ([]byte, error) {
 	}{
 		Counts: x.Counts,
 		Stats:  x.Stats,
+	}
+	if resp.Counts == nil {
+		resp.Counts = make([]*FacetCount, 0)
 	}
 	return json.Marshal(resp)
 }


### PR DESCRIPTION
Includes fixes for:
- null `Hits` and `Facets` to be serialized as empty JSON objects instead of null
- totalPages were having an extra page being computed in some cases (when found elements was either `0` or same as `pageSize`)