### PR TITLE
fix: Allow Searching and Faceting over nested fields

### DIFF
--- a/schema/collection.go
+++ b/schema/collection.go
@@ -108,6 +108,10 @@ func (d *DefaultCollection) GetIndexes() *Indexes {
 	return d.Indexes
 }
 
+func (d *DefaultCollection) GetQueryableFields() []*QueryableField {
+	return d.QueryableFields
+}
+
 // Validate expects an unmarshalled document which it will validate again the schema of this collection.
 func (d *DefaultCollection) Validate(document interface{}) error {
 	err := d.Validator.Validate(document)

--- a/server/services/v1/query_runner.go
+++ b/server/services/v1/query_runner.go
@@ -526,17 +526,17 @@ func (runner *SearchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		return nil, ctx, err
 	}
 
-	searchFields, err := runner.getSearchFields(collection.GetFields())
+	searchFields, err := runner.getSearchFields(collection.GetQueryableFields())
 	if err != nil {
 		return nil, ctx, err
 	}
 
-	facets, err := runner.getFacetFields(collection.GetFields())
+	facets, err := runner.getFacetFields(collection.GetQueryableFields())
 	if err != nil {
 		return nil, ctx, err
 	}
 
-	fieldSelection, err := runner.getFieldSelection(collection.GetFields())
+	fieldSelection, err := runner.getFieldSelection(collection.GetQueryableFields())
 	if err != nil {
 		return nil, ctx, err
 	}
@@ -624,7 +624,7 @@ func (runner *SearchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	return &Response{}, ctx, nil
 }
 
-func (runner *SearchQueryRunner) getSearchFields(collFields []*schema.Field) ([]string, error) {
+func (runner *SearchQueryRunner) getSearchFields(collFields []*schema.QueryableField) ([]string, error) {
 	var searchFields = runner.req.SearchFields
 	if len(searchFields) == 0 {
 		// this is to include all searchable fields if not present in the query
@@ -654,7 +654,7 @@ func (runner *SearchQueryRunner) getSearchFields(collFields []*schema.Field) ([]
 	return searchFields, nil
 }
 
-func (runner *SearchQueryRunner) getFacetFields(collFields []*schema.Field) (qsearch.Facets, error) {
+func (runner *SearchQueryRunner) getFacetFields(collFields []*schema.QueryableField) (qsearch.Facets, error) {
 	facets, err := qsearch.UnmarshalFacet(runner.req.Facet)
 	if err != nil {
 		return qsearch.Facets{}, err
@@ -665,6 +665,9 @@ func (runner *SearchQueryRunner) getFacetFields(collFields []*schema.Field) (qse
 		for _, cf := range collFields {
 			if ff.Name != cf.FieldName {
 				continue
+			}
+			if !cf.Faceted {
+				return qsearch.Facets{}, api.Errorf(api.Code_INVALID_ARGUMENT, "Faceting not enabled for `%s`", ff.Name)
 			}
 			if cf.DataType != schema.StringType {
 				return qsearch.Facets{}, api.Errorf(api.Code_INVALID_ARGUMENT, "Cannot generate facets for `%s`. Faceting is only supported for text fields", ff.Name)
@@ -680,7 +683,7 @@ func (runner *SearchQueryRunner) getFacetFields(collFields []*schema.Field) (qse
 	return facets, nil
 }
 
-func (runner *SearchQueryRunner) getFieldSelection(collFields []*schema.Field) (*read.FieldFactory, error) {
+func (runner *SearchQueryRunner) getFieldSelection(collFields []*schema.QueryableField) (*read.FieldFactory, error) {
 	var selectionFields []string
 
 	// Only one of include/exclude. Honor inclusion over exclusion

--- a/server/services/v1/query_runner_test.go
+++ b/server/services/v1/query_runner_test.go
@@ -8,16 +8,78 @@ import (
 	"github.com/tigrisdata/tigris/schema"
 )
 
-func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
-	t.Run("only include fields are provided", func(t *testing.T) {
-		collFields := []*schema.Field{
-			{FieldName: "field_1"},
-			{FieldName: "field_2"},
-		}
+func TestSearchQueryRunner_getFacetFields(t *testing.T) {
+	collFields := []*schema.QueryableField{
+		{FieldName: "field_1", Faceted: true, DataType: schema.StringType},
+		{FieldName: "parent.field_2", Faceted: true, DataType: schema.StringType},
+		{FieldName: "field_3", Faceted: false, DataType: schema.StringType},
+		{FieldName: "field_4", Faceted: true, DataType: schema.Int32Type},
+	}
+	runner := &SearchQueryRunner{req: &api.SearchRequest{}}
 
+	t.Run("no facet field param in input", func(t *testing.T) {
+		runner.req.Facet = nil
+		facets, err := runner.getFacetFields(collFields)
+		assert.NoError(t, err)
+		assert.NotNil(t, facets)
+		assert.Empty(t, facets.Fields)
+	})
+
+	t.Run("no queryable field in collection", func(t *testing.T) {
+		var collFields []*schema.QueryableField
+		runner.req.Facet = []byte(`{"field_1":{"size":10}}`)
+		facets, err := runner.getFacetFields(collFields)
+		assert.ErrorContains(t, err, "`field_1` is not a schema field")
+		assert.NotNil(t, facets)
+		assert.Empty(t, facets.Fields)
+	})
+
+	t.Run("requested facet field is not faceted in collection", func(t *testing.T) {
+		runner.req.Facet = []byte(`{"parent.field_2":{"size":10},"field_3":{"size":10}}`)
+		facets, err := runner.getFacetFields(collFields)
+		assert.ErrorContains(t, err, "Faceting not enabled for `field_3`")
+		assert.NotNil(t, facets)
+		assert.Empty(t, facets.Fields)
+	})
+
+	t.Run("requested facet fields are not in collection", func(t *testing.T) {
+		runner.req.Facet = []byte(`{"field_1":{"size":10},"field_5":{"size":10}}`)
+		facets, err := runner.getFacetFields(collFields)
+		assert.ErrorContains(t, err, "`field_5` is not a schema field")
+		assert.NotNil(t, facets)
+		assert.Empty(t, facets.Fields)
+	})
+
+	t.Run("requested facet fields are not of String datatype", func(t *testing.T) {
+		runner.req.Facet = []byte(`{"field_1":{"size":10},"field_4":{"size":10}}`)
+		facets, err := runner.getFacetFields(collFields)
+		assert.ErrorContains(t, err, "Cannot generate facets for `field_4`")
+		assert.NotNil(t, facets)
+		assert.Empty(t, facets.Fields)
+	})
+
+	t.Run("valid facet fields requested", func(t *testing.T) {
+		runner.req.Facet = []byte(`{"field_1":{"size":10},"parent.field_2":{"size":10}}`)
+		facets, err := runner.getFacetFields(collFields)
+		assert.NoError(t, err)
+		assert.Len(t, facets.Fields, 2)
+		for _, ff := range facets.Fields {
+			assert.Contains(t, []string{"field_1", "parent.field_2"}, ff.Name)
+			assert.Equal(t, ff.Size, 10)
+		}
+	})
+}
+
+func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
+	collFields := []*schema.QueryableField{
+		{FieldName: "field_1"},
+		{FieldName: "parent.field_2"},
+	}
+
+	t.Run("only include fields are provided", func(t *testing.T) {
 		runner := &SearchQueryRunner{
 			req: &api.SearchRequest{
-				IncludeFields: []string{"field_1", "field_2"},
+				IncludeFields: []string{"field_1", "parent.field_2"},
 			},
 		}
 
@@ -28,18 +90,13 @@ func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 		assert.Empty(t, factory.Exclude)
 		assert.Len(t, factory.Include, 2)
 		assert.Contains(t, factory.Include, "field_1")
-		assert.Contains(t, factory.Include, "field_2")
+		assert.Contains(t, factory.Include, "parent.field_2")
 	})
 
 	t.Run("only exclude fields are provided", func(t *testing.T) {
-		collFields := []*schema.Field{
-			{FieldName: "field_1"},
-			{FieldName: "field_2"},
-		}
-
 		runner := &SearchQueryRunner{
 			req: &api.SearchRequest{
-				ExcludeFields: []string{"field_1", "field_2"},
+				ExcludeFields: []string{"field_1", "parent.field_2"},
 			},
 		}
 
@@ -50,14 +107,10 @@ func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 		assert.Empty(t, factory.Include)
 		assert.Len(t, factory.Exclude, 2)
 		assert.Contains(t, factory.Exclude, "field_1")
-		assert.Contains(t, factory.Exclude, "field_2")
+		assert.Contains(t, factory.Exclude, "parent.field_2")
 	})
 
 	t.Run("no fields to include or exclude", func(t *testing.T) {
-		collFields := []*schema.Field{
-			{FieldName: "field_1"},
-			{FieldName: "field_2"},
-		}
 		runner := &SearchQueryRunner{req: &api.SearchRequest{}}
 
 		factory, err := runner.getFieldSelection(collFields)
@@ -67,7 +120,7 @@ func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 	})
 
 	t.Run("no schema fields are defined", func(t *testing.T) {
-		var collFields []*schema.Field
+		var collFields []*schema.QueryableField
 		runner := &SearchQueryRunner{req: &api.SearchRequest{}}
 
 		factory, err := runner.getFieldSelection(collFields)
@@ -77,14 +130,9 @@ func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 	})
 
 	t.Run("selection fields are not in schema", func(t *testing.T) {
-		collFields := []*schema.Field{
-			{FieldName: "field_1"},
-			{FieldName: "field_2"},
-		}
-
 		runner := &SearchQueryRunner{
 			req: &api.SearchRequest{
-				ExcludeFields: []string{"field_2", "field_3"},
+				ExcludeFields: []string{"field_1", "field_3"},
 			},
 		}
 


### PR DESCRIPTION
Validating search request against `queryable` fields instead of schema fields.