### PR TITLE
feat: expose go process metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"time"
 
-	prom "github.com/m3db/prometheus_client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/util"
@@ -57,8 +56,7 @@ func GetGlobalTags() map[string]string {
 func InitializeMetrics() io.Closer {
 	var closer io.Closer
 	log.Debug().Msg("Initializing metrics")
-	registry := prom.NewRegistry()
-	Reporter = promreporter.NewReporter(promreporter.Options{Registerer: registry})
+	Reporter = promreporter.NewReporter(promreporter.Options{})
 	root, closer = tally.NewRootScope(tally.ScopeOptions{
 		Tags:           GetGlobalTags(),
 		CachedReporter: Reporter,


### PR DESCRIPTION
Expose go metrics on /metrics.

Example:
```
fdb_response_time_sum{collection="unknown",db="unknown",env="pboros",fdb_method="TableSize",grpc_method="ListDatabases",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="unary",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 0.002893325
fdb_response_time_count{collection="unknown",db="unknown",env="pboros",fdb_method="TableSize",grpc_method="ListDatabases",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="unary",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 6

# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 6.5687e-05
go_gc_duration_seconds{quantile="0.25"} 7.8915e-05
go_gc_duration_seconds{quantile="0.5"} 9.044e-05
go_gc_duration_seconds{quantile="0.75"} 0.000583164
go_gc_duration_seconds{quantile="1"} 0.000583164
go_gc_duration_seconds_sum 0.000818206
go_gc_duration_seconds_count 4
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 22
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.18.2"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 9.7774e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.2843424e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.451466e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 34091
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 5.129104e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 9.7774e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 8.02816e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.2025856e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 24773
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 6.848512e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 2.0054016e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.662643571954543e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 58864
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 19200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 31200
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 221272
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 228480
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.8889568e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.893454e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 917504
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 917504
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.9705224e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 18

# HELP net_bytes_received net_bytes_received counter
# TYPE net_bytes_received counter
net_bytes_received{collection="unknown",db="unknown",env="pboros",grpc_method="ListDatabases",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="unary",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 0
# HELP net_bytes_sent net_bytes_sent counter
# TYPE net_bytes_sent counter
net_bytes_sent{collection="unknown",db="unknown",env="pboros",grpc_method="ListDatabases",grpc_service="tigrisdata.v1.Tigris",grpc_service_type="unary",service="tigris-server",tigris_tenant="default_namespace",version="dev"} 24

```