### PR TITLE
refactor: Consolidated namespace tags parsing

### DIFF
--- a/server/metrics/requests_test.go
+++ b/server/metrics/requests_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/request"
 	"google.golang.org/grpc"
 )
 
@@ -45,32 +46,32 @@ func TestGRPCMetrics(t *testing.T) {
 
 	ctx := context.Background()
 
-	unaryEndPointMetadata := newRequestEndpointMetadata(ctx, svcName, unaryMethodInfo)
-	streamingEndpointMetadata := newRequestEndpointMetadata(ctx, svcName, streamingMethodInfo)
+	unaryEndPointMetadata := request.NewRequestEndpointMetadata(ctx, svcName, unaryMethodInfo)
+	streamingEndpointMetadata := request.NewRequestEndpointMetadata(ctx, svcName, streamingMethodInfo)
 
 	t.Run("Test GetGrpcEndPointMetadataFromFullMethod", func(t *testing.T) {
-		unaryMetadata := GetGrpcEndPointMetadataFromFullMethod(ctx, unaryEndPointMetadata.getFullMethod(), "unary")
+		unaryMetadata := request.GetGrpcEndPointMetadataFromFullMethod(ctx, unaryEndPointMetadata.GetFullMethod(), "unary")
 		assert.Equal(t, unaryMetadata, unaryEndPointMetadata)
 
-		streamMetadata := GetGrpcEndPointMetadataFromFullMethod(ctx, streamingEndpointMetadata.getFullMethod(), "stream")
+		streamMetadata := request.GetGrpcEndPointMetadataFromFullMethod(ctx, streamingEndpointMetadata.GetFullMethod(), "stream")
 		assert.Equal(t, streamMetadata, streamingEndpointMetadata)
 	})
 
 	t.Run("Test full method names", func(t *testing.T) {
-		assert.Equal(t, unaryEndPointMetadata.getFullMethod(), fmt.Sprintf("/%s/%s", svcName, unaryMethodName))
-		assert.Equal(t, streamingEndpointMetadata.getFullMethod(), fmt.Sprintf("/%s/%s", svcName, streamingMethodName))
+		assert.Equal(t, unaryEndPointMetadata.GetFullMethod(), fmt.Sprintf("/%s/%s", svcName, unaryMethodName))
+		assert.Equal(t, streamingEndpointMetadata.GetFullMethod(), fmt.Sprintf("/%s/%s", svcName, streamingMethodName))
 	})
 
 	t.Run("Test unary endpoint metadata", func(t *testing.T) {
-		assert.Equal(t, unaryEndPointMetadata.serviceName, svcName)
-		assert.Equal(t, unaryEndPointMetadata.methodInfo.Name, unaryMethodName)
-		assert.False(t, unaryEndPointMetadata.methodInfo.IsServerStream)
+		assert.Equal(t, unaryEndPointMetadata.GetServiceName(), svcName)
+		assert.Equal(t, unaryEndPointMetadata.GetMethodInfo().Name, unaryMethodName)
+		assert.False(t, unaryEndPointMetadata.GetMethodInfo().IsServerStream)
 	})
 
 	t.Run("Test streaming endpoint metadata", func(t *testing.T) {
-		assert.Equal(t, streamingEndpointMetadata.serviceName, svcName)
-		assert.Equal(t, streamingEndpointMetadata.methodInfo.Name, streamingMethodName)
-		assert.True(t, streamingEndpointMetadata.methodInfo.IsServerStream)
+		assert.Equal(t, streamingEndpointMetadata.GetServiceName(), svcName)
+		assert.Equal(t, streamingEndpointMetadata.GetMethodInfo().Name, streamingMethodName)
+		assert.True(t, streamingEndpointMetadata.GetMethodInfo().IsServerStream)
 	})
 
 	t.Run("Test unary method preinitialized tags", func(t *testing.T) {

--- a/server/middleware/tracing.go
+++ b/server/middleware/tracing.go
@@ -17,6 +17,7 @@ package middleware
 import (
 	"context"
 
+	"github.com/tigrisdata/tigris/server/request"
 	"github.com/tigrisdata/tigris/util"
 
 	"google.golang.org/protobuf/proto"
@@ -57,8 +58,9 @@ func traceUnary() func(ctx context.Context, req interface{}, info *grpc.UnarySer
 			resp, err := handler(ctx, req)
 			return resp, err
 		}
-		grpcMeta := metrics.GetGrpcEndPointMetadataFromFullMethod(ctx, info.FullMethod, "unary")
-		tags := grpcMeta.GetInitialTags()
+		reqMetadata := request.GetGrpcEndPointMetadataFromFullMethod(ctx, info.FullMethod, "unary")
+		ctx = request.SetRequestMetadata(ctx, reqMetadata)
+		tags := reqMetadata.GetInitialTags()
 		spanMeta := metrics.NewSpanMeta(util.Service, info.FullMethod, metrics.GrpcSpanType, tags)
 		spanMeta.AddTags(metrics.GetDbCollTagsForReq(req))
 		defer metrics.RequestsRespTime.Tagged(spanMeta.GetRequestTimerTags()).Timer("time").Start().Stop()
@@ -88,8 +90,9 @@ func traceStream() grpc.StreamServerInterceptor {
 			err := handler(srv, wrapped)
 			return err
 		}
-		grpcMeta := metrics.GetGrpcEndPointMetadataFromFullMethod(wrapped.WrappedContext, info.FullMethod, "stream")
-		tags := grpcMeta.GetInitialTags()
+		reqMetadata := request.GetGrpcEndPointMetadataFromFullMethod(wrapped.WrappedContext, info.FullMethod, "stream")
+		wrapped.WrappedContext = request.SetRequestMetadata(wrapped.WrappedContext, reqMetadata)
+		tags := reqMetadata.GetInitialTags()
 		spanMeta := metrics.NewSpanMeta(util.Service, info.FullMethod, metrics.GrpcSpanType, tags)
 		defer metrics.RequestsRespTime.Tagged(spanMeta.GetRequestTimerTags()).Timer("time").Start().Stop()
 		wrapped.spanMeta = spanMeta

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -16,11 +16,14 @@ package request
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
 	"github.com/buger/jsonparser"
+	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/server/config"
+	"google.golang.org/grpc"
 
 	api "github.com/tigrisdata/tigris/api/server/v1"
 )
@@ -47,7 +50,77 @@ type AccessToken struct {
 
 type RequestMetadata struct {
 	accessToken *AccessToken
-	namespace   string
+	serviceName string
+	methodInfo  grpc.MethodInfo
+	// this is authenticated namespace
+	namespace string
+	// this is parsed and set early in request processing chain - before it is authenticated for observability.
+	unauthenticatedNamespaceName string
+}
+
+func NewRequestEndpointMetadata(ctx context.Context, serviceName string, methodInfo grpc.MethodInfo) RequestMetadata {
+	return RequestMetadata{serviceName: serviceName, methodInfo: methodInfo, unauthenticatedNamespaceName: GetNameSpaceFromHeader(ctx)}
+}
+
+func GetGrpcEndPointMetadataFromFullMethod(ctx context.Context, fullMethod string, methodType string) RequestMetadata {
+	var methodInfo grpc.MethodInfo
+	methodList := strings.Split(fullMethod, "/")
+	svcName := methodList[1]
+	methodName := methodList[2]
+	if methodType == "unary" {
+		methodInfo = grpc.MethodInfo{
+			Name:           methodName,
+			IsClientStream: false,
+			IsServerStream: false,
+		}
+	} else if methodType == "stream" {
+		methodInfo = grpc.MethodInfo{
+			Name:           methodName,
+			IsClientStream: false,
+			IsServerStream: true,
+		}
+	}
+	return NewRequestEndpointMetadata(ctx, svcName, methodInfo)
+}
+
+func (r *RequestMetadata) GetMethodName() string {
+	return strings.Split(r.methodInfo.Name, "/")[2]
+}
+
+func (r *RequestMetadata) GetServiceType() string {
+	if r.methodInfo.IsServerStream {
+		return "stream"
+	} else {
+		return "unary"
+	}
+}
+
+func (r *RequestMetadata) GetServiceName() string {
+	return r.serviceName
+}
+
+func (r *RequestMetadata) GetUnAuthenticatedNamespaceName() string {
+	return r.unauthenticatedNamespaceName
+}
+
+func (r *RequestMetadata) GetMethodInfo() grpc.MethodInfo {
+	return r.methodInfo
+}
+
+func (r *RequestMetadata) GetInitialTags() map[string]string {
+	return map[string]string{
+		"grpc_method":       r.methodInfo.Name,
+		"grpc_service":      r.serviceName,
+		"tigris_tenant":     r.unauthenticatedNamespaceName,
+		"grpc_service_type": r.GetServiceType(),
+		"env":               config.GetEnvironment(),
+		"db":                UnknownValue,
+		"collection":        UnknownValue,
+	}
+}
+
+func (r *RequestMetadata) GetFullMethod() string {
+	return fmt.Sprintf("/%s/%s", r.serviceName, r.methodInfo.Name)
 }
 
 // NamespaceExtractor - extract the namespace from context
@@ -69,6 +142,15 @@ func GetRequestMetadata(ctx context.Context) (*RequestMetadata, error) {
 		}
 	}
 	return nil, api.Errorf(api.Code_NOT_FOUND, "RequestMetadata not found")
+}
+
+func SetRequestMetadata(ctx context.Context, metadata RequestMetadata) context.Context {
+	requestMetadata, err := GetRequestMetadata(ctx)
+	if err == nil && requestMetadata != nil {
+		log.Debug().Msg("Overriding RequestMetadata in context")
+	}
+	requestMetadata = &metadata
+	return context.WithValue(ctx, RequestMetadataCtxKey{}, requestMetadata)
 }
 
 func SetAccessToken(ctx context.Context, token *AccessToken) context.Context {
@@ -136,16 +218,26 @@ func IsAdminApi(fullMethodName string) bool {
 	return strings.HasPrefix(fullMethodName, "/tigrisdata.admin.v1.Admin/")
 }
 
-func getTokenFromHeader(header string) ([]byte, error) {
+func getTokenFromHeader(header string) (string, error) {
 	splits := strings.SplitN(header, " ", 2)
 	if len(splits) < 2 {
-		return nil, fmt.Errorf("could not find token in header")
+		return "", fmt.Errorf("could not find token in header")
 	}
-	return []byte(splits[1]), nil
+	return splits[1], nil
 }
 
-func getNameSpaceFromToken(token []byte) string {
-	namespace, err := jsonparser.GetString(token, "https://tigris/n", "code")
+func getNameSpaceFromToken(token string) string {
+	tokenParts := strings.SplitN(token, ".", 3)
+	if len(tokenParts) < 3 {
+		log.Debug().Msg("Could not split the token into its parts")
+		return UnknownValue
+	}
+	decodedToken, err := base64.RawStdEncoding.DecodeString(tokenParts[1])
+	if err != nil {
+		log.Debug().Err(err).Msg("Could not base64 decode token")
+		return UnknownValue
+	}
+	namespace, err := jsonparser.GetString(decodedToken, "https://tigris/n", "code")
 	if err != nil {
 		return UnknownValue
 	}

--- a/server/request/request_test.go
+++ b/server/request/request_test.go
@@ -76,22 +76,8 @@ func TestRequestMetadata(t *testing.T) {
 	})
 
 	t.Run("Test get namespace from token", func(t *testing.T) {
-		testToken := "{\n" +
-			"  \"https://tigris/u\": {\n" +
-			"    \"email\": \"testemail@domain.com\"\n" +
-			"  },\n  \"https://tigris/n\": {\n" +
-			"    \"code\": \"test-tenant\"\n  },\n" +
-			"  \"iss\": \"https://fake.url.com/\",\n" +
-			"  \"sub\": \"google-oauth2|12345678\",\n" +
-			"  \"aud\": [\n" +
-			"    \"https://some-fake-url\",\n" +
-			"    \"https://some-fake-url.com/userinfo\"\n" +
-			"  ],\n  \"iat\": 1662396960,\n" +
-			"  \"exp\": 1662483360,\n" +
-			"  \"azp\": \"foobar\",\n" +
-			"  \"scope\": \"openid profile email\",\n" +
-			"  \"org_id\": \"org_fake\"\n" +
-			"}"
-		assert.Equal(t, "test-tenant", getNameSpaceFromToken([]byte(testToken)))
+		// base64 encoding of {"https://tigris/u":{"email":"test@tigrisdata.com"},"https://tigris/n":{"code":"test-namespace"},"iss":"https://test-issuer.com/","sub":"google-oauth2|1","aud":["https://tigris-api-test"],"iat":1662745495,"exp":1662831895,"azp":"test","scope":"openid profile email","org_id":"test"}
+		testToken := "header.eyJodHRwczovL3RpZ3Jpcy91Ijp7ImVtYWlsIjoidGVzdEB0aWdyaXNkYXRhLmNvbSJ9LCJodHRwczovL3RpZ3Jpcy9uIjp7ImNvZGUiOiJ0ZXN0LW5hbWVzcGFjZSJ9LCJpc3MiOiJodHRwczovL3Rlc3QtaXNzdWVyLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDEiLCJhdWQiOlsiaHR0cHM6Ly90aWdyaXMtYXBpLXRlc3QiXSwiaWF0IjoxNjYyNzQ1NDk1LCJleHAiOjE2NjI4MzE4OTUsImF6cCI6InRlc3QiLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIiwib3JnX2lkIjoidGVzdCJ9.signature"
+		assert.Equal(t, "test-namespace", getNameSpaceFromToken(testToken))
 	})
 }


### PR DESCRIPTION
- consolidated RequestMetadata & RequestEndpointMetadata into RequestMetadata.
- fixed the tenant name parsing prior to authentication.
- reduced logging level to avoid flooding in case of unauthenticated requests.