### PR TITLE
feat: Fallback to full table scan if indexing store is not available/disabled

### DIFF
--- a/keys/key.go
+++ b/keys/key.go
@@ -14,7 +14,15 @@
 
 package keys
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
+	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
+	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
+)
 
 // Key is an interface that provides an encoded key which will be used for storing Key, Value in FDB. The Key has two
 // elements, the first set of bytes is the encoded table name and the remaining is the actual index values.
@@ -30,6 +38,12 @@ type Key interface {
 	// key index or some other user defined index. Essentially to encode key for a given row. Some other internal packages
 	// may use this as simply to form a key without any significance of index identifier.
 	IndexParts() []interface{}
+	// SerializeToBytes follows the ordering of how the Key is persisted in database so to compare a Key call this method
+	// get bytes and compare it with raw bytes stored in database.
+	SerializeToBytes() []byte
+	// CompareBytes compares the serialized form of keys. It returns 0 if p == input, -1 if p < input, and +1 if p > input.
+	// A nil argument is equivalent to an empty slice.
+	CompareBytes(input []byte) int
 }
 
 type tableKey struct {
@@ -55,4 +69,31 @@ func (p *tableKey) IndexParts() []interface{} {
 
 func (p *tableKey) String() string {
 	return fmt.Sprintf("table:%v, indexKeyAndValues:%v", string(p.table), p.indexParts)
+}
+
+// SerializeToBytes follows the ordering of how the Key is persisted in database so to compare a Key call this method
+// get bytes and compare it with raw bytes stored in database
+func (p *tableKey) SerializeToBytes() []byte {
+	if len(p.indexParts) == 0 {
+		return p.table
+	}
+
+	sb := subspace.FromBytes(p.table)
+	return sb.Pack(*(*tuple.Tuple)(unsafe.Pointer(&p.indexParts)))
+}
+
+// CompareBytes compares the serialized form of keys. It returns 0 if p == input, -1 if p < input, and +1 if p > input.
+// A nil argument is equivalent to an empty slice.
+func (p *tableKey) CompareBytes(input []byte) int {
+	return bytes.Compare(p.SerializeToBytes(), input)
+}
+
+func FromBinary(table []byte, fdbKey []byte) (Key, error) {
+	sb := subspace.FromBytes(table)
+	tp, err := sb.Unpack(fdb.Key(fdbKey))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewKey(table, *(*[]interface{})(unsafe.Pointer(&tp))...), nil
 }

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -27,11 +27,11 @@ import (
 )
 
 var (
-	filterAll   = []byte(`{}`)
+	filterNone  = []byte(`{}`)
 	emptyFilter = &WrappedFilter{Filter: &EmptyFilter{}}
 )
 
-// A Filter represents a query filter that can have any multiple conditions, logical filtering, nested conditions, etc
+// A Filter represents a query filter that can have any multiple conditions, logical filtering, nested conditions, etc.
 // On a high level, a filter from a user query will map like this
 //    {Selector} --> Filter with a single condition
 //    {Selector, Selector, LogicalOperator} --> Filter with two condition and a logicalOperator
@@ -59,7 +59,7 @@ func (f *EmptyFilter) MatchesDoc(_ map[string]interface{}) bool { return true }
 func (f *EmptyFilter) ToSearchFilter() []string                 { return nil }
 
 type WrappedFilter struct {
-	Filter Filter
+	Filter
 }
 
 func NewWrappedFilter(filters []Filter) *WrappedFilter {
@@ -80,8 +80,8 @@ func NewWrappedFilter(filters []Filter) *WrappedFilter {
 	}
 }
 
-func All(reqFilter []byte) bool {
-	return len(reqFilter) == 0 || bytes.Equal(reqFilter, filterAll)
+func None(reqFilter []byte) bool {
+	return len(reqFilter) == 0 || bytes.Equal(reqFilter, filterNone)
 }
 
 type Factory struct {

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -180,3 +180,7 @@ type QuotaConfig struct {
 	LimitUpdateInterval       int64 `mapstructure:"limit_update_interval" yaml:"limit_update_interval" json:"limit_update_interval"`
 	TenantSizeRefreshInterval int64 `mapstructure:"tenant_size_refresh_interval" yaml:"tenant_size_refresh_interval" json:"tenant_size_refresh_interval"`
 }
+
+func IsIndexingStoreReadEnabled() bool {
+	return DefaultConfig.Search.WriteEnabled && DefaultConfig.Search.ReadEnabled
+}

--- a/server/services/v1/request.go
+++ b/server/services/v1/request.go
@@ -44,7 +44,6 @@ type SubscribeStreaming interface {
 // ReqOptions are options used by queryLifecycle to execute a query
 type ReqOptions struct {
 	txCtx              *api.TransactionCtx
-	queryRunner        QueryRunner
 	metadataChange     bool
 	instantVerTracking bool
 }

--- a/server/services/v1/row_reader.go
+++ b/server/services/v1/row_reader.go
@@ -17,9 +17,9 @@ package v1
 import (
 	"context"
 
-	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/query/filter"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
 	ulog "github.com/tigrisdata/tigris/util/log"
@@ -30,69 +30,179 @@ type Row struct {
 	Data *internal.TableData
 }
 
-type RowReader interface {
-	Next(context.Context, *Row) bool
-	Err() error
+// Iterator is to iterate over a single collection.
+type Iterator interface {
+	// Next fills the next element in the iteration. Returns true if the Iterator has more element.
+	Next(*Row) bool
+	// Interrupted returns an error if iterator encounters any error.
+	Interrupted() error
 }
 
-type DatabaseRowReader struct {
-	idx        int
-	err        error
-	keys       []keys.Key
-	tx         transaction.Tx
-	ctx        context.Context
-	kvIterator kv.Iterator
+type ScanIterator struct {
+	it  kv.Iterator
+	err error
 }
 
-func MakeDatabaseRowReader(ctx context.Context, tx transaction.Tx, keys []keys.Key) (*DatabaseRowReader, error) {
-	d := &DatabaseRowReader{
-		idx:  0,
-		tx:   tx,
-		ctx:  ctx,
-		keys: keys,
-	}
-	if d.idx >= len(d.keys) {
-		return nil, api.Errorf(api.Code_INVALID_ARGUMENT, "no keys to read")
-	}
-	if d.kvIterator, d.err = d.readNextKey(d.ctx, d.keys[d.idx]); d.err != nil {
-		return nil, d.err
+func NewScanIterator(ctx context.Context, tx transaction.Tx, from keys.Key) (*ScanIterator, error) {
+	it, err := tx.ReadRange(ctx, from, nil, false)
+	if ulog.E(err) {
+		return nil, err
 	}
 
-	return d, nil
+	return &ScanIterator{
+		it: it,
+	}, nil
 }
 
-func (d *DatabaseRowReader) Next(_ context.Context, row *Row) bool {
-	if d.err != nil {
+func (s *ScanIterator) Next(row *Row) bool {
+	if s.err != nil {
+		return false
+	}
+
+	var keyValue kv.KeyValue
+	if s.it.Next(&keyValue) {
+		row.Key = keyValue.FDBKey
+		row.Data = keyValue.Data
+		return true
+	}
+	s.err = s.it.Err()
+
+	return false
+}
+
+func (s *ScanIterator) Interrupted() error { return s.err }
+
+type KeyIterator struct {
+	it    kv.Iterator
+	tx    transaction.Tx
+	ctx   context.Context
+	keys  []keys.Key
+	err   error
+	keyId int
+}
+
+func NewKeyIterator(ctx context.Context, tx transaction.Tx, keys []keys.Key) (*KeyIterator, error) {
+	keyId := 0
+	it, err := tx.Read(ctx, keys[keyId])
+	if ulog.E(err) {
+		return nil, err
+	}
+
+	return &KeyIterator{
+		tx:    tx,
+		it:    it,
+		ctx:   ctx,
+		keys:  keys,
+		keyId: keyId,
+	}, nil
+}
+
+func (k *KeyIterator) Next(row *Row) bool {
+	if k.err != nil {
 		return false
 	}
 
 	for {
 		var keyValue kv.KeyValue
-		if d.kvIterator.Next(&keyValue) {
+		if k.it.Next(&keyValue) {
 			row.Key = keyValue.FDBKey
 			row.Data = keyValue.Data
 			return true
 		}
-		if d.kvIterator.Err() != nil {
-			d.err = d.kvIterator.Err()
+
+		if k.err = k.it.Err(); k.err != nil {
 			return false
 		}
 
-		d.idx++
-		if d.idx == len(d.keys) {
+		k.keyId++
+		if k.keyId == len(k.keys) {
 			return false
 		}
 
-		d.kvIterator, d.err = d.readNextKey(d.ctx, d.keys[d.idx])
+		k.it, k.err = k.tx.Read(k.ctx, k.keys[k.keyId])
 	}
 }
 
-func (d *DatabaseRowReader) readNextKey(ctx context.Context, key keys.Key) (kv.Iterator, error) {
-	it, err := d.tx.Read(ctx, key)
-	if ulog.E(err) {
-		return nil, err
-	}
-	return it, nil
+func (k *KeyIterator) Interrupted() error { return k.err }
+
+// FilterIterator only returns elements that match the given predicate.
+type FilterIterator struct {
+	iterator Iterator
+	filter   *filter.WrappedFilter
 }
 
-func (d *DatabaseRowReader) Err() error { return d.err }
+func NewFilterIterator(iterator Iterator, filter *filter.WrappedFilter) *FilterIterator {
+	return &FilterIterator{
+		iterator: iterator,
+		filter:   filter,
+	}
+}
+
+func (it *FilterIterator) Interrupted() error {
+	return it.iterator.Interrupted()
+}
+
+// Next advances the iterator till the matching row found and then only fill the row object. In contrast
+// to Iterator, filterable allows filtering during iterating of document. Underneath it is just using Iterator
+// to iterate over rows to apply filter.
+func (it *FilterIterator) Next(row *Row) bool {
+	for {
+		if !it.iterator.Next(row) {
+			return false
+		}
+
+		if it.advanceToMatchingRow(row) {
+			return true
+		}
+	}
+}
+
+func (it *FilterIterator) advanceToMatchingRow(row *Row) bool {
+	return it.filter.Matches(row.Data.RawData)
+}
+
+type DatabaseReader struct {
+	tx  transaction.Tx
+	ctx context.Context
+}
+
+func NewDatabaseReader(ctx context.Context, tx transaction.Tx) *DatabaseReader {
+	return &DatabaseReader{
+		ctx: ctx,
+		tx:  tx,
+	}
+}
+
+// ScanTable returns an iterator for all the rows in this table.
+func (reader *DatabaseReader) ScanTable(table []byte) (Iterator, error) {
+	return NewKeyIterator(reader.ctx, reader.tx, []keys.Key{keys.NewKey(table)})
+}
+
+// ScanIterator only returns an iterator that has elements starting from.
+func (reader *DatabaseReader) ScanIterator(from keys.Key) (Iterator, error) {
+	return NewScanIterator(reader.ctx, reader.tx, from)
+}
+
+// StrictlyKeysFrom is an optimized version that takes input keys and filter out keys that are lower than the "from".
+func (reader *DatabaseReader) StrictlyKeysFrom(ikeys []keys.Key, from []byte) (Iterator, error) {
+	// this means we have returned data to the user, and now we need to stream again but only from the last offset
+	// therefore we need to prune keys that are not needed, i.e. lower by this offset
+	var toReadKeys []keys.Key
+	for i, k := range ikeys {
+		if k.CompareBytes(from) > 0 {
+			toReadKeys = append(toReadKeys, ikeys[i])
+		}
+	}
+
+	return reader.KeyIterator(toReadKeys)
+}
+
+// KeyIterator returns an iterator that iterates on a key or a set of keys.
+func (reader *DatabaseReader) KeyIterator(ikeys []keys.Key) (Iterator, error) {
+	return NewKeyIterator(reader.ctx, reader.tx, ikeys)
+}
+
+// FilteredRead returns an iterator that implicitly will be doing filtering on the iterator.
+func (reader *DatabaseReader) FilteredRead(iterator Iterator, filter *filter.WrappedFilter) (Iterator, error) {
+	return NewFilterIterator(iterator, filter), nil
+}

--- a/server/services/v1/sessions.go
+++ b/server/services/v1/sessions.go
@@ -40,8 +40,9 @@ type Session interface {
 	Create(ctx context.Context, trackVerInOwnTxn bool, instantVerTracking bool, track bool) (*QuerySession, error)
 	Get(ctx context.Context) (*QuerySession, error)
 	Remove(ctx context.Context) error
-	Execute(ctx context.Context, req *ReqOptions) (*Response, error)
-	executeWithRetry(ctx context.Context, req *ReqOptions) (resp *Response, err error)
+	ReadOnlyExecute(ctx context.Context, runner ReadOnlyQueryRunner, req *ReqOptions) (*Response, error)
+	Execute(ctx context.Context, runner QueryRunner, req *ReqOptions) (*Response, error)
+	executeWithRetry(ctx context.Context, runner QueryRunner, req *ReqOptions) (resp *Response, err error)
 }
 
 type SessionManager struct {
@@ -91,17 +92,25 @@ func (m SessionManagerWithMetrics) Remove(ctx context.Context) (err error) {
 	return m.s.Remove(ctx)
 }
 
-func (m SessionManagerWithMetrics) Execute(ctx context.Context, req *ReqOptions) (resp *Response, err error) {
-	m.measure(ctx, "Execute", func(ctx context.Context) error {
-		resp, err = m.s.Execute(ctx, req)
+func (m SessionManagerWithMetrics) ReadOnlyExecute(ctx context.Context, runner ReadOnlyQueryRunner, req *ReqOptions) (resp *Response, err error) {
+	m.measure(ctx, "ReadOnlyExecute", func(ctx context.Context) error {
+		resp, err = m.s.ReadOnlyExecute(ctx, runner, req)
 		return err
 	})
 	return
 }
 
-func (m SessionManagerWithMetrics) executeWithRetry(ctx context.Context, req *ReqOptions) (resp *Response, err error) {
+func (m SessionManagerWithMetrics) Execute(ctx context.Context, runner QueryRunner, req *ReqOptions) (resp *Response, err error) {
+	m.measure(ctx, "Execute", func(ctx context.Context) error {
+		resp, err = m.s.Execute(ctx, runner, req)
+		return err
+	})
+	return
+}
+
+func (m SessionManagerWithMetrics) executeWithRetry(ctx context.Context, runner QueryRunner, req *ReqOptions) (resp *Response, err error) {
 	m.measure(ctx, "executeWithRetry", func(ctx context.Context) error {
-		resp, err = m.s.executeWithRetry(ctx, req)
+		resp, err = m.s.executeWithRetry(ctx, runner, req)
 		return err
 	})
 	return
@@ -129,6 +138,34 @@ func NewSessionManagerWithMetrics(txMgr *transaction.Manager, tenantMgr *metadat
 			tenantTracker: tenantTracker,
 		},
 	}
+}
+
+func (sessMgr *SessionManager) CreateReadOnlySession(ctx context.Context) (*ReadOnlySession, error) {
+	namespaceForThisSession, err := request.GetNamespace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tenant, err := sessMgr.tenantMgr.GetTenant(ctx, namespaceForThisSession, sessMgr.txMgr)
+	if err != nil {
+		log.Warn().Err(err).Msgf("Could not find tenant, this must not happen with right authn/authz configured")
+		return nil, api.Errorf(api.Code_NOT_FOUND, "Tenant %s not found", namespaceForThisSession)
+	}
+
+	tx, err := sessMgr.txMgr.StartTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = sessMgr.tenantTracker.InstantTracking(ctx, tx, tenant); err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, err
+	}
+	_ = tx.Commit(ctx)
+
+	return &ReadOnlySession{
+		ctx:    ctx,
+		tenant: tenant,
+	}, nil
 }
 
 // Create returns the QuerySession after creating all the necessary elements that a query execution needs.
@@ -198,25 +235,35 @@ func (sessMgr *SessionManager) Remove(ctx context.Context) error {
 // Execute is responsible to execute a query. In a way this method is managing the lifecycle of a query. For implicit
 // transaction everything is done in this method. For explicit transaction, a session may already exist, so it only
 // needs to run without calling Commit/Rollback.
-func (sessMgr *SessionManager) Execute(ctx context.Context, req *ReqOptions) (*Response, error) {
+func (sessMgr *SessionManager) Execute(ctx context.Context, runner QueryRunner, req *ReqOptions) (*Response, error) {
 	if req.txCtx != nil {
 		session := sessMgr.tracker.get(req.txCtx.Id)
 		if session == nil {
 			return nil, transaction.ErrSessionIsGone
 		}
-		resp, ctx, err := session.Run(req.queryRunner)
+		resp, ctx, err := session.Run(runner)
 		session.ctx = ctx
 		return resp, err
 	}
 
-	resp, err := sessMgr.executeWithRetry(ctx, req)
+	resp, err := sessMgr.executeWithRetry(ctx, runner, req)
 	if err == kv.ErrConflictingTransaction {
 		return nil, api.Errorf(api.Code_ABORTED, err.Error())
 	}
 	return resp, err
 }
 
-func (sessMgr *SessionManager) executeWithRetry(ctx context.Context, req *ReqOptions) (resp *Response, err error) {
+func (sessMgr *SessionManager) ReadOnlyExecute(ctx context.Context, runner ReadOnlyQueryRunner, req *ReqOptions) (*Response, error) {
+	session, err := sessMgr.CreateReadOnlySession(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, _, err := session.Run(runner)
+	return resp, err
+}
+
+func (sessMgr *SessionManager) executeWithRetry(ctx context.Context, runner QueryRunner, req *ReqOptions) (resp *Response, err error) {
 	delta := time.Duration(50) * time.Millisecond
 	start := time.Now()
 	for {
@@ -227,7 +274,7 @@ func (sessMgr *SessionManager) executeWithRetry(ctx context.Context, req *ReqOpt
 		}
 
 		// use the same ctx assigned in the session
-		resp, session.ctx, err = session.Run(req.queryRunner)
+		resp, session.ctx, err = session.Run(runner)
 		if changed, err1 := session.versionTracker.Stop(session.ctx); err1 != nil || changed {
 			// other than for write request, stop will be no-op.
 			_ = session.tx.Rollback(session.ctx)
@@ -258,6 +305,15 @@ func (sessMgr *SessionManager) executeWithRetry(ctx context.Context, req *ReqOpt
 			time.Sleep(time.Duration(rand.Intn(25)) * time.Millisecond)
 		}
 	}
+}
+
+type ReadOnlySession struct {
+	ctx    context.Context
+	tenant *metadata.Tenant
+}
+
+func (s *ReadOnlySession) Run(runner ReadOnlyQueryRunner) (*Response, context.Context, error) {
+	return runner.ReadOnly(s.ctx, s.tenant)
 }
 
 type QuerySession struct {

--- a/server/transaction/manager.go
+++ b/server/transaction/manager.go
@@ -51,7 +51,6 @@ type Tx interface {
 	Rollback(ctx context.Context) error
 	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
 	SetVersionstampedKey(ctx context.Context, key []byte, value []byte) error
-	start(ctx context.Context) error
 }
 
 type StagedDB interface {
@@ -227,8 +226,14 @@ func (s *TxSession) ReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key,
 	if err := s.validateSession(); err != nil {
 		return nil, err
 	}
-
-	return s.kTx.ReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), kv.BuildKey(rKey.IndexParts()...), isSnapshot)
+	
+	if rKey != nil && lKey != nil {
+		return s.kTx.ReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), kv.BuildKey(rKey.IndexParts()...), isSnapshot)
+	} else if lKey != nil {
+		return s.kTx.ReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), nil, isSnapshot)
+	} else {
+		return s.kTx.ReadRange(ctx, lKey.Table(), nil, kv.BuildKey(rKey.IndexParts()...), isSnapshot)
+	}
 }
 
 func (s *TxSession) SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error {

--- a/store/kv/errors.go
+++ b/store/kv/errors.go
@@ -27,6 +27,7 @@ const (
 	ErrCodeInvalid                StoreErrCode = 0x00
 	ErrCodeDuplicateKey           StoreErrCode = 0x01
 	ErrCodeConflictingTransaction StoreErrCode = 0x02
+	ErrCodeTransactionMaxDuration StoreErrCode = 0x03
 )
 
 var (
@@ -34,6 +35,8 @@ var (
 	ErrDuplicateKey = NewStoreError(ErrCodeDuplicateKey, "duplicate key value, violates key constraint")
 	// ErrConflictingTransaction is returned when there are conflicting transactions.
 	ErrConflictingTransaction = NewStoreError(ErrCodeConflictingTransaction, "transaction not committed due to conflict with another transaction")
+	// ErrTransactionMaxDurationReached is returned when transaction running beyond 5seconds.
+	ErrTransactionMaxDurationReached = NewStoreError(ErrCodeTransactionMaxDuration, "transaction is old to perform reads or be committed")
 )
 
 type StoreError struct {


### PR DESCRIPTION
- Supporting read by any fields even if indexing store is disabled
- Implicit transactions now allow long-running reads
- Introduce ReadOnly Session so that implicit transactional reads do not create any transaction if reads need to happen from the indexing store. Also, moving out the search API to ReadOnlySession so that it happens without creating any transaction.  