### PR TITLE
fix: Cache access token validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/json-iterator/go v1.1.12
 	github.com/m3db/prometheus_client_golang v1.12.8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,7 @@ github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -40,19 +40,22 @@ type Config struct {
 }
 
 type AuthConfig struct {
-	IssuerURL                string        `mapstructure:"issuer_url" yaml:"issuer_url" json:"issuer_url"`
-	Audience                 string        `mapstructure:"audience" yaml:"audience" json:"audience"`
-	JWKSCacheTimeout         time.Duration `mapstructure:"jwks_cache_timeout" yaml:"jwks_cache_timeout" json:"jwks_cache_timeout"`
-	LogOnly                  bool          `mapstructure:"log_only" yaml:"log_only" json:"log_only"`
-	EnableNamespaceIsolation bool          `mapstructure:"enable_namespace_isolation" yaml:"enable_namespace_isolation" json:"enable_namespace_isolation"`
-	AdminNamespaces          []string      `mapstructure:"admin_namespaces" yaml:"admin_namespaces" json:"admin_namespaces"`
-	OAuthProvider            string        `mapstructure:"oauth_provider" yaml:"oauth_provider" json:"oauth_provider"`
-	ClientId                 string        `mapstructure:"client_id" yaml:"client_id" json:"client_id"`
-	ExternalTokenURL         string        `mapstructure:"external_token_url" yaml:"external_token_url" json:"external_token_url"`
-	EnableOauth              bool          `mapstructure:"enable_oauth" yaml:"enable_oauth" json:"enable_oauth"`
-	Domain                   string        `mapstructure:"external_domain" yaml:"external_domain" json:"external_domain"`
-	ManagementClientId       string        `mapstructure:"management_client_id" yaml:"management_client_id" json:"management_client_id"`
-	ManagementClientSecret   string        `mapstructure:"management_client_secret" yaml:"management_client_secret" json:"management_client_secret"`
+	Enabled                   bool          `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	IssuerURL                 string        `mapstructure:"issuer_url" yaml:"issuer_url" json:"issuer_url"`
+	Audience                  string        `mapstructure:"audience" yaml:"audience" json:"audience"`
+	JWKSCacheTimeout          time.Duration `mapstructure:"jwks_cache_timeout" yaml:"jwks_cache_timeout" json:"jwks_cache_timeout"`
+	LogOnly                   bool          `mapstructure:"log_only" yaml:"log_only" json:"log_only"`
+	EnableNamespaceIsolation  bool          `mapstructure:"enable_namespace_isolation" yaml:"enable_namespace_isolation" json:"enable_namespace_isolation"`
+	AdminNamespaces           []string      `mapstructure:"admin_namespaces" yaml:"admin_namespaces" json:"admin_namespaces"`
+	OAuthProvider             string        `mapstructure:"oauth_provider" yaml:"oauth_provider" json:"oauth_provider"`
+	ClientId                  string        `mapstructure:"client_id" yaml:"client_id" json:"client_id"`
+	ExternalTokenURL          string        `mapstructure:"external_token_url" yaml:"external_token_url" json:"external_token_url"`
+	EnableOauth               bool          `mapstructure:"enable_oauth" yaml:"enable_oauth" json:"enable_oauth"`
+	TokenCacheSize            int           `mapstructure:"token_cache_size" yaml:"token_cache_size" json:"token_cache_size"`
+	ExternalDomain            string        `mapstructure:"external_domain" yaml:"external_domain" json:"external_domain"`
+	ManagementClientId        string        `mapstructure:"management_client_id" yaml:"management_client_id" json:"management_client_id"`
+	ManagementClientSecret    string        `mapstructure:"management_client_secret" yaml:"management_client_secret" json:"management_client_secret"`
+	TokenClockSkewDurationSec int           `mapstructure:"token_clock_skew_duration_sec" yaml:"token_clock_skew_duration_sec" json:"token_clock_skew_duration_sec"`
 }
 
 type CdcConfig struct {
@@ -118,6 +121,7 @@ var DefaultConfig = Config{
 		FDBHardDrop: false,
 	},
 	Auth: AuthConfig{
+		Enabled:          false,
 		IssuerURL:        "https://tigrisdata-dev.us.auth0.com/",
 		Audience:         "https://tigris-api",
 		JWKSCacheTimeout: 5 * time.Minute,

--- a/server/services/v1/auth.go
+++ b/server/services/v1/auth.go
@@ -233,7 +233,7 @@ func (a Auth0) ListApplications(ctx context.Context, _ *api.ListApplicationsRequ
 
 func newAuthService() *authService {
 	if config.DefaultConfig.Auth.OAuthProvider == auth0 {
-		m, err := management.New(config.DefaultConfig.Auth.Domain, management.WithClientCredentials(config.DefaultConfig.Auth.ManagementClientId, config.DefaultConfig.Auth.ManagementClientSecret))
+		m, err := management.New(config.DefaultConfig.Auth.ExternalDomain, management.WithClientCredentials(config.DefaultConfig.Auth.ManagementClientId, config.DefaultConfig.Auth.ManagementClientSecret))
 		if err != nil {
 			if config.DefaultConfig.Auth.EnableOauth {
 				panic("Unable to configure external oauth provider")


### PR DESCRIPTION
- Added one switch that will control if the auth middleware should be invoked or not.
- cache access token for better performance.
- validate expiration after reading from cache.
- TODO: handle key rotation