### PR TITLE
refactor: merge and sort facets for multi-search

### DIFF
--- a/lib/container/priority_queue.go
+++ b/lib/container/priority_queue.go
@@ -54,13 +54,12 @@ func (pq *PriorityQueue[T]) Pop() (*T, error) {
 
 // Push pushes the element x onto the heap.
 // The complexity is O(log n) where n = h.Len().
-func (pq *PriorityQueue[T]) Push(x *T) error {
+func (pq *PriorityQueue[T]) Push(x *T) {
 	// Copy the item value(s) so that modifications to the source item does not
 	// affect the item on the queue
 	clone := *x
 
 	heap.Push(&pq.queue, &clone)
-	return nil
 }
 
 // queue is the internal data structure used to satisfy heap.Interface and not

--- a/lib/container/priority_queue_test.go
+++ b/lib/container/priority_queue_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package container
 
 import (

--- a/lib/container/priority_queue_test.go
+++ b/lib/container/priority_queue_test.go
@@ -27,8 +27,7 @@ func TestPriorityQueue(t *testing.T) {
 		})
 
 		for _, doc := range documents {
-			err := pq.Push(&doc)
-			assert.NoError(t, err)
+			pq.Push(&doc)
 		}
 
 		expectedOrder := []int{1, 2, 3, 4, 5}
@@ -45,8 +44,7 @@ func TestPriorityQueue(t *testing.T) {
 		})
 
 		for _, doc := range documents {
-			err := pq.Push(&doc)
-			assert.NoError(t, err)
+			pq.Push(&doc)
 		}
 
 		expectedOrder := []int{5, 4, 3, 2, 1}
@@ -71,7 +69,7 @@ func TestPriorityQueue(t *testing.T) {
 			return this.Priority > that.Priority
 		})
 		assert.Equal(t, pq.Len(), 0)
-		_ = pq.Push(&documents[0])
+		pq.Push(&documents[0])
 		assert.Equal(t, pq.Len(), 1)
 		_, _ = pq.Pop()
 		assert.Equal(t, pq.Len(), 0)

--- a/server/search/facets.go
+++ b/server/search/facets.go
@@ -1,0 +1,191 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/lib/container"
+	tsApi "github.com/typesense/typesense-go/typesense/api"
+	"github.com/pkg/errors"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+)
+
+type SortedFacets struct {
+	counts     map[string]*container.PriorityQueue[FacetCount]
+	facetAttrs map[string]*FacetAttrs
+	sorted     bool
+}
+
+func NewSortedFacets() *SortedFacets {
+	return &SortedFacets{
+		counts:     map[string]*container.PriorityQueue[FacetCount]{},
+		facetAttrs: map[string]*FacetAttrs{},
+		sorted:     false,
+	}
+}
+
+func (f *SortedFacets) Add(tsCounts *tsApi.FacetCounts) error {
+	if tsCounts == nil || tsCounts.FieldName == nil {
+		return nil
+	}
+	if f.sorted {
+		return errors.New("Already initialized and sorted. No more inserts.")
+	}
+
+	if _, ok := f.facetAttrs[*tsCounts.FieldName]; !ok {
+		f.facetAttrs[*tsCounts.FieldName] = newFacetAttrs()
+	}
+	attrs := f.facetAttrs[*tsCounts.FieldName]
+
+	for i := 0; tsCounts.Counts != nil && i < len(*tsCounts.Counts); i++ {
+		c := (*tsCounts.Counts)[i]
+		if c.Value != nil {
+			attrs.addCount(*c.Value, c.Count)
+		}
+	}
+
+	attrs.addStats(tsCounts)
+	return nil
+}
+
+func (f *SortedFacets) GetFacetCount(field string) (*FacetCount, bool) {
+	if !f.sorted {
+		f.sort()
+	}
+	if f.hasMoreFacets(field) {
+		if fc, err := f.counts[field].Pop(); err == nil {
+			return fc, true
+		} else {
+			log.Err(err)
+			return nil, false
+		}
+	}
+
+	return nil, false
+}
+
+func (f *SortedFacets) GetStats(field string) *api.FacetStats {
+	if attrs, ok := f.facetAttrs[field]; ok {
+		return attrs.stats
+	} else {
+		return nil
+	}
+}
+
+func (f *SortedFacets) hasMoreFacets(field string) bool {
+	if q, ok := f.counts[field]; ok {
+		return q.Len() > 0
+	}
+	return false
+}
+
+func (f *SortedFacets) initPriorityQueue(field string) {
+	if _, ok := f.counts[field]; !ok {
+		f.counts[field] = container.NewPriorityQueue[FacetCount](facetCountComparator)
+	}
+}
+
+func (f *SortedFacets) sort() {
+	if f.sorted {
+		return
+	}
+
+	for field, attrs := range f.facetAttrs {
+		f.initPriorityQueue(field)
+		for _, fc := range attrs.counts {
+			if err := f.counts[field].Push(fc); err != nil {
+				log.Err(err)
+			}
+		}
+	}
+	f.sorted = true
+}
+
+type FacetAttrs struct {
+	counts         map[string]*FacetCount
+	stats          *api.FacetStats
+	statsBuiltOnce bool
+}
+
+func (fa *FacetAttrs) addCount(value string, count *int) {
+	if fc, ok := fa.counts[value]; ok {
+		fc.Count += int64(*count)
+	} else {
+		fa.counts[value] = &FacetCount{
+			Value: value,
+			Count: int64(*count),
+		}
+	}
+}
+
+func (fa *FacetAttrs) addStats(counts *tsApi.FacetCounts) {
+	if counts == nil || counts.Stats == nil {
+		return
+	}
+
+	// always sum the counts
+	if counts.Stats.TotalValues != nil {
+		fa.stats.Count += int64(*counts.Stats.TotalValues)
+	}
+
+	// reset all stats to nil as the computation could be incorrect
+	if fa.statsBuiltOnce {
+		fa.stats.Avg = nil
+		fa.stats.Min = nil
+		fa.stats.Max = nil
+		fa.stats.Sum = nil
+	} else {
+		// build stats
+		if counts.Stats.Avg != nil {
+			avg := float64(*counts.Stats.Avg)
+			fa.stats.Avg = &avg
+		}
+		if counts.Stats.Max != nil {
+			max := float64(*counts.Stats.Max)
+			fa.stats.Max = &max
+		}
+		if counts.Stats.Min != nil {
+			min := float64(*counts.Stats.Min)
+			fa.stats.Min = &min
+		}
+		if counts.Stats.Sum != nil {
+			sum := float64(*counts.Stats.Sum)
+			fa.stats.Sum = &sum
+		}
+		fa.statsBuiltOnce = true
+	}
+}
+
+func newFacetAttrs() *FacetAttrs {
+	return &FacetAttrs{
+		counts: map[string]*FacetCount{},
+		stats:  &api.FacetStats{},
+	}
+}
+
+type FacetCount struct {
+	Value string
+	Count int64
+}
+
+func facetCountComparator(this, that *FacetCount) bool {
+	if this == nil {
+		return that == nil
+	} else if that == nil {
+		return this != nil
+	}
+
+	return this.Count > that.Count
+}

--- a/server/search/facets_test.go
+++ b/server/search/facets_test.go
@@ -1,0 +1,142 @@
+package search
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	tsApi "github.com/typesense/typesense-go/typesense/api"
+	"encoding/json"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+)
+
+func TestFacetCountComparator(t *testing.T) {
+	testCases := []struct {
+		name     string
+		this     *FacetCount
+		that     *FacetCount
+		expected bool
+	}{
+		{
+			"both values nil", nil, nil, true,
+		},
+		{
+			"this is nil", nil, &FacetCount{"that", 20}, false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, facetCountComparator(tc.this, tc.that))
+		})
+	}
+}
+
+func TestSortedFacets(t *testing.T) {
+
+	t.Run("Retrieves facet counts in a descending order", func(t *testing.T) {
+		var tsCounts tsApi.FacetCounts
+		facets := NewSortedFacets()
+
+		inputData := [][]byte{
+			[]byte(`{"field_name":"field_1","counts":[{"count":20,"value":"value_1"},{"count":30,"value":"value_2"},{"count":10,"value":null}]}`),
+			[]byte(`{"field_name":"field_2","counts":[{"count":14,"value":"value_1"},{"count":12,"value":"value_2"}]}`),
+			[]byte(`{"field_name":null,"counts":[{"count":20,"value":"value_1"},{"count":30,"value":"value_2"},{"count":10,"value":null}]}`),
+			[]byte(`{"field_name":"field_1","counts":[{"count":20,"value":"value_1"},{"count":30,"value":"value_2"},{"count":10,"value":null},{"count":10,"value":"value_3"}]}`),
+		}
+
+		for _, data := range inputData {
+			err := json.Unmarshal(data, &tsCounts)
+			assert.NoError(t, err)
+			_ = facets.Add(&tsCounts)
+		}
+
+		expectedField1Order := []FacetCount{
+			{"value_2", int64(60)},
+			{"value_1", int64(40)},
+			{"value_3", int64(10)},
+		}
+
+		for _, o := range expectedField1Order {
+			fc, _ := facets.GetFacetCount("field_1")
+			assert.Equal(t, o, *fc)
+		}
+
+		fc, hasMore := facets.GetFacetCount("field_1")
+		assert.Nil(t, fc)
+		assert.False(t, hasMore)
+
+		expectedField2Order := []FacetCount{
+			{"value_1", int64(14)},
+			{"value_2", int64(12)},
+		}
+		for _, o := range expectedField2Order {
+			fc, _ := facets.GetFacetCount("field_2")
+			assert.Equal(t, o, *fc)
+		}
+		fc, hasMore = facets.GetFacetCount("field_2")
+		assert.Nil(t, fc)
+		assert.False(t, hasMore)
+	})
+
+	t.Run("add nil facet counts", func(t *testing.T) {
+		facets := NewSortedFacets()
+		err := facets.Add(nil)
+		assert.NoError(t, err)
+		assert.Empty(t, facets.facetAttrs)
+	})
+
+	t.Run("facet count with nil field name", func(t *testing.T) {
+		facets := NewSortedFacets()
+		tsCounts := &tsApi.FacetCounts{FieldName: nil}
+		err := facets.Add(tsCounts)
+		assert.NoError(t, err)
+		assert.Empty(t, facets.facetAttrs)
+	})
+
+	t.Run("facet count with nil values only", func(t *testing.T) {
+		field1 := "field_1"
+		tsCounts := &tsApi.FacetCounts{FieldName: &field1}
+		facets := NewSortedFacets()
+		err := facets.Add(tsCounts)
+		assert.NoError(t, err)
+		assert.Empty(t, facets.facetAttrs[field1].counts)
+	})
+
+	t.Run("build facet stats", func(t *testing.T) {
+		facets := NewSortedFacets()
+
+		inputData := [][]byte{
+			[]byte(`{"field_name":"field_1", "stats": {"total_values": 2, "avg": 10, "max": 20.21, "min": -30, "sum": 50}}`),
+			[]byte(`{"field_name":"field_2", "stats": {"total_values": 64, "avg": 10.56, "min": -30.50}}`),
+			[]byte(`{"field_name":"field_3", "stats": null}`),
+			[]byte(`{"field_name":"field_1", "stats": {"total_values": 128, "avg": 10, "max": 20, "min": -10.34, "sum": 50}}`),
+		}
+
+		for _, data := range inputData {
+			var tsCounts tsApi.FacetCounts
+			err := json.Unmarshal(data, &tsCounts)
+			assert.NoError(t, err)
+
+			err = facets.Add(&tsCounts)
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, &api.FacetStats{Count: 130}, facets.GetStats("field_1"))
+		f2Avg, f2Min := float64(float32(10.56)), -30.5
+		assert.Equal(t, &api.FacetStats{Avg: &f2Avg, Min: &f2Min, Count: 64}, facets.GetStats("field_2"))
+		assert.Equal(t, &api.FacetStats{Count: 0}, facets.GetStats("field_3"))
+	})
+
+	t.Run("Cannot insert once sorted", func(t *testing.T) {
+		var tsCounts tsApi.FacetCounts
+		data := []byte(`{"field_name":"field_2","counts":[{"count":14,"value":"value_1"},{"count":12,"value":"value_2"}]}`)
+		err := json.Unmarshal(data, &tsCounts)
+		assert.NoError(t, err)
+
+		facets := NewSortedFacets()
+		err = facets.Add(&tsCounts)
+		assert.NoError(t, err)
+
+		_, _ = facets.GetFacetCount("field_2")
+		err = facets.Add(&tsCounts)
+		assert.ErrorContains(t, err, "Already initialized and sorted")
+	})
+}

--- a/server/search/facets_test.go
+++ b/server/search/facets_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (

--- a/server/search/facets_test.go
+++ b/server/search/facets_test.go
@@ -15,11 +15,12 @@
 package search
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
-	tsApi "github.com/typesense/typesense-go/typesense/api"
 	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	api "github.com/tigrisdata/tigris/api/server/v1"
+	tsApi "github.com/typesense/typesense-go/typesense/api"
 )
 
 func TestFacetCountComparator(t *testing.T) {

--- a/server/search/hits.go
+++ b/server/search/hits.go
@@ -64,11 +64,10 @@ func NewSortedHits(sortingOrder *sort.Ordering) SortedHits {
 	}
 }
 
-func (s *SortedHits) Add(hit *Hit) error {
-	if hit == nil || hit.Document == nil {
-		return nil
+func (s *SortedHits) Add(hit *Hit) {
+	if hit != nil || hit.Document != nil {
+		s.hits.Push(hit)
 	}
-	return s.hits.Push(hit)
 }
 
 func (s *SortedHits) Get() (*Hit, error) {

--- a/server/search/hits_test.go
+++ b/server/search/hits_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (

--- a/server/search/hits_test.go
+++ b/server/search/hits_test.go
@@ -244,8 +244,7 @@ func TestSortedHits(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pq := NewSortedHits(tc.sortOrder)
 			for _, h := range tc.inputHits {
-				err := pq.Add(h)
-				assert.NoError(t, err)
+				pq.Add(h)
 			}
 
 			assert.Equal(t, len(tc.expectedOrder), pq.Len())
@@ -269,7 +268,7 @@ func TestSortedHits(t *testing.T) {
 		assert.Equal(t, 0, pq.Len())
 		assert.False(t, pq.HasMoreHits())
 
-		_ = pq.Add(searchHits[0])
+		pq.Add(searchHits[0])
 		assert.Equal(t, 1, pq.Len())
 		assert.True(t, pq.HasMoreHits())
 

--- a/server/services/v1/search_reader.go
+++ b/server/services/v1/search_reader.go
@@ -108,9 +108,7 @@ func (p *pageReader) read() error {
 		if r.Hits != nil {
 			for _, h := range *r.Hits {
 				hit := tsearch.NewSearchHit(&h)
-				if ulog.E(sortedHits.Add(hit)) {
-					continue
-				}
+				sortedHits.Add(hit)
 			}
 		}
 


### PR DESCRIPTION
- Instead of directly appending facets from multiple search queries, store them in intermediate data structure, handle duplicates and sort them in descending order before returning to user. 
- This only impacts `OR` queries and skips `FacetStats` altogether for them
- Regular search queries are not impacted by this change 