### PR TITLE
feat: Size metrics for namespace, database and collection

### DIFF
--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -49,7 +49,7 @@ func GetFdbErrorTags(ctx context.Context, reqMethodName string, code string) map
 	return addTigrisTenantToTags(ctx, getFdbReqErrorTags(reqMethodName, code))
 }
 
-func InitializeFdbScopes() {
+func initializeFdbScopes() {
 	FdbOkRequests = FdbMetrics.SubScope("count")
 	FdbErrorRequests = FdbMetrics.SubScope("count")
 	FdbRespTime = FdbMetrics.SubScope("resptime")

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -27,19 +27,13 @@ import (
 )
 
 var (
-	root     tally.Scope
-	Reporter promreporter.Reporter
-	// GRPC and HTTP related metric scopes
-	Requests         tally.Scope
-	OkRequests       tally.Scope
-	ErrorRequests    tally.Scope
-	RequestsRespTime tally.Scope
-	// Fdb related metric scopes
-	FdbMetrics tally.Scope
-	// Search related metrics scopes
-	SearchMetrics tally.Scope
-	// Session related metris scopes
+	root           tally.Scope
+	Reporter       promreporter.Reporter
+	Requests       tally.Scope
+	FdbMetrics     tally.Scope
+	SearchMetrics  tally.Scope
 	SessionMetrics tally.Scope
+	SizeMetrics    tally.Scope
 )
 
 func GetGlobalTags() map[string]string {
@@ -67,16 +61,19 @@ func InitializeMetrics() io.Closer {
 	if config.DefaultConfig.Tracing.Enabled {
 		// Request level metrics (HTTP and GRPC)
 		Requests = root.SubScope("requests")
-		InitializeRequestScopes()
+		initializeRequestScopes()
 		// FDB level metrics
 		FdbMetrics = root.SubScope("fdb")
-		InitializeFdbScopes()
+		initializeFdbScopes()
 		// Search level metrics
 		SearchMetrics = root.SubScope("search")
-		InitializeSearchScopes()
+		initializeSearchScopes()
 		// Session level metrics
 		SessionMetrics = root.SubScope("session")
-		InitializeSessionScopes()
+		initializeSessionScopes()
+		// Size metrics
+		SizeMetrics = root.SubScope("size")
+		initializeSizeScopes()
 	}
 	return closer
 }

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -21,12 +21,19 @@ import (
 
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/request"
+	"github.com/uber-go/tally"
 	"google.golang.org/grpc"
 )
 
 const (
 	SystemTigrisTenantName = "system"
 	UnknownValue           = "unknown"
+)
+
+var (
+	OkRequests       tally.Scope
+	ErrorRequests    tally.Scope
+	RequestsRespTime tally.Scope
 )
 
 type RequestEndpointMetadata struct {
@@ -108,7 +115,7 @@ func GetGrpcEndPointMetadataFromFullMethod(ctx context.Context, fullMethod strin
 	return newRequestEndpointMetadata(ctx, svcName, methodInfo)
 }
 
-func InitializeRequestScopes() {
+func initializeRequestScopes() {
 	OkRequests = Requests.SubScope("count")
 	ErrorRequests = Requests.SubScope("count")
 	RequestsRespTime = Requests.SubScope("resptime")

--- a/server/metrics/search.go
+++ b/server/metrics/search.go
@@ -26,7 +26,7 @@ var (
 	SearchRespTime      tally.Scope
 )
 
-func InitializeSearchScopes() {
+func initializeSearchScopes() {
 	SearchOkRequests = SearchMetrics.SubScope("count")
 	SearchErrorRequests = SearchMetrics.SubScope("count")
 	SearchRespTime = SearchMetrics.SubScope("resptime")

--- a/server/metrics/session.go
+++ b/server/metrics/session.go
@@ -36,7 +36,7 @@ func GetSessionTags(ctx context.Context, sessionMethodName string) map[string]st
 	return addTigrisTenantToTags(ctx, getSessionTags(sessionMethodName))
 }
 
-func InitializeSessionScopes() {
+func initializeSessionScopes() {
 	SessionOkRequests = SessionMetrics.SubScope("count")
 	SessionErrorRequests = SessionMetrics.SubScope("count")
 	SessionRespTime = SessionMetrics.SubScope("resptime")

--- a/server/metrics/size.go
+++ b/server/metrics/size.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/uber-go/tally"
+)
+
+var (
+	NamespaceSize  tally.Scope
+	DbSize         tally.Scope
+	CollectionSize tally.Scope
+)
+
+func initializeSizeScopes() {
+	NamespaceSize = SizeMetrics.SubScope("namespace")
+	DbSize = SizeMetrics.SubScope("db")
+	CollectionSize = SizeMetrics.SubScope("collection")
+}
+
+func getNamespaceSizeTags(namespaceName string) map[string]string {
+	return map[string]string{
+		"tigris_tenant": namespaceName,
+	}
+}
+
+func getDbSizeTags(namespaceName string, dbName string) map[string]string {
+	return map[string]string{
+		"tigris_tenant": namespaceName,
+		"db":            dbName,
+	}
+}
+
+func getCollectionSizeTags(namespaceName string, dbName string, collectionName string) map[string]string {
+	return map[string]string{
+		"tigris_tenant": namespaceName,
+		"db":            dbName,
+		"collection":    collectionName,
+	}
+}
+
+func UpdateNameSpaceSizeMetrics(namespaceName string, size int64) {
+	if config.DefaultConfig.Tracing.Enabled {
+		NamespaceSize.Tagged(getNamespaceSizeTags(namespaceName)).Gauge("bytes").Update(float64(size))
+	}
+}
+
+func UpdateDbSizeMetrics(namespaceName string, dbName string, size int64) {
+	if config.DefaultConfig.Tracing.Enabled {
+		DbSize.Tagged(getDbSizeTags(namespaceName, dbName)).Gauge("bytes").Update(float64(size))
+	}
+}
+
+func UpdateCollectionSizeMetrics(namespaceName string, dbName string, collectionName string, size int64) {
+	if config.DefaultConfig.Tracing.Enabled {
+		CollectionSize.Tagged(getCollectionSizeTags(namespaceName, dbName, collectionName)).Gauge("bytes").Update(float64(size))
+	}
+}

--- a/server/metrics/size_test.go
+++ b/server/metrics/size_test.go
@@ -15,36 +15,29 @@
 package metrics
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tigrisdata/tigris/server/config"
-	"github.com/uber-go/tally"
 )
 
-func TestSessionMetrics(t *testing.T) {
+func TestSizeMetrics(t *testing.T) {
+	var testSize int64 = 1000
+	var testNamespace = "test_namespace"
+	var testDb = "test_db"
+	var testCollection = "test_collection"
+
 	config.DefaultConfig.Tracing.Enabled = true
 	InitializeMetrics()
 
-	ctx := context.Background()
-
-	testTags := []map[string]string{
-		GetSessionTags(ctx, "Create"),
-		GetSessionTags(ctx, "Get"),
-		GetSessionTags(ctx, "Remove"),
-		GetSessionTags(ctx, "Execute"),
-		GetSessionTags(ctx, "executeWithRetry"),
-	}
-
-	t.Run("Test Session counters", func(t *testing.T) {
-		for _, tags := range testTags {
-			SessionOkRequests.Tagged(tags).Counter("ok").Inc(1)
-			SessionErrorRequests.Tagged(tags).Counter("error").Inc(1)
-		}
+	t.Run("Update namespace size metrics", func(t *testing.T) {
+		UpdateNameSpaceSizeMetrics(testNamespace, testSize)
 	})
 
-	t.Run("Test Session histograms", func(t *testing.T) {
-		tags := GetSessionTags(ctx, "Create")
-		defer SessionRespTime.Tagged(tags).Histogram("histogram", tally.DefaultBuckets).Start().Stop()
+	t.Run("Update database size metrics", func(t *testing.T) {
+		UpdateDbSizeMetrics(testNamespace, testDb, testSize)
+	})
+
+	t.Run("Update collection size metrics", func(t *testing.T) {
+		UpdateCollectionSizeMetrics(testNamespace, testDb, testCollection, testSize)
 	})
 }

--- a/server/metrics/tenant.go
+++ b/server/metrics/tenant.go
@@ -30,3 +30,11 @@ func addTigrisTenantToTags(ctx context.Context, tags map[string]string) map[stri
 	}
 	return tags
 }
+
+func GetNamespace(ctx context.Context) string {
+	namespace, err := request.GetNamespace(ctx)
+	if err != nil {
+		namespace = "unknown"
+	}
+	return namespace
+}

--- a/server/quota/quota.go
+++ b/server/quota/quota.go
@@ -8,6 +8,7 @@ import (
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
@@ -94,6 +95,7 @@ func (m *Manager) checkStorageSize(ctx context.Context, namespace string, s *Sta
 	sz := s.Size.Load()
 
 	if time.Now().Unix() < s.SizeUpdateAt.Load()+sizeLimitUpdateInterval {
+		metrics.UpdateNameSpaceSizeMetrics(namespace, sz)
 		if sz+int64(size) >= m.cfg.DataSizeLimit {
 			return ErrStorageSizeExceeded
 		}

--- a/server/services/v1/query_runner.go
+++ b/server/services/v1/query_runner.go
@@ -17,6 +17,7 @@ package v1
 import (
 	"bytes"
 	"context"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"math"
 	"time"
 
@@ -934,6 +935,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		if err != nil {
 			return nil, ctx, err
 		}
+		namespace := metrics.GetNamespace(ctx)
 
 		coll, err := runner.GetCollections(db, runner.describeReq.GetCollection())
 		if err != nil {
@@ -944,6 +946,8 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		if err != nil {
 			return nil, ctx, err
 		}
+
+		metrics.UpdateCollectionSizeMetrics(namespace, db.Name(), coll.GetName(), size)
 
 		return &Response{
 			Response: &api.DescribeCollectionResponse{
@@ -1027,6 +1031,7 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		if err != nil {
 			return nil, ctx, err
 		}
+		namespace := metrics.GetNamespace(ctx)
 
 		collectionList := db.ListCollection()
 
@@ -1036,6 +1041,9 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 			if err != nil {
 				return nil, ctx, err
 			}
+
+			metrics.UpdateCollectionSizeMetrics(namespace, db.Name(), c.GetName(), size)
+
 			collections[i] = &api.CollectionDescription{
 				Collection: c.GetName(),
 				Metadata:   &api.CollectionMetadata{},
@@ -1048,6 +1056,8 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		if err != nil {
 			return nil, ctx, err
 		}
+
+		metrics.UpdateDbSizeMetrics(namespace, db.Name(), size)
 
 		return &Response{
 			Response: &api.DescribeDatabaseResponse{


### PR DESCRIPTION
* Namespace level metrics are updated on quota calculation refresh, they are not appearing if quotas are disabled.
* Database level metrics are updated on DescribeDatabase requests.
* Collections level metrics are updated on DescribeCollection requests (metrics are updated for that single collection) and on DescribeDatabase requests (metrics are updated for all collections in the database). 