### PR TITLE
feat: Metrics for bytes sent and bytes received on the network

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -34,6 +34,7 @@ var (
 	SearchMetrics  tally.Scope
 	SessionMetrics tally.Scope
 	SizeMetrics    tally.Scope
+	NetworkMetrics tally.Scope
 )
 
 func GetGlobalTags() map[string]string {
@@ -74,6 +75,9 @@ func InitializeMetrics() io.Closer {
 		// Size metrics
 		SizeMetrics = root.SubScope("size")
 		initializeSizeScopes()
+		// Network netrics
+		NetworkMetrics = root.SubScope("net")
+		initializeNetorkScopes()
 	}
 	return closer
 }

--- a/server/metrics/network.go
+++ b/server/metrics/network.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "github.com/uber-go/tally"
+
+var (
+	BytesReceived tally.Scope
+	BytesSent     tally.Scope
+)
+
+func initializeNetorkScopes() {
+	BytesReceived = NetworkMetrics.SubScope("bytes")
+	BytesSent = NetworkMetrics.SubScope("bytes")
+}
+
+func (s *SpanMeta) CountSentBytes(scope tally.Scope, size int) {
+	// proto.Size has int, need to convert it here
+	scope.Tagged(s.GetTags()).Counter("sent").Inc(int64(size))
+}
+
+func (s *SpanMeta) CountReceivedBytes(scope tally.Scope, size int) {
+	// proto.Size has int, need to convert it here
+	scope.Tagged(s.GetTags()).Counter("received").Inc(int64(size))
+}

--- a/server/metrics/network_test.go
+++ b/server/metrics/network_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "testing"
+
+func TestNetworkMetrics(t *testing.T) {
+	InitializeMetrics()
+	testSpanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+
+	t.Run("Test bytes send", func(t *testing.T) {
+		testSpanMeta.CountSentBytes(BytesSent, 100)
+	})
+
+	t.Run("Test bytes received", func(t *testing.T) {
+		testSpanMeta.CountReceivedBytes(BytesReceived, 100)
+	})
+}


### PR DESCRIPTION
Metrics for bytes sent and received. 

Example metrics:
```
net_bytes_received{collection="users",db="sampledb",env="pboros",grpc_method="Read",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="stream",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 27

net_bytes_sent{collection="users",db="sampledb",env="pboros",grpc_method="Read",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="stream",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 195
```

