### PR TITLE
feat: Querying on metadata fields

### DIFF
--- a/lib/date/converter.go
+++ b/lib/date/converter.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// ToUnixNano converts a time to Unix nano seconds
+// ToUnixNano converts a string formatted time to Unix nanoseconds
 func ToUnixNano(format string, dateStr string) (int64, error) {
 	t, err := time.Parse(format, dateStr)
 	if err != nil {

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -146,7 +146,7 @@ func (factory *Factory) Factorize(reqFilter []byte) ([]Filter, error) {
 func (factory *Factory) UnmarshalFilter(input jsoniter.RawMessage) (expression.Expr, error) {
 	var err error
 	var filter Filter
-	err = jsonparser.ObjectEach(input, func(k []byte, v []byte, jsonDataType jsonparser.ValueType, offset int) error {
+	parsingError := jsonparser.ObjectEach(input, func(k []byte, v []byte, dt jsonparser.ValueType, offset int) error {
 		if err != nil {
 			return err
 		}
@@ -157,10 +157,14 @@ func (factory *Factory) UnmarshalFilter(input jsoniter.RawMessage) (expression.E
 		case string(OrOP):
 			filter, err = factory.UnmarshalOr(v)
 		default:
-			filter, err = factory.ParseSelector(k, v, jsonDataType)
+			filter, err = factory.ParseSelector(k, v, dt)
 		}
 		return nil
 	})
+
+	if parsingError != nil {
+		return filter, parsingError
+	}
 
 	return filter, err
 }

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -87,7 +87,7 @@ func NewDefaultCollection(name string, id uint32, schVer int, fields []*Field, i
 	validator.AdditionalProperties = false
 	disableAdditionalProperties(validator.Properties)
 
-	queryableFields := buildQueryableFields(fields)
+	queryableFields := BuildQueryableFields(fields)
 
 	return &DefaultCollection{
 		Id:              id,
@@ -156,7 +156,7 @@ func (d *DefaultCollection) SearchCollectionName() string {
 }
 
 func GetSearchDeltaFields(existingFields []*QueryableField, incomingFields []*Field) []tsApi.Field {
-	incomingQueryable := buildQueryableFields(incomingFields)
+	incomingQueryable := BuildQueryableFields(incomingFields)
 
 	var existingFieldSet = set.New()
 	for _, f := range existingFields {
@@ -195,7 +195,7 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 			Optional: &ptrTrue,
 		})
 		// Save original date as string to disk
-		if s.DataType == DateTimeType {
+		if !s.IsReserved() && s.DataType == DateTimeType {
 			tsFields = append(tsFields, tsApi.Field{
 				Name:     ToSearchDateKey(s.Name()),
 				Type:     toSearchFieldType(StringType),

--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -285,6 +285,7 @@ func TestCollection_SearchSchema(t *testing.T) {
 	expFlattenedFields := []string{"id", "id_32", "product", "id_uuid", "ts", ToSearchDateKey("ts"), "price", "simple_items", "simple_object.name",
 		"simple_object.phone", "simple_object.address.street", "simple_object.details.nested_id", "simple_object.details.nested_obj.id",
 		"simple_object.details.nested_obj.name", "simple_object.details.nested_array", "simple_object.details.nested_string",
+		"created_at", "updated_at",
 	}
 
 	coll := NewDefaultCollection("t1", 1, 1, schFactory.Fields, schFactory.Indexes, schFactory.Schema, "t1")

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -395,10 +395,14 @@ func (q *QueryableField) Name() string {
 }
 
 func (q *QueryableField) ShouldPack() bool {
-	return q.DataType == ArrayType || q.DataType == DateTimeType
+	return !q.IsReserved() && (q.DataType == ArrayType || q.DataType == DateTimeType)
 }
 
-func buildQueryableFields(fields []*Field) []*QueryableField {
+func (q *QueryableField) IsReserved() bool {
+	return IsReservedField(q.Name())
+}
+
+func BuildQueryableFields(fields []*Field) []*QueryableField {
 	var queryableFields []*QueryableField
 
 	for _, f := range fields {
@@ -408,6 +412,10 @@ func buildQueryableFields(fields []*Field) []*QueryableField {
 			queryableFields = append(queryableFields, buildQueryableField("", f))
 		}
 	}
+
+	// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
+	queryableFields = append(queryableFields, NewQueryableField(ReservedFields[CreatedAt], DateTimeType))
+	queryableFields = append(queryableFields, NewQueryableField(ReservedFields[UpdatedAt], DateTimeType))
 
 	return queryableFields
 }

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -132,3 +132,48 @@ func TestFieldBuilder_Build(t *testing.T) {
 		}
 	})
 }
+
+func TestQueryableField_ShouldPack(t *testing.T) {
+	// reserved fields should never be packed
+	for _, f := range ReservedFields {
+		t.Run(fmt.Sprintf("%s is reserved and should not be packed", f), func(t *testing.T) {
+			q := &QueryableField{FieldName: f}
+			require.False(t, q.ShouldPack())
+		})
+	}
+
+	for _, f := range [...]FieldType{ArrayType, DateTimeType} {
+		t.Run(fmt.Sprintf("%s should be packed", FieldNames[f]), func(t *testing.T) {
+			q := &QueryableField{FieldName: "myField", DataType: f}
+			require.True(t, q.ShouldPack())
+		})
+	}
+
+	shouldNotPack := [...]FieldType{
+		UnknownType,
+		NullType,
+		BoolType,
+		Int32Type,
+		Int64Type,
+		DoubleType,
+		StringType,
+		ByteType,
+		ObjectType,
+	}
+	for _, f := range shouldNotPack {
+		t.Run(fmt.Sprintf("%s should not be packed", FieldNames[f]), func(t *testing.T) {
+			q := &QueryableField{FieldName: "myField", DataType: f}
+			require.False(t, q.ShouldPack())
+		})
+	}
+}
+
+func TestQueryableField_IsReserved(t *testing.T) {
+	// this should reflect schema.Reserved fields array
+	for _, f := range ReservedFields {
+		t.Run(fmt.Sprintf("%s is reserved", f), func(t *testing.T) {
+			q := &QueryableField{FieldName: f}
+			require.True(t, q.IsReserved())
+		})
+	}
+}

--- a/server/services/v1/search_indexer.go
+++ b/server/services/v1/search_indexer.go
@@ -273,15 +273,6 @@ func UnpackSearchFields(doc map[string]interface{}, collection *schema.DefaultCo
 	return searchKey, tableData, doc, nil
 }
 
-func UnpackAndSetMD(doc map[string]interface{}, tableData *internal.TableData) {
-	if v, ok := doc[schema.ReservedFields[schema.CreatedAt]]; ok {
-		tableData.CreatedAt = internal.CreateNewTimestamp(int64(v.(float64)))
-	}
-	if v, ok := doc[schema.ReservedFields[schema.UpdatedAt]]; ok {
-		tableData.UpdatedAt = internal.CreateNewTimestamp(int64(v.(float64)))
-	}
-}
-
 func FlattenObjects(data map[string]any) map[string]any {
 	resp := make(map[string]any)
 	flattenObjects("", data, resp)

--- a/server/services/v1/search_indexer_test.go
+++ b/server/services/v1/search_indexer_test.go
@@ -15,14 +15,19 @@
 package v1
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
+	"strconv"
 
 	"github.com/buger/jsonparser"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/internal"
+	encoder "github.com/tigrisdata/tigris/lib/json"
+	"github.com/tigrisdata/tigris/schema"
 )
 
 func TestFlattenObj(t *testing.T) {
@@ -36,6 +41,273 @@ func TestFlattenObj(t *testing.T) {
 	require.Equal(t, []interface{}{float64(1), float64(2), float64(3)}, flattened["b.f"])
 
 	require.True(t, reflect.DeepEqual(UnFlattenMap, UnFlattenObjects(flattened)))
+}
+
+func TestPackSearchFields(t *testing.T) {
+	nanoTs := internal.CreateNewTimestamp(int64(1641024000000000000)) // 2022-01-01
+	emptyColl := &schema.DefaultCollection{}
+
+	t.Run("with empty data should throw error", func(t *testing.T) {
+		td := &internal.TableData{}
+		res, err := PackSearchFields(td, emptyColl, "1")
+		require.ErrorContains(t, err, "EOF")
+		require.Nil(t, res)
+	})
+
+	mdTestCases := []struct {
+		name    string
+		rawData []byte
+	}{
+		{"metadata fields packed from table data", []byte(`{}`)},
+		{"metadata fields in raw data are overriden", []byte(`{"created_at":123,"updated_at":542}`)},
+	}
+
+	for _, v := range mdTestCases {
+		t.Run(v.name, func(t *testing.T) {
+			td := &internal.TableData{
+				CreatedAt: nanoTs,
+				UpdatedAt: nanoTs,
+				RawData:   v.rawData,
+			}
+			td.RawData = v.rawData
+			res, err := PackSearchFields(td, emptyColl, "123")
+			require.NoError(t, err)
+
+			decData, err := encoder.Decode(res)
+			require.NoError(t, err)
+
+			createdAt, err := decData["created_at"].(json.Number).Int64()
+			require.NoError(t, err)
+			require.Equal(t, createdAt, td.CreatedAt.UnixNano())
+
+			updatedAt, err := decData["updated_at"].(json.Number).Int64()
+			require.NoError(t, err)
+			require.Equal(t, updatedAt, td.UpdatedAt.UnixNano())
+		})
+	}
+
+	t.Run("nil metadata fields are skipped", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{}`),
+		}
+		res, err := PackSearchFields(td, emptyColl, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+
+		createdAt, err := decData["created_at"].(json.Number).Int64()
+		require.NoError(t, err)
+		require.Equal(t, createdAt, td.CreatedAt.UnixNano())
+
+		updatedAt := decData["updated_at"]
+		require.Nil(t, updatedAt)
+	})
+
+	t.Run("id in data is shadowed by internal key", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"id":"myData_321"}`),
+		}
+		res, err := PackSearchFields(td, emptyColl, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+
+		require.Equal(t, decData["id"], "123")
+		require.Equal(t, decData[schema.ReservedFields[schema.IdToSearchKey]], "myData_321")
+	})
+
+	t.Run("id not shadowed if not in document", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"some_id":"myData_321"}`),
+		}
+		res, err := PackSearchFields(td, emptyColl, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+
+		require.Equal(t, decData["id"], "123")
+		require.Equal(t, decData["some_id"], "myData_321")
+		require.Nil(t, decData[schema.ReservedFields[schema.IdToSearchKey]])
+	})
+
+	t.Run("nested objects are flattened", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"parent":{"node_1":123,"node_2":"nested"}}`),
+		}
+		res, err := PackSearchFields(td, emptyColl, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+		require.Equal(t, decData["parent.node_2"], "nested")
+
+		v, err := strconv.Atoi(string(decData["parent.node_1"].(json.Number)))
+		require.NoError(t, err)
+		require.Equal(t, v, 123)
+	})
+
+	t.Run("array type of schema fields are unpacked", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"arrayField":[1,2,3,4,5]}`),
+		}
+		f := &schema.Field{DataType: schema.ArrayType, FieldName: "arrayField"}
+		coll := &schema.DefaultCollection{
+			QueryableFields: schema.BuildQueryableFields([]*schema.Field{f}),
+		}
+
+		res, err := PackSearchFields(td, coll, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+		require.Equal(t, "[1,2,3,4,5]", decData["arrayField"])
+	})
+
+	t.Run("dateTime type of schema fields are unpacked", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"dateField":"2022-10-11T04:19:32+05:30"}`),
+		}
+		f := &schema.Field{DataType: schema.DateTimeType, FieldName: "dateField"}
+		coll := &schema.DefaultCollection{
+			QueryableFields: schema.BuildQueryableFields([]*schema.Field{f}),
+		}
+		res, err := PackSearchFields(td, coll, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+
+		require.Equal(t, "2022-10-11T04:19:32+05:30", decData[schema.ToSearchDateKey(f.Name())])
+		d, err := decData["dateField"].(json.Number).Int64()
+		require.NoError(t, err)
+		require.Equal(t, int64(1665442172000000000), d)
+	})
+
+	t.Run("values are encoded to their types", func(t *testing.T) {
+		td := &internal.TableData{
+			CreatedAt: nanoTs,
+			RawData:   []byte(`{"strField":"strValue", "floatField":99999.12345, "intField": 12, "nilField": null}`),
+		}
+		res, err := PackSearchFields(td, emptyColl, "123")
+		require.NoError(t, err)
+
+		decData, err := encoder.Decode(res)
+		require.NoError(t, err)
+		require.Equal(t, "strValue", decData["strField"])
+		require.Nil(t, decData["nilField"])
+
+		v, err := decData["intField"].(json.Number).Int64()
+		require.NoError(t, err)
+		require.Equal(t, int64(12), v)
+
+		f, err := decData["floatField"].(json.Number).Float64()
+		require.NoError(t, err)
+		require.Equal(t, 99999.12345, f)
+	})
+}
+
+func TestUnpackSearchFields(t *testing.T) {
+	emptyColl := &schema.DefaultCollection{}
+
+	t.Run("no id key in schema, extract search key", func(t *testing.T) {
+		doc := map[string]any{
+			"id": "123",
+		}
+
+		searchKey, _, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.NoError(t, err)
+		require.Equal(t, doc["id"], searchKey)
+		require.Len(t, unpacked, 0)
+	})
+
+	t.Run("populate id key and search key", func(t *testing.T) {
+		doc := map[string]any{
+			"id":         "internalId",
+			"_tigris_id": 123,
+		}
+		searchKey, _, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.NoError(t, err)
+		require.Len(t, unpacked, 1)
+		require.Equal(t, doc[schema.ReservedFields[schema.IdToSearchKey]], unpacked["id"])
+		require.Equal(t, doc["id"], searchKey)
+	})
+
+	t.Run("created_at metadata gets populated", func(t *testing.T) {
+		doc := map[string]any{
+			"id":         "123",
+			"created_at": float64(1666054267528106000),
+		}
+		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.NoError(t, err)
+		require.Empty(t, unpacked)
+		require.Equal(t, doc["created_at"], float64(td.CreatedAt.UnixNano()))
+		require.Nil(t, td.UpdatedAt)
+	})
+
+	t.Run("updated_at metadata gets populated", func(t *testing.T) {
+		doc := map[string]any{
+			"id":         "123",
+			"updated_at": float64(1666054267528106000),
+		}
+		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.NoError(t, err)
+		require.Empty(t, unpacked)
+		require.Equal(t, doc["updated_at"], float64(td.UpdatedAt.UnixNano()))
+		require.Nil(t, td.CreatedAt)
+	})
+
+	t.Run("nested object is unflattened", func(t *testing.T) {
+		doc := map[string]any{
+			"id":            "123",
+			"parent.node_1": 123,
+			"parent.node_2": "someData",
+		}
+		_, _, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.NoError(t, err)
+		require.Len(t, unpacked, 1)
+		require.Len(t, unpacked["parent"], 2)
+		require.Equal(t, map[string]interface{}{"node_1": 123, "node_2": "someData"}, unpacked["parent"])
+	})
+
+	t.Run("array type is unpacked from string", func(t *testing.T) {
+		doc := map[string]any{
+			"id":         "123",
+			"arrayField": "[1.1,2.1,3.0,4.3,5.5]",
+		}
+		f := &schema.Field{DataType: schema.ArrayType, FieldName: "arrayField"}
+		coll := &schema.DefaultCollection{
+			QueryableFields: schema.BuildQueryableFields([]*schema.Field{f}),
+		}
+		_, _, unpacked, err := UnpackSearchFields(doc, coll)
+		require.NoError(t, err)
+		require.Len(t, unpacked, 1)
+		require.Equal(t, []interface{}{1.1, 2.1, 3.0, 4.3, 5.5}, unpacked["arrayField"])
+	})
+
+	t.Run("dateTime fields are unpacked", func(t *testing.T) {
+		doc := map[string]any{
+			"id":                     "123",
+			"dateField":              1665442172000000000,
+			"_tigris_date_dateField": "2022-10-11T04:19:32+05:30",
+		}
+		f := &schema.Field{DataType: schema.DateTimeType, FieldName: "dateField"}
+		coll := &schema.DefaultCollection{
+			QueryableFields: schema.BuildQueryableFields([]*schema.Field{f}),
+		}
+		_, _, unpacked, err := UnpackSearchFields(doc, coll)
+		require.NoError(t, err)
+		require.Len(t, unpacked, 1)
+		require.Equal(t, "2022-10-11T04:19:32+05:30", unpacked["dateField"])
+	})
 }
 
 // Benchmarking to test if it makes sense to decode the data and then add fields to the decoded map and then encode


### PR DESCRIPTION
Allowing filtering and sorting by metadata fields `created_at` and `updated_at`:

```json
{
    "q": "",
    "filter": {
        "$and": [
            {
                "created_at": {
                    "$gt": "2022-08-16T17:29:28.000Z"
                }
            },
            {
                "created_at": {
                    "$lt": "2022-08-25T17:29:28.000Z"
                }
            }
        ]
    }
}
```