### PR TITLE
fix: unauthenticated namespace available regardless of tracing

### DIFF
--- a/server/metrics/tags.go
+++ b/server/metrics/tags.go
@@ -88,9 +88,16 @@ func getTagsForError(err error, source string) map[string]string {
 			"error_value":  "none",
 		}
 	}
+
+	genericErrorValue := err.Error()
+	// Don't capture the full stack trace as a tag for a panic, just the error message
+	if strings.HasPrefix(genericErrorValue, "panic") {
+		genericErrorValue = strings.Split(genericErrorValue, "\n")[0]
+	}
+
 	return map[string]string{
 		"error_source": source,
-		"error_value":  err.Error(),
+		"error_value":  genericErrorValue,
 	}
 }
 

--- a/server/metrics/tracing.go
+++ b/server/metrics/tracing.go
@@ -44,7 +44,6 @@ type SpanMeta struct {
 	tags         map[string]string
 	span         tracer.Span
 	parent       *SpanMeta
-	stopwatch    *tally.Stopwatch
 }
 
 type SpanMetaCtxKey struct {
@@ -69,25 +68,6 @@ func (s *SpanMeta) CountOkForScope(scope tally.Scope, tags map[string]string) {
 
 func (s *SpanMeta) CountErrorForScope(scope tally.Scope, tags map[string]string) {
 	scope.Tagged(tags).Counter("error").Inc(1)
-}
-
-func (s *SpanMeta) StartTimer(scope tally.Scope) error {
-	if s.stopwatch != nil {
-		return fmt.Errorf("programming error: timer already started")
-	}
-	timer := scope.Tagged(s.tags).Timer("time")
-	stopwatch := timer.Start()
-	s.stopwatch = &stopwatch
-	return nil
-}
-
-func (s *SpanMeta) StopTimer() error {
-	if s.stopwatch == nil {
-		return fmt.Errorf("programming error: no timer running")
-	}
-	s.stopwatch.Stop()
-	s.stopwatch = nil
-	return nil
 }
 
 func (s *SpanMeta) GetServiceName() string {

--- a/server/middleware/metadata_extractor.go
+++ b/server/middleware/metadata_extractor.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	"github.com/tigrisdata/tigris/server/request"
+	"google.golang.org/grpc"
+)
+
+func metadataExtractorUnary() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		reqMetadata := request.GetGrpcEndPointMetadataFromFullMethod(ctx, info.FullMethod, "unary")
+		ctx = request.SetRequestMetadata(ctx, reqMetadata)
+		resp, err := handler(ctx, req)
+		return resp, err
+	}
+}
+
+func metadataExtractorStream() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapped := &wrappedStream{WrappedServerStream: middleware.WrapServerStream(stream)}
+		wrapped.WrappedContext = stream.Context()
+		reqMetadata := request.GetGrpcEndPointMetadataFromFullMethod(wrapped.WrappedContext, info.FullMethod, "stream")
+		wrapped.WrappedContext = request.SetRequestMetadata(wrapped.WrappedContext, reqMetadata)
+		err := handler(srv, wrapped)
+		return err
+	}
+}

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -78,7 +78,9 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 		Logger()
 
 	// The order of the interceptors matter with optional elements in them
-	var streamInterceptors []grpc.StreamServerInterceptor
+	streamInterceptors := []grpc.StreamServerInterceptor{
+		metadataExtractorStream(),
+	}
 
 	if config.Tracing.Enabled {
 		streamInterceptors = append(streamInterceptors, traceStream())
@@ -106,7 +108,9 @@ func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transa
 	// error which is not convertible to the internal rest error code.
 
 	// The order of the interceptors matter with optional elements in them
-	var unaryInterceptors []grpc.UnaryServerInterceptor
+	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		metadataExtractorUnary(),
+	}
 
 	if config.Tracing.Enabled {
 		unaryInterceptors = append(unaryInterceptors, traceUnary())

--- a/server/quota/quota.go
+++ b/server/quota/quota.go
@@ -19,6 +19,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
+	"github.com/tigrisdata/tigris/server/request"
+
 	"github.com/tigrisdata/tigris/schema"
 
 	ulog "github.com/tigrisdata/tigris/util/log"
@@ -74,6 +78,17 @@ func Allow(ctx context.Context, namespace string, reqSize int) error {
 
 	if !config.DefaultConfig.Quota.Enabled {
 		return nil
+	}
+
+	if namespace == request.UnknownValue {
+		method := request.UnknownValue
+		reqMetadata, err := request.GetRequestMetadata(ctx)
+		if err != nil {
+			ulog.E(err)
+		} else {
+			method = reqMetadata.GetFullMethod()
+		}
+		log.Info().Str("namespace", namespace).Str("fullMethod", method).Msg("Invalid request received")
 	}
 
 	return mgr.check(ctx, namespace, reqSize)


### PR DESCRIPTION
* On panic, the full stack trace can to to the error tag, cutting that after the first newline
* The SendMsg and ReceiveMsg are present on the streams regardless if the interceptors are present, so they should not expect values populated by the interceptor
* More logging in quota in case of unknown tenant 
* Move namespace name extraction before authentication to it's own interceptor, so it's not dependent on tracing