### PR TITLE
fix: fix panic on inconsistent metric tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/tigrisdata/tigris
 go 1.18
 
 require (
+	github.com/ajg/form v1.5.1
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
+	github.com/auth0/go-auth0 v0.9.3
 	github.com/auth0/go-jwt-middleware/v2 v2.0.1
 	github.com/buger/jsonparser v1.1.1
 	github.com/davecgh/go-spew v1.1.1
@@ -51,9 +53,7 @@ require (
 	github.com/DataDog/sketches-go v1.4.1 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/PuerkitoBio/rehttp v1.1.0 // indirect
-	github.com/ajg/form v1.5.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/auth0/go-auth0 v0.9.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/deepmap/oapi-codegen v1.11.0 // indirect
@@ -88,7 +88,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.18.1 // indirect
-	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.2 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,7 +131,9 @@ github.com/aws/aws-sdk-go-v2/service/sqs v1.0.0/go.mod h1:w5BclCU8ptTbagzXS/fHBr
 github.com/aws/aws-sdk-go-v2/service/sts v1.0.0/go.mod h1:5f+cELGATgill5Pu3/vK3Ebuigstc+qYEHW5MvGWZO4=
 github.com/aws/smithy-go v1.0.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/aws/smithy-go v1.11.0/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -189,6 +191,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dnaeon/go-vcr/v2 v2.0.1 h1:KQnAAR6r4GbcJ71KfVxM7qhX85oVj3A0zWbuoxpbYcA=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -299,7 +302,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -557,6 +559,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -839,7 +842,6 @@ github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiu
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -851,7 +853,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -26,17 +26,59 @@ var (
 	FdbRespTime      tally.Scope
 )
 
+func getFdbOkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"fdb_method",
+	}
+}
+
+func getFdbTimerTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"fdb_method",
+	}
+}
+
+func getFdbErrorTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"fdb_method",
+		"error_source",
+		"error_value",
+	}
+}
+
 func getFdbReqOkTags(reqMethodName string) map[string]string {
 	return map[string]string{
-		"method":        reqMethodName,
+		"fdb_method":    reqMethodName,
 		"tigris_tenant": UnknownValue,
 	}
 }
 
 func getFdbReqErrorTags(reqMethodName string, code string) map[string]string {
 	return map[string]string{
-		"method":        reqMethodName,
-		"error_code":    code,
+		"fdb_method":    reqMethodName,
+		"error_source":  "fdb",
+		"error_value":   code,
 		"tigris_tenant": UnknownValue,
 	}
 }

--- a/server/metrics/fdb_test.go
+++ b/server/metrics/fdb_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tigrisdata/tigris/server/config"
 )
 
@@ -38,6 +40,12 @@ func TestFdbMetrics(t *testing.T) {
 		GetFdbErrorTags(ctx, "Insert", "2"),
 		GetFdbErrorTags(ctx, "Insert", "3"),
 	}
+
+	t.Run("Test fdb tags", func(t *testing.T) {
+		assert.Greater(t, len(getFdbOkTagKeys()), 2)
+		assert.Greater(t, len(getFdbTimerTagKeys()), 2)
+		assert.Greater(t, len(getFdbErrorTagKeys()), 2)
+	})
 
 	t.Run("Test FDB counters", func(t *testing.T) {
 		for _, tags := range testNormalTags {

--- a/server/metrics/network.go
+++ b/server/metrics/network.go
@@ -21,17 +21,29 @@ var (
 	BytesSent     tally.Scope
 )
 
+func getNetworkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+	}
+}
+
 func initializeNetworkScopes() {
 	BytesReceived = NetworkMetrics.SubScope("bytes")
 	BytesSent = NetworkMetrics.SubScope("bytes")
 }
 
-func (s *SpanMeta) CountSentBytes(scope tally.Scope, size int) {
+func (s *SpanMeta) CountSentBytes(scope tally.Scope, tags map[string]string, size int) {
 	// proto.Size has int, need to convert it here
-	scope.Tagged(s.GetTags()).Counter("sent").Inc(int64(size))
+	scope.Tagged(tags).Counter("sent").Inc(int64(size))
 }
 
-func (s *SpanMeta) CountReceivedBytes(scope tally.Scope, size int) {
+func (s *SpanMeta) CountReceivedBytes(scope tally.Scope, tags map[string]string, size int) {
 	// proto.Size has int, need to convert it here
-	scope.Tagged(s.GetTags()).Counter("received").Inc(int64(size))
+	scope.Tagged(tags).Counter("received").Inc(int64(size))
 }

--- a/server/metrics/network_test.go
+++ b/server/metrics/network_test.go
@@ -21,10 +21,10 @@ func TestNetworkMetrics(t *testing.T) {
 	testSpanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
 
 	t.Run("Test bytes send", func(t *testing.T) {
-		testSpanMeta.CountSentBytes(BytesSent, 100)
+		testSpanMeta.CountSentBytes(BytesSent, testSpanMeta.GetNetworkTags(), 100)
 	})
 
 	t.Run("Test bytes received", func(t *testing.T) {
-		testSpanMeta.CountReceivedBytes(BytesReceived, 100)
+		testSpanMeta.CountReceivedBytes(BytesReceived, testSpanMeta.GetNetworkTags(), 100)
 	})
 }

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	SystemTigrisTenantName = "system"
-	UnknownValue           = "unknown"
+	UnknownValue = "unknown"
 )
 
 var (
@@ -35,6 +34,44 @@ var (
 	ErrorRequests    tally.Scope
 	RequestsRespTime tally.Scope
 )
+
+func getRequestOkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+	}
+}
+
+func getRequestTimerTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+	}
+}
+
+func getRequestErrorTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"error_code",
+		"error_value",
+	}
+}
 
 type RequestEndpointMetadata struct {
 	serviceName   string
@@ -65,7 +102,7 @@ func (r *RequestEndpointMetadata) GetServiceType() string {
 	}
 }
 
-func (r *RequestEndpointMetadata) GetOkTags() map[string]string {
+func (r *RequestEndpointMetadata) GetInitialTags() map[string]string {
 	return map[string]string{
 		"grpc_method":       r.methodInfo.Name,
 		"grpc_service":      r.serviceName,
@@ -74,19 +111,6 @@ func (r *RequestEndpointMetadata) GetOkTags() map[string]string {
 		"env":               config.GetEnvironment(),
 		"db":                UnknownValue,
 		"collection":        UnknownValue,
-	}
-}
-
-func (r *RequestEndpointMetadata) GetErrorTags(source string, code string) map[string]string {
-	return map[string]string{
-		"grpc_method":   r.methodInfo.Name,
-		"grpc_service":  r.serviceName,
-		"error_source":  source,
-		"error_code":    code,
-		"env":           config.GetEnvironment(),
-		"tigris_tenant": SystemTigrisTenantName,
-		"db":            UnknownValue,
-		"collection":    UnknownValue,
 	}
 }
 

--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -74,7 +74,7 @@ func TestGRPCMetrics(t *testing.T) {
 	})
 
 	t.Run("Test unary method preinitialized tags", func(t *testing.T) {
-		tags := unaryEndPointMetadata.GetOkTags()
+		tags := unaryEndPointMetadata.GetInitialTags()
 		for tagName, tagValue := range tags {
 			switch tagName {
 			case "grpc_method":
@@ -86,7 +86,7 @@ func TestGRPCMetrics(t *testing.T) {
 	})
 
 	t.Run("Test streaming method preinitialized tags", func(t *testing.T) {
-		tags := streamingEndpointMetadata.GetOkTags()
+		tags := streamingEndpointMetadata.GetInitialTags()
 		for tagName, tagValue := range tags {
 			switch tagName {
 			case "grpc_method":

--- a/server/metrics/search.go
+++ b/server/metrics/search.go
@@ -26,6 +26,47 @@ var (
 	SearchRespTime      tally.Scope
 )
 
+func getSearchOkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"search_method",
+	}
+}
+
+func getSearchTimerTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"search_method",
+	}
+}
+
+func getSearchErrorTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"error_code",
+		"error_value",
+		"search_method",
+	}
+}
+
 func initializeSearchScopes() {
 	SearchOkRequests = SearchMetrics.SubScope("count")
 	SearchErrorRequests = SearchMetrics.SubScope("count")
@@ -38,7 +79,7 @@ func GetSearchTags(ctx context.Context, reqMethodName string) map[string]string 
 
 func getSearchReqTags(reqMethodName string) map[string]string {
 	return map[string]string{
-		"method":        reqMethodName,
+		"search_method": reqMethodName,
 		"tigris_tenant": UnknownValue,
 	}
 }

--- a/server/metrics/search_test.go
+++ b/server/metrics/search_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tigrisdata/tigris/server/config"
 )
 
@@ -35,6 +37,12 @@ func TestSearchMetrics(t *testing.T) {
 		GetSearchTags(ctx, "DeleteDocuments"),
 		GetSearchTags(ctx, "Search"),
 	}
+
+	t.Run("Test search tags", func(t *testing.T) {
+		assert.Greater(t, len(getSearchOkTagKeys()), 2)
+		assert.Greater(t, len(getSearchTimerTagKeys()), 2)
+		assert.Greater(t, len(getSearchErrorTagKeys()), 2)
+	})
 
 	t.Run("Test Search counters", func(t *testing.T) {
 		for _, tags := range testNormalTags {

--- a/server/metrics/session.go
+++ b/server/metrics/session.go
@@ -26,10 +26,51 @@ var (
 	SessionRespTime      tally.Scope
 )
 
+func getSessionOkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"session_method",
+	}
+}
+
+func getSessionTimerTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"session_method",
+	}
+}
+
+func getSessionErrorTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"grpc_service",
+		"tigris_tenant",
+		"grpc_service_type",
+		"env",
+		"db",
+		"collection",
+		"error_code",
+		"error_value",
+		"session_method",
+	}
+}
+
 func getSessionTags(sessionMethodName string) map[string]string {
 	return map[string]string{
-		"method":        sessionMethodName,
-		"tigris_tenant": UnknownValue,
+		"session_method": sessionMethodName,
+		"tigris_tenant":  UnknownValue,
 	}
 }
 

--- a/server/metrics/size.go
+++ b/server/metrics/size.go
@@ -31,6 +31,36 @@ func initializeSizeScopes() {
 	CollectionSize = SizeMetrics.SubScope("collection")
 }
 
+func getNameSpaceSizeTagKeys() []string {
+	return []string{
+		"env",
+		"service",
+		"tigris_tenant",
+		"version",
+	}
+}
+
+func getDbSizeTagKeys() []string {
+	return []string{
+		"env",
+		"service",
+		"tigris_tenant",
+		"version",
+		"db",
+	}
+}
+
+func getCollectionSizeTagKeys() []string {
+	return []string{
+		"env",
+		"service",
+		"tigris_tenant",
+		"version",
+		"db",
+		"collection",
+	}
+}
+
 func getNamespaceSizeTags(namespaceName string) map[string]string {
 	return map[string]string{
 		"tigris_tenant": namespaceName,

--- a/server/metrics/tags_test.go
+++ b/server/metrics/tags_test.go
@@ -23,11 +23,6 @@ import (
 )
 
 func TestTagsHelpers(t *testing.T) {
-	t.Run("Test getOkTagsKeys", func(t *testing.T) {
-		keys := getOkTagKeys()
-		assert.Greater(t, len(keys), 2)
-	})
-
 	t.Run("Test mergeTags", func(t *testing.T) {
 		tagSet1 := map[string]string{
 			"key1": "value1",
@@ -50,14 +45,17 @@ func TestTagsHelpers(t *testing.T) {
 		assert.Equal(t, "value5", mergedTagSet["key5"])
 	})
 
-	t.Run("Test getErrorTags", func(t *testing.T) {
-		assert.Equal(t, map[string]string{}, getErrorTags(nil))
+	t.Run("Test getTagsForError", func(t *testing.T) {
+		assert.Equal(t, map[string]string{
+			"error_source": "unknown",
+			"error_value":  "unknown",
+		}, getTagsForError(nil))
 
-		fdbErrTags := getErrorTags(fdb.Error{Code: 1})
+		fdbErrTags := getTagsForError(fdb.Error{Code: 1})
 		assert.Equal(t, "fdb", fdbErrTags["error_source"])
 		assert.Equal(t, "1", fdbErrTags["error_value"])
 
-		tigrisErrTags := getErrorTags(&api.TigrisError{Code: api.Code_NOT_FOUND})
+		tigrisErrTags := getTagsForError(&api.TigrisError{Code: api.Code_NOT_FOUND})
 		assert.Equal(t, "tigris_server", tigrisErrTags["error_source"])
 		assert.Equal(t, "NOT_FOUND", tigrisErrTags["error_value"])
 	})

--- a/server/metrics/tracing_test.go
+++ b/server/metrics/tracing_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type FakeError struct{}
+
+func (f *FakeError) Error() string {
+	return "fake error for testing tags"
+}
+
 func TestTracing(t *testing.T) {
 	t.Run("Test NewSpanMeta", func(t *testing.T) {
 		tags := GetGlobalTags()
@@ -77,9 +83,155 @@ func TestTracing(t *testing.T) {
 		config.DefaultConfig.Tracing.Enabled = true
 		InitializeMetrics()
 		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
-		defer RequestsRespTime.Tagged(spanMeta.GetTags()).Timer("time").Start().Stop()
-		spanMeta.CountOkForScope(OkRequests)
+		defer RequestsRespTime.Tagged(spanMeta.GetRequestTimerTags()).Timer("time").Start().Stop()
+		spanMeta.CountOkForScope(OkRequests, spanMeta.GetRequestOkTags())
 		err := fmt.Errorf("hello error")
-		spanMeta.CountErrorForScope(ErrorRequests, err)
+		spanMeta.CountErrorForScope(ErrorRequests, spanMeta.GetRequestErrorTags(err))
+	})
+
+	t.Run("Test request tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+		requestOkTags := spanMeta.GetRequestOkTags()
+		for _, key := range getRequestOkTagKeys() {
+			assert.NotNil(t, requestOkTags[key])
+		}
+		assert.Equal(t, len(getRequestOkTagKeys()), len(requestOkTags))
+
+		requestTimerTags := spanMeta.GetRequestTimerTags()
+		for _, key := range getRequestTimerTagKeys() {
+			assert.NotNil(t, requestTimerTags[key])
+		}
+		assert.Equal(t, len(getRequestTimerTagKeys()), len(requestOkTags))
+
+		requestErrorTags := spanMeta.GetRequestErrorTags(&FakeError{})
+		for _, key := range getRequestErrorTagKeys() {
+			assert.NotNil(t, requestErrorTags[key])
+		}
+		assert.Equal(t, len(getRequestErrorTagKeys()), len(requestErrorTags))
+	})
+
+	t.Run("Test fdb tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+		fdbOkTags := spanMeta.GetFdbOkTags()
+		for _, key := range getFdbOkTagKeys() {
+			assert.NotNil(t, fdbOkTags[key])
+		}
+		assert.Equal(t, len(getFdbOkTagKeys()), len(fdbOkTags))
+
+		fdbTimerTags := spanMeta.GetFdbTimerTags()
+		for _, key := range getFdbTimerTagKeys() {
+			assert.NotNil(t, fdbTimerTags[key])
+		}
+		assert.Equal(t, len(getFdbTimerTagKeys()), len(fdbTimerTags))
+
+		fdbErrorTags := spanMeta.GetFdbErrorTags(&FakeError{})
+		for _, key := range getFdbErrorTagKeys() {
+			assert.NotNil(t, fdbErrorTags[key])
+		}
+		assert.Equal(t, len(getFdbErrorTagKeys()), len(fdbErrorTags))
+	})
+
+	t.Run("Test search tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+		searchOkTags := spanMeta.GetSearchOkTags()
+		for _, key := range getSearchOkTagKeys() {
+			assert.NotNil(t, searchOkTags[key])
+		}
+		assert.Equal(t, len(getSearchOkTagKeys()), len(searchOkTags))
+
+		searchTimerTags := spanMeta.GetSearchTimerTags()
+		for _, key := range getSearchTimerTagKeys() {
+			assert.NotNil(t, searchTimerTags[key])
+		}
+		assert.Equal(t, len(getSearchTimerTagKeys()), len(searchTimerTags))
+
+		searchErrorTags := spanMeta.GetSearchErrorTags(&FakeError{})
+		for _, key := range getSearchErrorTagKeys() {
+			assert.NotNil(t, searchErrorTags[key])
+		}
+		assert.Equal(t, len(getSearchErrorTagKeys()), len(searchErrorTags))
+	})
+
+	t.Run("Test session tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+		sessionOkTags := spanMeta.GetSessionOkTags()
+		for _, key := range getSessionOkTagKeys() {
+			assert.NotNil(t, sessionOkTags[key])
+		}
+		assert.Equal(t, len(getSessionOkTagKeys()), len(sessionOkTags))
+
+		sessionTimerTags := spanMeta.GetSessionTimerTags()
+		for _, key := range getSessionTimerTagKeys() {
+			assert.NotNil(t, sessionTimerTags[key])
+		}
+		assert.Equal(t, len(getSessionTimerTagKeys()), len(sessionTimerTags))
+
+		sessionErrorTags := spanMeta.GetSessionErrorTags(&FakeError{})
+		for _, key := range getSessionErrorTagKeys() {
+			assert.NotNil(t, sessionErrorTags[key])
+		}
+		assert.Equal(t, len(getSessionErrorTagKeys()), len(sessionErrorTags))
+	})
+
+	t.Run("Test size tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+
+		namespaceSizeTags := spanMeta.GetNamespaceSizeTags()
+		for _, key := range getNameSpaceSizeTagKeys() {
+			assert.NotNil(t, namespaceSizeTags[key])
+		}
+		assert.Equal(t, len(getNameSpaceSizeTagKeys()), len(namespaceSizeTags))
+
+		dbSizeTags := spanMeta.GetDbSizeTags()
+		for _, key := range getDbSizeTagKeys() {
+			assert.NotNil(t, dbSizeTags[key])
+		}
+		assert.Equal(t, len(getDbSizeTagKeys()), len(dbSizeTags))
+
+		collSizeTags := spanMeta.GetCollectionSizeTags()
+		for _, key := range getCollectionSizeTagKeys() {
+			assert.NotNil(t, collSizeTags[key])
+		}
+		assert.Equal(t, len(getCollectionSizeTagKeys()), len(collSizeTags))
+	})
+
+	t.Run("Test network tags", func(t *testing.T) {
+		config.DefaultConfig.Tracing.Enabled = true
+		InitializeMetrics()
+		spanMeta := NewSpanMeta("test.service.name", "TestResource", "rpc", GetGlobalTags())
+		spanMeta.AddTags(map[string]string{
+			"brokentag": "brokenvalue",
+		})
+
+		networkTags := spanMeta.GetNetworkTags()
+		for _, key := range getNetworkTagKeys() {
+			assert.NotNil(t, networkTags[key])
+		}
+		assert.Equal(t, len(getNetworkTagKeys()), len(networkTags))
 	})
 }

--- a/server/services/v1/sessions.go
+++ b/server/services/v1/sessions.go
@@ -62,15 +62,15 @@ type SessionManagerWithMetrics struct {
 
 func (m *SessionManagerWithMetrics) measure(ctx context.Context, name string, f func(ctx context.Context) error) {
 	tags := metrics.GetSessionTags(ctx, name)
-	spanMeta := metrics.NewSpanMeta(metrics.SessionManagerServiceName, name, "session", tags)
-	defer metrics.SessionRespTime.Tagged(spanMeta.GetTags()).Timer("time").Start().Stop()
+	spanMeta := metrics.NewSpanMeta(metrics.SessionManagerServiceName, name, metrics.SessionSpanType, tags)
+	defer metrics.SessionRespTime.Tagged(spanMeta.GetSessionTimerTags()).Timer("time").Start().Stop()
 	ctx = spanMeta.StartTracing(ctx, true)
 	if err := f(ctx); err != nil {
-		spanMeta.CountErrorForScope(metrics.SessionErrorRequests, err)
+		spanMeta.CountErrorForScope(metrics.SessionErrorRequests, spanMeta.GetSessionErrorTags(err))
 		spanMeta.FinishWithError(ctx, err)
 		return
 	}
-	spanMeta.CountOkForScope(metrics.SessionOkRequests)
+	spanMeta.CountOkForScope(metrics.SessionOkRequests, spanMeta.GetSessionOkTags())
 	_ = spanMeta.FinishTracing(ctx)
 }
 

--- a/store/kv/kv.go
+++ b/store/kv/kv.go
@@ -98,18 +98,18 @@ func NewKeyValueStoreWithMetrics(cfg *config.FoundationDBConfig) (KeyValueStore,
 func measureLow(ctx context.Context, name string, f func() error) {
 	// Low level measurement wrapper that is called by the measure functions on the appropriate receiver
 	tags := metrics.GetFdbOkTags(ctx, name)
-	spanMeta := metrics.NewSpanMeta(metrics.KvTracingServiceName, name, "fdb_kv", tags)
-	defer metrics.FdbRespTime.Tagged(spanMeta.GetTags()).Timer("time").Start().Stop()
+	spanMeta := metrics.NewSpanMeta(metrics.KvTracingServiceName, name, metrics.FdbSpanType, tags)
+	defer metrics.FdbRespTime.Tagged(spanMeta.GetFdbTimerTags()).Timer("time").Start().Stop()
 	ctx = spanMeta.StartTracing(ctx, true)
 	err := f()
 	if err == nil {
 		// Request was ok
-		spanMeta.CountOkForScope(metrics.FdbOkRequests)
+		spanMeta.CountOkForScope(metrics.FdbOkRequests, spanMeta.GetFdbOkTags())
 		_ = spanMeta.FinishTracing(ctx)
 		return
 	}
 	// Request had an error
-	spanMeta.CountErrorForScope(metrics.FdbOkRequests, err)
+	spanMeta.CountErrorForScope(metrics.FdbOkRequests, spanMeta.GetFdbErrorTags(err))
 	spanMeta.FinishWithError(ctx, err)
 }
 


### PR DESCRIPTION
Fixes panic on inconsistent metrics tags by forcing tags on each tally scope to be always the same. 
* If a tag key is missing, it's filled up with "unknown"
* If there is an extra tag key, it's removed

Added stronger testing to ensure this no longer happens. 