### PR TITLE
fix: fix datadog traces

### DIFF
--- a/server/metrics/tracing.go
+++ b/server/metrics/tracing.go
@@ -24,6 +24,7 @@ import (
 const (
 	KvTracingServiceName        = "kv"
 	TxManagerTracingServiceName = "txmanager"
+	TraceServiceName            = "tigris.grpc.server"
 )
 
 type SpanMeta struct {
@@ -60,7 +61,7 @@ func (s *SpanMeta) StartTracing(ctx context.Context, childOnly bool) (context.Co
 		// There is no parent span, no need to start tracing here
 		return ctx, func() {}
 	}
-	span := tracer.StartSpan(s.resourceName, spanOpts...)
+	span := tracer.StartSpan(TraceServiceName, spanOpts...)
 	for k, v := range s.tags {
 		span.SetTag(k, v)
 	}

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -117,7 +117,6 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 	}
 
 	unaryInterceptors = append(unaryInterceptors, []grpc.UnaryServerInterceptor{
-		//grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(util.Service)),
 		pprofUnaryServerInterceptor(),
 		quotaUnaryServerInterceptor(),
 		grpc_logging.UnaryServerInterceptor(grpc_zerolog.InterceptorLogger(sampledTaggedLogger)),


### PR DESCRIPTION
Fix datadog traces, all methods are visible in datadog traces under the same operation name.