### PR TITLE
feat: Support case sensitive/insensitive collation in filters

### DIFF
--- a/query/expression/expression.go
+++ b/query/expression/expression.go
@@ -35,7 +35,7 @@ func Unmarshal(input jsoniter.RawMessage, objCb func(jsoniter.RawMessage) (Expr,
 
 	switch next {
 	case jsoniter.StringValue:
-		return value.NewStringValue(iter.ReadString()), nil
+		return value.NewStringValue(iter.ReadString(), nil), nil
 	case jsoniter.NumberValue:
 		number := iter.ReadNumber()
 		if i, err := number.Int64(); err == nil {

--- a/query/expression/expression_test.go
+++ b/query/expression/expression_test.go
@@ -15,9 +15,10 @@
 package expression
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/value"
-	"testing"
 )
 
 func TestExpression(t *testing.T) {
@@ -26,9 +27,9 @@ func TestExpression(t *testing.T) {
 	listExpr, ok := expr.([]Expr)
 	require.True(t, ok)
 	require.Equal(t, 5, len(listExpr))
-	require.Equal(t, "$foo", string(*listExpr[0].(value.Value).(*value.StringValue)))
-	require.Equal(t, "bar", string(*listExpr[1].(value.Value).(*value.StringValue)))
+	require.Equal(t, "$foo", listExpr[0].(value.Value).(*value.StringValue).Value)
+	require.Equal(t, "bar", listExpr[1].(value.Value).(*value.StringValue).Value)
 	require.Equal(t, int64(1), int64(*listExpr[2].(value.Value).(*value.IntValue)))
-	require.Equal(t, float64(1.01), listExpr[3].(value.Value).(*value.DoubleValue).Double)
+	require.Equal(t, 1.01, listExpr[3].(value.Value).(*value.DoubleValue).Double)
 	require.Equal(t, false, bool(*listExpr[4].(value.Value).(*value.BoolValue)))
 }

--- a/query/filter/comparison.go
+++ b/query/filter/comparison.go
@@ -103,12 +103,6 @@ type GreaterThanMatcher struct {
 	Value value.Value
 }
 
-func NewGreaterThanMatcher(v value.Value) *GreaterThanMatcher {
-	return &GreaterThanMatcher{
-		Value: v,
-	}
-}
-
 func (g *GreaterThanMatcher) GetValue() value.Value {
 	return g.Value
 }

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -128,3 +128,20 @@ func TestFilterDuplicateKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, filters)
 }
+
+func TestFiltersWithCollation(t *testing.T) {
+	var factory = Factory{
+		fields: []*schema.QueryableField{
+			{FieldName: "a", DataType: schema.Int64Type},
+			{FieldName: "b", DataType: schema.Int64Type},
+			{FieldName: "c", DataType: schema.StringType},
+		},
+	}
+	filters, err := factory.Factorize([]byte(`{"a": 10, "b": {"$gt": 10}, "c": {"$eq": "hello"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, filters)
+
+	filters, err = factory.Factorize([]byte(`{"a": 10, "b": {"$gt": 10}, "c": {"$eq": "hello", "collation": {"case": "ci"}}}`))
+	require.NoError(t, err)
+	require.NotNil(t, filters)
+}

--- a/schema/collation.go
+++ b/schema/collation.go
@@ -1,0 +1,48 @@
+package schema
+
+import api "github.com/tigrisdata/tigris/api/server/v1"
+
+const CollationKey string = "collation"
+
+type CollationType uint8
+
+const (
+	Undefined CollationType = iota
+	CaseInsensitive
+	CaseSensitive
+)
+
+var SupportedCollations = [...]string{
+	CaseInsensitive: "ci",
+	CaseSensitive:   "cs",
+}
+
+func ToCollationType(userCollation string) CollationType {
+	for ct, cs := range SupportedCollations {
+		if cs == userCollation {
+			return CollationType(ct)
+		}
+	}
+
+	return Undefined
+}
+
+type Collation struct {
+	Case string `json:"case,omitempty"`
+}
+
+func (c *Collation) IsCaseSensitive() bool {
+	return c.Case == SupportedCollations[CaseSensitive]
+}
+
+func (c *Collation) IsCaseInsensitive() bool {
+	return c.Case == SupportedCollations[CaseInsensitive]
+}
+
+func (c *Collation) IsValid() error {
+	if caseType := ToCollationType(c.Case); caseType == Undefined {
+		return api.Errorf(api.Code_INVALID_ARGUMENT, "collation %s is not supported", c.Case)
+	}
+
+	return nil
+}

--- a/server/services/v1/key_generator.go
+++ b/server/services/v1/key_generator.go
@@ -153,16 +153,16 @@ func isNull(tp schema.FieldType, val []byte) bool {
 func (k *keyGenerator) get(ctx context.Context, txMgr *transaction.Manager, table []byte, field *schema.Field) ([]byte, value.Value, error) {
 	switch field.Type() {
 	case schema.StringType, schema.UUIDType:
-		value := value.NewStringValue(uuid.NewUUIDAsString())
-		return []byte(*value), value, nil
+		value := value.NewStringValue(uuid.NewUUIDAsString(), nil)
+		return []byte(value.Value), value, nil
 	case schema.ByteType:
 		value := value.NewBytesValue([]byte(uuid.NewUUIDAsString()))
 		b64 := base64.StdEncoding.EncodeToString([]byte(*value))
 		return []byte(b64), value, nil
 	case schema.DateTimeType:
 		// use timestamp nano to reduce the contention if multiple workers end up generating same timestamp.
-		value := value.NewStringValue(time.Now().UTC().Format(time.RFC3339Nano))
-		return []byte(*value), value, nil
+		value := value.NewStringValue(time.Now().UTC().Format(time.RFC3339Nano), nil)
+		return []byte(value.Value), value, nil
 	case schema.Int64Type:
 		// use timestamp nano to reduce the contention if multiple workers end up generating same timestamp.
 		value := value.NewIntValue(time.Now().UTC().UnixNano())

--- a/value/value_test.go
+++ b/value/value_test.go
@@ -50,7 +50,7 @@ func TestNewValue(t *testing.T) {
 		}, {
 			schema.StringType,
 			[]byte(`foo`),
-			NewStringValue("foo"),
+			NewStringValue("foo", nil),
 			nil,
 		}, {
 			// we decode byte type because it was encoded to base64 by JSON encoding.
@@ -107,7 +107,7 @@ func TestValue(t *testing.T) {
 		require.Equal(t, -2, r)
 	})
 	t.Run("string", func(t *testing.T) {
-		i := StringValue("abc")
+		i := NewStringValue("abc", nil)
 
 		v, err := NewValue(schema.StringType, []byte(`abc`))
 		require.NoError(t, err)


### PR DESCRIPTION
The filters now allow passing a collation to allow case-insensitive queries like the below syntax. 

`{
	"filter": {
		"string_value": {
			"$eq": "UPPer",
			"collation": {
				"case": "ci"
			}
		}
	}
}`