### PR TITLE
feat: authentication related metrics

### DIFF
--- a/server/metrics/auth.go
+++ b/server/metrics/auth.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/uber-go/tally"
+)
+
+var (
+	AuthOkRequests    tally.Scope
+	AuthErrorRequests tally.Scope
+	AuthRespTime      tally.Scope
+)
+
+func getAuthOkTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"env",
+		"service",
+		"version",
+	}
+}
+
+func getAuthTimerTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"env",
+		"service",
+		"version",
+	}
+}
+
+func getAuthErrorTagKeys() []string {
+	return []string{
+		"grpc_method",
+		"env",
+		"service",
+		"version",
+		"error_source",
+		"error_code",
+	}
+}
+
+func GetAuthBaseTags(ctx context.Context) map[string]string {
+	return getGrpcTagsFromContext(ctx)
+}
+
+func initializeAuthScopes() {
+	AuthOkRequests = AuthMetrics.SubScope("count")
+	AuthErrorRequests = AuthMetrics.SubScope("count")
+	AuthRespTime = AuthMetrics.SubScope("response")
+}

--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -83,6 +83,10 @@ func getFdbReqErrorTags(reqMethodName string, code string) map[string]string {
 	}
 }
 
+func GetFdbBaseTags(reqMthodName string) map[string]string {
+	return getFdbReqOkTags(reqMthodName)
+}
+
 func GetFdbOkTags(ctx context.Context, reqMethodName string) map[string]string {
 	return addTigrisTenantToTags(ctx, getFdbReqOkTags(reqMethodName))
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -35,17 +35,23 @@ var (
 	SessionMetrics tally.Scope
 	SizeMetrics    tally.Scope
 	NetworkMetrics tally.Scope
+	AuthMetrics    tally.Scope
 )
 
+func getVersion() string {
+	if util.Version != "" {
+		return util.Version
+	} else {
+		return "dev"
+	}
+}
+
 func GetGlobalTags() map[string]string {
-	res := map[string]string{
+	return map[string]string{
 		"service": util.Service,
 		"env":     config.GetEnvironment(),
+		"version": getVersion(),
 	}
-	if res["version"] = util.Version; res["version"] == "" {
-		res["version"] = "dev"
-	}
-	return res
 }
 
 func InitializeMetrics() io.Closer {
@@ -78,6 +84,8 @@ func InitializeMetrics() io.Closer {
 		// Network netrics
 		NetworkMetrics = root.SubScope("net")
 		initializeNetworkScopes()
+		AuthMetrics = root.SubScope("auth")
+		initializeAuthScopes()
 	}
 	return closer
 }

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -17,9 +17,9 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"github.com/tigrisdata/tigris/server/config"
 	"strings"
 
-	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/request"
 	"github.com/uber-go/tally"
 	"google.golang.org/grpc"

--- a/server/metrics/tags_test.go
+++ b/server/metrics/tags_test.go
@@ -47,15 +47,17 @@ func TestTagsHelpers(t *testing.T) {
 
 	t.Run("Test getTagsForError", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"error_source": "unknown",
-			"error_value":  "unknown",
-		}, getTagsForError(nil))
+			"error_source": "test_source",
+			"error_value":  "none",
+		}, getTagsForError(nil, "test_source"))
 
-		fdbErrTags := getTagsForError(fdb.Error{Code: 1})
+		// For specific errors, the source is ignored
+		fdbErrTags := getTagsForError(fdb.Error{Code: 1}, "ignored_source")
 		assert.Equal(t, "fdb", fdbErrTags["error_source"])
 		assert.Equal(t, "1", fdbErrTags["error_value"])
 
-		tigrisErrTags := getTagsForError(&api.TigrisError{Code: api.Code_NOT_FOUND})
+		// For specific errors, the source is ignored
+		tigrisErrTags := getTagsForError(&api.TigrisError{Code: api.Code_NOT_FOUND}, "ignored_source")
 		assert.Equal(t, "tigris_server", tigrisErrTags["error_source"])
 		assert.Equal(t, "NOT_FOUND", tigrisErrTags["error_value"])
 	})

--- a/server/middleware/tracing.go
+++ b/server/middleware/tracing.go
@@ -47,7 +47,7 @@ func traceUnary() func(ctx context.Context, req interface{}, info *grpc.UnarySer
 		if err != nil {
 			// Request had an error
 			spanMeta.CountErrorForScope(metrics.OkRequests, spanMeta.GetRequestErrorTags(err))
-			spanMeta.FinishWithError(ctx, err)
+			_ = spanMeta.FinishWithError(ctx, "request", err)
 			ulog.E(err)
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func traceStream() grpc.StreamServerInterceptor {
 		err := handler(srv, wrapped)
 		if err != nil {
 			spanMeta.CountErrorForScope(metrics.OkRequests, spanMeta.GetRequestErrorTags(err))
-			spanMeta.FinishWithError(wrapped.WrappedContext, err)
+			wrapped.WrappedContext = spanMeta.FinishWithError(wrapped.WrappedContext, "request", err)
 			ulog.E(err)
 			return err
 		}

--- a/server/services/v1/sessions.go
+++ b/server/services/v1/sessions.go
@@ -61,13 +61,12 @@ type SessionManagerWithMetrics struct {
 }
 
 func (m *SessionManagerWithMetrics) measure(ctx context.Context, name string, f func(ctx context.Context) error) {
-	tags := metrics.GetSessionTags(ctx, name)
-	spanMeta := metrics.NewSpanMeta(metrics.SessionManagerServiceName, name, metrics.SessionSpanType, tags)
-	defer metrics.SessionRespTime.Tagged(spanMeta.GetSessionTimerTags()).Timer("time").Start().Stop()
+	spanMeta := metrics.NewSpanMeta(metrics.SessionManagerServiceName, name, metrics.SessionSpanType, metrics.GetSessionTags(ctx, name))
 	ctx = spanMeta.StartTracing(ctx, true)
+	defer metrics.SessionRespTime.Tagged(spanMeta.GetSessionTimerTags()).Timer("time").Start().Stop()
 	if err := f(ctx); err != nil {
 		spanMeta.CountErrorForScope(metrics.SessionErrorRequests, spanMeta.GetSessionErrorTags(err))
-		spanMeta.FinishWithError(ctx, err)
+		_ = spanMeta.FinishWithError(ctx, "session", err)
 		return
 	}
 	spanMeta.CountOkForScope(metrics.SessionOkRequests, spanMeta.GetSessionOkTags())

--- a/store/search/ts.go
+++ b/store/search/ts.go
@@ -39,8 +39,7 @@ type storeImplWithMetrics struct {
 
 func (m *storeImplWithMetrics) measure(ctx context.Context, name string, f func(ctx context.Context) error) {
 	// Low level measurement wrapper that is called by the measure functions on the appropriate receiver
-	tags := metrics.GetSearchTags(ctx, name)
-	spanMeta := metrics.NewSpanMeta("tigris.search", name, metrics.SearchSpanType, tags)
+	spanMeta := metrics.NewSpanMeta("tigris.search", name, metrics.SearchSpanType, metrics.GetSearchTags(ctx, name))
 	ctx = spanMeta.StartTracing(ctx, true)
 	defer metrics.SearchRespTime.Tagged(spanMeta.GetSearchTimerTags()).Timer("time").Start().Stop()
 	err := f(ctx)
@@ -52,7 +51,7 @@ func (m *storeImplWithMetrics) measure(ctx context.Context, name string, f func(
 	}
 	// Request had error
 	spanMeta.CountErrorForScope(metrics.SearchMetrics, spanMeta.GetSearchErrorTags(err))
-	spanMeta.FinishWithError(ctx, err)
+	_ = spanMeta.FinishWithError(ctx, "search", err)
 }
 
 func (m *storeImplWithMetrics) CreateCollection(ctx context.Context, schema *tsApi.CollectionSchema) (err error) {


### PR DESCRIPTION
Initial take on authentication related metrics.
* Has the grpc_method tag
* Doesn't have tigris_tenant or any other standard tags
* Works even if authentication is turned off and measures the no-op in that case
* It creates tracing spans for authentication, but can't tie it yet to the rest of the spans. Will improve this in the future.

Fixes:
* grpc_method tags were not always propagated to child spans correctly
* on setting some tags (like env, version) only from the standardizing process led to unknown values where the value was actually known, this is fixed