### PR TITLE
fix: Added db and collection name restriction

### DIFF
--- a/api/server/v1/validator.go
+++ b/api/server/v1/validator.go
@@ -14,6 +14,14 @@
 
 package api
 
+import (
+	"regexp"
+
+	"github.com/tigrisdata/tigris/util"
+)
+
+var validNamePattern = regexp.MustCompile("^[a-zA-Z]+[a-zA-Z0-9_]+$")
+
 type Validator interface {
 	Validate() error
 }
@@ -182,7 +190,9 @@ func isValidCollection(name string) error {
 	if len(name) == 0 {
 		return Errorf(Code_INVALID_ARGUMENT, "invalid collection name")
 	}
-
+	if !validNamePattern.MatchString(name) || util.LanguageKeywords.Contains(name) {
+		return Errorf(Code_INVALID_ARGUMENT, "invalid collection name")
+	}
 	return nil
 }
 
@@ -190,7 +200,9 @@ func isValidDatabase(name string) error {
 	if len(name) == 0 {
 		return Errorf(Code_INVALID_ARGUMENT, "invalid database name")
 	}
-
+	if !validNamePattern.MatchString(name) || util.LanguageKeywords.Contains(name) {
+		return Errorf(Code_INVALID_ARGUMENT, "invalid database name")
+	}
 	return nil
 }
 

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -21,6 +21,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/lib/set"
+	"github.com/tigrisdata/tigris/util"
 )
 
 type FieldType int
@@ -65,25 +66,7 @@ var FieldNames = [...]string{
 var (
 	MsgFieldNameAsLanguageKeyword = "Invalid collection field name, It contains language keyword for fieldName = '%s'"
 	MsgFieldNameInvalidPattern    = "Invalid collection field name, field name can only contain [a-zA-Z0-9_$] and it can only start with [a-zA-Z_$] for fieldName = '%s'"
-	LanguageKeywords              = set.New("abstract", "add", "alias", "and", "any", "args", "arguments", "array",
-		"as", "as?", "ascending", "assert", "async", "await", "base", "bool", "boolean", "break", "by", "byte",
-		"callable", "case", "catch", "chan", "char", "checked", "class", "clone", "const", "constructor", "continue",
-		"debugger", "decimal", "declare", "def", "default", "defer", "del", "delegate", "delete", "descending", "die",
-		"do", "double", "dynamic", "echo", "elif", "else", "elseif", "empty", "enddeclare", "endfor", "endforeach",
-		"endif", "endswitch", "endwhile", "enum", "equals", "eval", "event", "except", "exception", "exit", "explicit",
-		"export", "extends", "extern", "fallthrough", "false", "final", "finally", "fixed", "float", "fn", "for",
-		"foreach", "from", "fun", "func", "function", "get", "global", "go", "goto", "group", "if", "implements",
-		"implicit", "import", "in", "include", "include_once", "init", "instanceof", "insteadof", "int", "integer",
-		"interface", "internal", "into", "is", "isset", "join", "lambda", "let", "list", "lock", "long", "managed",
-		"map", "match", "module", "nameof", "namespace", "native", "new", "nint", "none", "nonlocal", "not", "notnull",
-		"nuint", "null", "number", "object", "of", "on", "operator", "or", "orderby", "out", "override", "package",
-		"params", "partial", "pass", "print", "private", "protected", "public", "raise", "range", "readonly", "record",
-		"ref", "remove", "require", "require_once", "return", "sbyte", "sealed", "select", "set", "short", "sizeof",
-		"stackalloc", "static", "strictfp", "string", "struct", "super", "switch", "symbol", "synchronized", "this",
-		"throw", "throws", "trait", "transient", "true", "try", "type", "typealias", "typeof", "uint", "ulong",
-		"unchecked", "unmanaged", "unsafe", "unset", "use", "ushort", "using", "val", "value", "var", "virtual", "void",
-		"volatile", "when", "where", "while", "with", "xor", "yield")
-	ValidFieldNamePattern = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
+	ValidFieldNamePattern         = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
 )
 
 const (
@@ -306,7 +289,7 @@ func (f *FieldBuilder) Build(isArrayElement bool) (*Field, error) {
 	}
 
 	// check for language keywords
-	if LanguageKeywords.Contains(strings.ToLower(f.FieldName)) {
+	if util.LanguageKeywords.Contains(strings.ToLower(f.FieldName)) {
 		return nil, api.Errorf(api.Code_INVALID_ARGUMENT, MsgFieldNameAsLanguageKeyword, f.FieldName)
 	}
 

--- a/test/v1/server/collection_test.go
+++ b/test/v1/server/collection_test.go
@@ -74,6 +74,18 @@ func TestCreateCollection(t *testing.T) {
 	})
 }
 
+func TestCreateCollectionInvalidName(t *testing.T) {
+	invalidCollectionName := []string{"", "test-coll", "1test-coll", "$testcoll", "testcoll$", "test$coll", "abstract", "yield"}
+	for _, name := range invalidCollectionName {
+		resp := createCollection(t, "valid_db_name", name, testCreateSchema)
+		resp.Status(http.StatusBadRequest).
+			JSON().
+			Path("$.error").
+			Object().
+			ValueEqual("message", "invalid collection name")
+	}
+}
+
 func TestDropCollection(t *testing.T) {
 	db, coll := setupTests(t)
 	defer cleanupTests(t, db)

--- a/test/v1/server/database_test.go
+++ b/test/v1/server/database_test.go
@@ -42,6 +42,18 @@ func TestCreateDatabase(t *testing.T) {
 		ValueEqual("message", "database created successfully")
 }
 
+func TestCreateDatabaseInvalidName(t *testing.T) {
+	invalidDbNames := []string{"", "1test-db", "test-db", "$testdb", "testdb$", "test$db", "abstract", "yield"}
+	for _, name := range invalidDbNames {
+		resp := createDatabase(t, name)
+		resp.Status(http.StatusBadRequest).
+			JSON().
+			Path("$.error").
+			Object().
+			ValueEqual("message", "invalid database name")
+	}
+}
+
 func TestBeginTransaction(t *testing.T) {
 	resp := beginTransaction(t, "test_db")
 	cookieVal := resp.Cookie("Tigris-Tx-Id").Value()

--- a/util/util.go
+++ b/util/util.go
@@ -14,8 +14,29 @@
 
 package util
 
+import "github.com/tigrisdata/tigris/lib/set"
+
 // Version of this build
 var Version string
 
 // Service program name used in logging and monitoring
 var Service string = "tigris-server"
+
+var LanguageKeywords = set.New("abstract", "add", "alias", "and", "any", "args", "arguments", "array",
+	"as", "as?", "ascending", "assert", "async", "await", "base", "bool", "boolean", "break", "by", "byte",
+	"callable", "case", "catch", "chan", "char", "checked", "class", "clone", "const", "constructor", "continue",
+	"debugger", "decimal", "declare", "def", "default", "defer", "del", "delegate", "delete", "descending", "die",
+	"do", "double", "dynamic", "echo", "elif", "else", "elseif", "empty", "enddeclare", "endfor", "endforeach",
+	"endif", "endswitch", "endwhile", "enum", "equals", "eval", "event", "except", "exception", "exit", "explicit",
+	"export", "extends", "extern", "fallthrough", "false", "final", "finally", "fixed", "float", "fn", "for",
+	"foreach", "from", "fun", "func", "function", "get", "global", "go", "goto", "group", "if", "implements",
+	"implicit", "import", "in", "include", "include_once", "init", "instanceof", "insteadof", "int", "integer",
+	"interface", "internal", "into", "is", "isset", "join", "lambda", "let", "list", "lock", "long", "managed",
+	"map", "match", "module", "nameof", "namespace", "native", "new", "nint", "none", "nonlocal", "not", "notnull",
+	"nuint", "null", "number", "object", "of", "on", "operator", "or", "orderby", "out", "override", "package",
+	"params", "partial", "pass", "print", "private", "protected", "public", "raise", "range", "readonly", "record",
+	"ref", "remove", "require", "require_once", "return", "sbyte", "sealed", "select", "set", "short", "sizeof",
+	"stackalloc", "static", "strictfp", "string", "struct", "super", "switch", "symbol", "synchronized", "this",
+	"throw", "throws", "trait", "transient", "true", "try", "type", "typealias", "typeof", "uint", "ulong",
+	"unchecked", "unmanaged", "unsafe", "unset", "use", "ushort", "using", "val", "value", "var", "virtual", "void",
+	"volatile", "when", "where", "while", "with", "xor", "yield")


### PR DESCRIPTION
db and collection name

- it cannot contain any programming language keyword (from our curated list).
- it must consist of alphanumeric and `_`.
- it must begin with alphabet.
- It must have length atleast 1.