### PR TITLE
fix: allow enabling fdb delete using config, fix a metadata version bug

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -21,8 +21,9 @@ import (
 )
 
 type ServerConfig struct {
-	Host string
-	Port int16
+	Host      string
+	Port      int16
+	FDBDelete bool `mapstructure:"fdb_delete" yaml:"fdb_delete" json:"fdb_delete"`
 }
 
 type Config struct {
@@ -105,8 +106,9 @@ var DefaultConfig = Config{
 		SampleRate: 0.01,
 	},
 	Server: ServerConfig{
-		Host: "0.0.0.0",
-		Port: 8081,
+		Host:      "0.0.0.0",
+		Port:      8081,
+		FDBDelete: false,
 	},
 	Auth: AuthConfig{
 		IssuerURL:                "https://tigrisdata-dev.us.auth0.com/",

--- a/server/main.go
+++ b/server/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Fatal().Err(err).Msg("error initializing search store")
 	}
 
-	tenantMgr := metadata.NewTenantManager()
+	tenantMgr := metadata.NewTenantManager(kvStore)
 	log.Info().Msg("initialized tenant manager")
 	txMgr := transaction.NewManager(kvStore)
 	log.Info().Msg("initialized transaction manager")

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/tigrisdata/tigris/server/config"
 	"reflect"
 	"sync"
 
@@ -26,8 +25,10 @@ import (
 	"github.com/rs/zerolog/log"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata/encoding"
 	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/kv"
 	"github.com/tigrisdata/tigris/store/search"
 	ulog "github.com/tigrisdata/tigris/util/log"
 	tsApi "github.com/typesense/typesense-go/typesense/api"
@@ -105,6 +106,7 @@ type TenantManager struct {
 
 	encoder        *encoding.DictionaryEncoder
 	schemaStore    *encoding.SchemaSubspace
+	kvStore        kv.KeyValueStore
 	tenants        map[string]*Tenant
 	idToTenantMap  map[uint32]string
 	version        Version
@@ -112,13 +114,14 @@ type TenantManager struct {
 	mdNameRegistry encoding.MDNameRegistry
 }
 
-func NewTenantManager() *TenantManager {
+func NewTenantManager(kvStore kv.KeyValueStore) *TenantManager {
 	mdNameRegistry := &encoding.DefaultMDNameRegistry{}
-	return newTenantManager(mdNameRegistry)
+	return newTenantManager(kvStore, mdNameRegistry)
 }
 
-func newTenantManager(mdNameRegistry encoding.MDNameRegistry) *TenantManager {
+func newTenantManager(kvStore kv.KeyValueStore, mdNameRegistry encoding.MDNameRegistry) *TenantManager {
 	return &TenantManager{
+		kvStore:        kvStore,
 		encoder:        encoding.NewDictionaryEncoder(mdNameRegistry),
 		schemaStore:    encoding.NewSchemaStore(mdNameRegistry),
 		tenants:        make(map[string]*Tenant),
@@ -249,7 +252,7 @@ func (m *TenantManager) GetTenant(ctx context.Context, namespaceName string, txM
 	}
 
 	namespace := NewTenantNamespace(namespaceName, id)
-	tenant = NewTenant(namespace, m.encoder, m.schemaStore, m.versionH, currentVersion)
+	tenant = NewTenant(namespace, m.kvStore, m.encoder, m.schemaStore, m.versionH, currentVersion)
 	if err = tenant.reload(ctx, tx, currentVersion); err != nil {
 		return nil, err
 	}
@@ -285,7 +288,7 @@ func (m *TenantManager) createOrGetTenantInternal(ctx context.Context, tx transa
 			return nil, err
 		}
 
-		tenant := NewTenant(namespace, m.encoder, m.schemaStore, m.versionH, currentVersion)
+		tenant := NewTenant(namespace, m.kvStore, m.encoder, m.schemaStore, m.versionH, currentVersion)
 		tenant.Lock()
 		err = tenant.reload(ctx, tx, currentVersion)
 		tenant.Unlock()
@@ -303,7 +306,7 @@ func (m *TenantManager) createOrGetTenantInternal(ctx context.Context, tx transa
 		return nil, err
 	}
 
-	return NewTenant(namespace, m.encoder, m.schemaStore, m.versionH, nil), nil
+	return NewTenant(namespace, m.kvStore, m.encoder, m.schemaStore, m.versionH, nil), nil
 }
 
 // GetTableNameFromId returns tenant name, database name, collection name corresponding to their encoded ids.
@@ -369,7 +372,7 @@ func (m *TenantManager) reload(ctx context.Context, tx transaction.Tx, currentVe
 
 	for namespace, id := range namespaces {
 		if _, ok := m.tenants[namespace]; !ok {
-			m.tenants[namespace] = NewTenant(NewTenantNamespace(namespace, id), m.encoder, m.schemaStore, m.versionH, currentVersion)
+			m.tenants[namespace] = NewTenant(NewTenantNamespace(namespace, id), m.kvStore, m.encoder, m.schemaStore, m.versionH, currentVersion)
 			m.idToTenantMap[id] = namespace
 		}
 	}
@@ -391,6 +394,7 @@ func (m *TenantManager) reload(ctx context.Context, tx transaction.Tx, currentVe
 type Tenant struct {
 	sync.RWMutex
 
+	kvStore         kv.KeyValueStore
 	encoder         *encoding.DictionaryEncoder
 	schemaStore     *encoding.SchemaSubspace
 	databases       map[string]*Database
@@ -400,8 +404,9 @@ type Tenant struct {
 	versionH        *VersionHandler
 }
 
-func NewTenant(namespace Namespace, encoder *encoding.DictionaryEncoder, schemaStore *encoding.SchemaSubspace, versionH *VersionHandler, currentVersion Version) *Tenant {
+func NewTenant(namespace Namespace, kvStore kv.KeyValueStore, encoder *encoding.DictionaryEncoder, schemaStore *encoding.SchemaSubspace, versionH *VersionHandler, currentVersion Version) *Tenant {
 	return &Tenant{
+		kvStore:         kvStore,
 		namespace:       namespace,
 		encoder:         encoder,
 		schemaStore:     schemaStore,
@@ -446,7 +451,8 @@ func (tenant *Tenant) ReloadUsingOutsideVersion(ctx context.Context, tx transact
 
 	tenant.Lock()
 	defer tenant.Unlock()
-	if bytes.Equal(version, tenant.version) {
+	if bytes.Compare(version, tenant.version) < 1 {
+		// do not reload if version retrogressed
 		return nil
 	}
 
@@ -466,7 +472,8 @@ func (tenant *Tenant) ReloadUsingTxVersion(ctx context.Context, tx transaction.T
 
 	tenant.Lock()
 	defer tenant.Unlock()
-	if bytes.Equal(currentVersion, tenant.version) {
+	if bytes.Compare(currentVersion, tenant.version) < 1 {
+		// do not reload if version retrogressed
 		return nil
 	}
 	log.Debug().Str("tx_id", id).Msgf("reloading tenants")
@@ -477,7 +484,7 @@ func (tenant *Tenant) shouldReload(currentVersion Version) bool {
 	tenant.RLock()
 	defer tenant.RUnlock()
 
-	return !bytes.Equal(currentVersion, tenant.version)
+	return bytes.Compare(currentVersion, tenant.version) > 0
 }
 
 func (tenant *Tenant) GetNamespace() Namespace {
@@ -508,7 +515,7 @@ func (tenant *Tenant) CreateDatabase(ctx context.Context, tx transaction.Tx, dbN
 
 // DropDatabase is responsible for first dropping a dictionary encoding of the database and then adding a corresponding
 // dropped encoding in the table. Drop returns "false" if database doesn't exist so that caller can reason about.
-func (tenant *Tenant) DropDatabase(ctx context.Context, tx transaction.Tx, dbName string, searchStore search.Store) (bool, error) {
+func (tenant *Tenant) DropDatabase(ctx context.Context, tx transaction.Tx, dbName string, searchStore search.Store, rowKeyEncoder Encoder) (bool, error) {
 	tenant.Lock()
 	defer tenant.Unlock()
 
@@ -525,7 +532,7 @@ func (tenant *Tenant) DropDatabase(ctx context.Context, tx transaction.Tx, dbNam
 	}
 
 	for _, c := range db.collections {
-		if err := tenant.dropCollection(ctx, tx, db, c.collection.Name, searchStore); err != nil {
+		if err := tenant.dropCollection(ctx, tx, db, c.collection.Name, searchStore, rowKeyEncoder); err != nil {
 			return true, err
 		}
 	}
@@ -720,11 +727,11 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 
 // DropCollection is to drop a collection and its associated indexes. It removes the "created" entry from the encoding
 // subspace and adds a "dropped" entry for the same collection key.
-func (tenant *Tenant) DropCollection(ctx context.Context, tx transaction.Tx, db *Database, collectionName string, searchStore search.Store) error {
+func (tenant *Tenant) DropCollection(ctx context.Context, tx transaction.Tx, db *Database, collectionName string, searchStore search.Store, rowKeyEncoder Encoder) error {
 	tenant.Lock()
 	defer tenant.Unlock()
 
-	err := tenant.dropCollection(ctx, tx, db, collectionName, searchStore)
+	err := tenant.dropCollection(ctx, tx, db, collectionName, searchStore, rowKeyEncoder)
 	if err != nil {
 		return err
 	}
@@ -736,7 +743,7 @@ func (tenant *Tenant) DropCollection(ctx context.Context, tx transaction.Tx, db 
 	return err
 }
 
-func (tenant *Tenant) dropCollection(ctx context.Context, tx transaction.Tx, db *Database, collectionName string, searchStore search.Store) error {
+func (tenant *Tenant) dropCollection(ctx context.Context, tx transaction.Tx, db *Database, collectionName string, searchStore search.Store, rowKeyEncoder Encoder) error {
 	if db == nil {
 		return api.Errorf(api.Code_NOT_FOUND, "database missing")
 	}
@@ -757,6 +764,17 @@ func (tenant *Tenant) dropCollection(ctx context.Context, tx transaction.Tx, db 
 	}
 	if err := tenant.schemaStore.Delete(ctx, tx, tenant.namespace.Id(), db.id, cHolder.id); err != nil {
 		return err
+	}
+
+	if config.DefaultConfig.Server.FDBDelete {
+		tableName, err := rowKeyEncoder.EncodeTableName(tenant.namespace, db, cHolder.collection)
+		if err != nil {
+			return err
+		}
+
+		if err = tenant.kvStore.DropTable(ctx, tableName); err != nil {
+			return err
+		}
 	}
 
 	if config.DefaultConfig.Search.WriteEnabled {

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -39,7 +39,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 
 	tm := transaction.NewManager(kvStore)
 	t.Run("create_tenant", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -62,7 +62,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 	})
 
 	t.Run("create_multiple_tenants", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -94,7 +94,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 	t.Run("create_duplicate_tenant_error", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -113,7 +113,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 	t.Run("create_duplicate_tenant_id_error", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -145,7 +145,7 @@ func TestTenantManager_CreateTenant(t *testing.T) {
 
 	tm := transaction.NewManager(kvStore)
 	t.Run("create_tenant", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -166,7 +166,7 @@ func TestTenantManager_CreateTenant(t *testing.T) {
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 	t.Run("create_multiple_tenants", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -194,7 +194,7 @@ func TestTenantManager_CreateTenant(t *testing.T) {
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 	t.Run("create_duplicate_tenant_error", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -214,7 +214,7 @@ func TestTenantManager_CreateTenant(t *testing.T) {
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 	t.Run("create_duplicate_tenant_id_error", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -243,7 +243,7 @@ func TestTenantManager_CreateDatabases(t *testing.T) {
 
 	tm := transaction.NewManager(kvStore)
 	t.Run("create_databases", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -290,7 +290,7 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 
 	tm := transaction.NewManager(kvStore)
 	t.Run("create_collections", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -373,7 +373,7 @@ func TestTenantManager_DropCollection(t *testing.T) {
 
 	tm := transaction.NewManager(kvStore)
 	t.Run("drop_collection", func(t *testing.T) {
-		m := newTenantManager(&encoding.TestMDNameRegistry{
+		m := newTenantManager(kvStore, &encoding.TestMDNameRegistry{
 			ReserveSB:  "test_tenant_reserve",
 			EncodingSB: "test_tenant_encoding",
 			SchemaSB:   "test_tenant_schema",
@@ -433,7 +433,7 @@ func TestTenantManager_DropCollection(t *testing.T) {
 
 		tx, err = tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, tenant.DropCollection(ctx, tx, db2, "test_collection", &search.NoopStore{}))
+		require.NoError(t, tenant.DropCollection(ctx, tx, db2, "test_collection", &search.NoopStore{}, NewEncoder(m)))
 		require.NoError(t, tx.Commit(ctx))
 
 		_, err = tm.StartTx(ctx)

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -138,8 +138,8 @@ func (s *apiService) BeginTransaction(ctx context.Context, _ *api.BeginTransacti
 	}, nil
 }
 
-func (s *apiService) CommitTransaction(ctx context.Context, r *api.CommitTransactionRequest) (*api.CommitTransactionResponse, error) {
-	txCtx := api.GetTransaction(ctx, r)
+func (s *apiService) CommitTransaction(ctx context.Context, _ *api.CommitTransactionRequest) (*api.CommitTransactionResponse, error) {
+	txCtx := api.GetTransaction(ctx)
 	session := s.sessions.Get(txCtx.GetId())
 	if session == nil {
 		return nil, api.Errorf(api.Code_NOT_FOUND, "session not found")
@@ -154,8 +154,8 @@ func (s *apiService) CommitTransaction(ctx context.Context, r *api.CommitTransac
 	return &api.CommitTransactionResponse{}, nil
 }
 
-func (s *apiService) RollbackTransaction(ctx context.Context, r *api.RollbackTransactionRequest) (*api.RollbackTransactionResponse, error) {
-	txCtx := api.GetTransaction(ctx, r)
+func (s *apiService) RollbackTransaction(ctx context.Context, _ *api.RollbackTransactionRequest) (*api.RollbackTransactionResponse, error) {
+	txCtx := api.GetTransaction(ctx)
 	session := s.sessions.Get(txCtx.GetId())
 	if session == nil {
 		return nil, api.Errorf(api.Code_NOT_FOUND, "session not found")
@@ -171,7 +171,7 @@ func (s *apiService) RollbackTransaction(ctx context.Context, r *api.RollbackTra
 // Operations done individually not in actual batch
 func (s *apiService) Insert(ctx context.Context, r *api.InsertRequest) (*api.InsertResponse, error) {
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:       api.GetTransaction(ctx, r),
+		txCtx:       api.GetTransaction(ctx),
 		queryRunner: s.runnerFactory.GetInsertQueryRunner(r),
 	})
 	if err != nil {
@@ -189,7 +189,7 @@ func (s *apiService) Insert(ctx context.Context, r *api.InsertRequest) (*api.Ins
 
 func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.ReplaceResponse, error) {
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:       api.GetTransaction(ctx, r),
+		txCtx:       api.GetTransaction(ctx),
 		queryRunner: s.runnerFactory.GetReplaceQueryRunner(r),
 	})
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.R
 
 func (s *apiService) Update(ctx context.Context, r *api.UpdateRequest) (*api.UpdateResponse, error) {
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:       api.GetTransaction(ctx, r),
+		txCtx:       api.GetTransaction(ctx),
 		queryRunner: s.runnerFactory.GetUpdateQueryRunner(r),
 	})
 	if err != nil {
@@ -225,7 +225,7 @@ func (s *apiService) Update(ctx context.Context, r *api.UpdateRequest) (*api.Upd
 
 func (s *apiService) Delete(ctx context.Context, r *api.DeleteRequest) (*api.DeleteResponse, error) {
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:       api.GetTransaction(ctx, r),
+		txCtx:       api.GetTransaction(ctx),
 		queryRunner: s.runnerFactory.GetDeleteQueryRunner(r),
 	})
 	if err != nil {
@@ -242,7 +242,7 @@ func (s *apiService) Delete(ctx context.Context, r *api.DeleteRequest) (*api.Del
 
 func (s *apiService) Read(r *api.ReadRequest, stream api.Tigris_ReadServer) error {
 	_, err := s.sessions.Execute(stream.Context(), &ReqOptions{
-		txCtx:       api.GetTransaction(stream.Context(), r),
+		txCtx:       api.GetTransaction(stream.Context()),
 		queryRunner: s.runnerFactory.GetStreamingQueryRunner(r, stream),
 	})
 	if err != nil {
@@ -254,7 +254,7 @@ func (s *apiService) Read(r *api.ReadRequest, stream api.Tigris_ReadServer) erro
 
 func (s *apiService) Search(r *api.SearchRequest, stream api.Tigris_SearchServer) error {
 	_, err := s.sessions.Execute(stream.Context(), &ReqOptions{
-		txCtx:       api.GetTransaction(stream.Context(), r),
+		txCtx:       api.GetTransaction(stream.Context()),
 		queryRunner: s.runnerFactory.GetSearchQueryRunner(r, stream),
 	})
 	if err != nil {
@@ -269,7 +269,7 @@ func (s *apiService) CreateOrUpdateCollection(ctx context.Context, r *api.Create
 	runner.SetCreateOrUpdateCollectionReq(r)
 
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:          api.GetTransaction(ctx, r),
+		txCtx:          api.GetTransaction(ctx),
 		queryRunner:    runner,
 		metadataChange: true,
 	})
@@ -288,7 +288,7 @@ func (s *apiService) DropCollection(ctx context.Context, r *api.DropCollectionRe
 	runner.SetDropCollectionReq(r)
 
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:          api.GetTransaction(ctx, r),
+		txCtx:          api.GetTransaction(ctx),
 		queryRunner:    runner,
 		metadataChange: true,
 	})
@@ -307,7 +307,7 @@ func (s *apiService) ListCollections(ctx context.Context, r *api.ListCollections
 	runner.SetListCollectionReq(r)
 
 	resp, err := s.sessions.Execute(ctx, &ReqOptions{
-		txCtx:       api.GetTransaction(ctx, r),
+		txCtx:       api.GetTransaction(ctx),
 		queryRunner: runner,
 	})
 	if err != nil {

--- a/server/services/v1/query_runner.go
+++ b/server/services/v1/query_runner.go
@@ -713,7 +713,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 			tx.Context().StageDatabase(db)
 		}
 
-		if err = tenant.DropCollection(ctx, tx, db, runner.dropReq.GetCollection(), runner.searchStore); err != nil {
+		if err = tenant.DropCollection(ctx, tx, db, runner.dropReq.GetCollection(), runner.searchStore, runner.encoder); err != nil {
 			return nil, ctx, err
 		}
 
@@ -820,7 +820,7 @@ func (runner *DatabaseQueryRunner) SetDescribeDatabaseReq(describe *api.Describe
 
 func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, tenant *metadata.Tenant) (*Response, context.Context, error) {
 	if runner.drop != nil {
-		exist, err := tenant.DropDatabase(ctx, tx, runner.drop.GetDb(), runner.searchStore)
+		exist, err := tenant.DropDatabase(ctx, tx, runner.drop.GetDb(), runner.searchStore, runner.encoder)
 		if err != nil {
 			return nil, ctx, err
 		}

--- a/test/v1/server/admin_test.go
+++ b/test/v1/server/admin_test.go
@@ -38,7 +38,7 @@ func adminExpect(s httpexpect.LoggerReporter) *httpexpect.Expect {
 
 func (s *AdminSuite) TestListNamespaces() {
 	s.Run("list_namespaces", func() {
-		_ = createNamespace(s.T(), "namespace-a", 2)
+		_ = createNamespace(s.T(), "namespace-b", 3)
 		resp := listNamespaces(s.T())
 		namespaces := resp.Status(http.StatusOK).
 			JSON().
@@ -49,7 +49,7 @@ func (s *AdminSuite) TestListNamespaces() {
 		var found = false
 		for _, namespace := range namespaces {
 			if converted, ok := namespace.(map[string]interface{}); ok {
-				if converted["name"] == "namespace-a" {
+				if converted["name"] == "namespace-b" {
 					found = true
 				}
 			}


### PR DESCRIPTION
By default, drop collection will be only metadata change. Setting `fdb_delete` to true will be performing fdb delete(clearrange call). 