### PR TITLE
fix: fixing encoding issues

### DIFF
--- a/lib/json/encoder.go
+++ b/lib/json/encoder.go
@@ -12,16 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package uuid
+package json
 
-import uuid2 "github.com/google/uuid"
+import (
+	"bytes"
 
-var NullUUID = uuid2.UUID{}
+	jsoniter "github.com/json-iterator/go"
+)
 
-func NewUUIDAsString() string {
-	return uuid2.New().String()
+func Encode(data map[string]any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := jsoniter.NewEncoder(&buffer)
+	err := encoder.Encode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
 }
 
-func New() uuid2.UUID {
-	return uuid2.New()
+func Decode(data []byte) (map[string]any, error) {
+	var decoded map[string]any
+
+	decoder := jsoniter.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+
+	return decoded, nil
 }

--- a/server/services/v1/search_indexer.go
+++ b/server/services/v1/search_indexer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/lib/json"
 	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/transaction"
@@ -155,7 +156,7 @@ func CreateSearchKey(table []byte, fdbKey []byte) (string, error) {
 		case string:
 			value = t
 		case []byte:
-			value = string(t)
+			value = base64.StdEncoding.EncodeToString(t)
 		}
 		return value, nil
 	} else {
@@ -165,10 +166,9 @@ func CreateSearchKey(table []byte, fdbKey []byte) (string, error) {
 }
 
 func PackSearchFields(data *internal.TableData, collection *schema.DefaultCollection, id string) ([]byte, error) {
-	var err error
 	// better to decode it and then update the JSON
-	var decData map[string]any
-	if err = jsoniter.Unmarshal(data.RawData, &decData); err != nil {
+	decData, err := json.Decode(data.RawData)
+	if err != nil {
 		return nil, err
 	}
 
@@ -195,7 +195,12 @@ func PackSearchFields(data *internal.TableData, collection *schema.DefaultCollec
 		decData[schema.ReservedFields[schema.UpdatedAt]] = data.UpdatedAt.UnixNano()
 	}
 
-	return jsoniter.Marshal(decData)
+	encoded, err := json.Encode(decData)
+	if err != nil {
+		return nil, err
+	}
+
+	return encoded, nil
 }
 
 func UnpackSearchFields(doc map[string]interface{}, collection *schema.DefaultCollection) (string, *internal.TableData, map[string]interface{}, error) {

--- a/server/services/v1/search_reader.go
+++ b/server/services/v1/search_reader.go
@@ -17,8 +17,8 @@ package v1
 import (
 	"context"
 
-	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/lib/json"
 	"github.com/tigrisdata/tigris/query/filter"
 	"github.com/tigrisdata/tigris/query/read"
 	qsearch "github.com/tigrisdata/tigris/query/search"
@@ -94,10 +94,8 @@ func (p *page) readRow(row *Row) bool {
 		}
 
 		var rawData []byte
-
 		// marshal the doc as bytes
-		rawData, p.err = jsoniter.Marshal(doc)
-		if p.err != nil {
+		if rawData, p.err = json.Encode(doc); p.err != nil {
 			return false
 		}
 


### PR DESCRIPTION
- Use decoder instead of JSON unmarshaler to avoid default float conversion
- Use base64 encoding for bytes field during indexing. 