### PR TITLE
Allow getAccessToken API without namespace set

### DIFF
--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -50,34 +50,34 @@ func TestAuth(t *testing.T) {
 		panic("Failed to setup cache")
 	}
 	t.Run("log_only mode: no token", func(t *testing.T) {
-		ctx, err := AuthFunction(context.TODO(), &validator.Validator{}, &config.DefaultConfig, cache)
+		ctx, err := authFunction(context.TODO(), &validator.Validator{}, &config.DefaultConfig, cache)
 		require.NotNil(t, ctx)
 		require.Nil(t, err)
 	})
 
 	t.Run("enforcing mode: no token", func(t *testing.T) {
-		_, err := AuthFunction(context.TODO(), &validator.Validator{}, &enforcedAuthConfig, cache)
+		_, err := authFunction(context.TODO(), &validator.Validator{}, &enforcedAuthConfig, cache)
 		require.NotNil(t, err)
 		require.Equal(t, err, api.Errorf(api.Code_UNAUTHENTICATED, "request unauthenticated with bearer"))
 	})
 
 	t.Run("enforcing mode: Bad authorization string1", func(t *testing.T) {
 		incomingCtx := metadata.NewIncomingContext(context.TODO(), metadata.Pairs("authorization", "bearer"))
-		_, err := AuthFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
+		_, err := authFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
 		require.NotNil(t, err)
 		require.Equal(t, err, api.Errorf(api.Code_UNAUTHENTICATED, "bad authorization string"))
 	})
 
 	t.Run("enforcing mode: Bad token", func(t *testing.T) {
 		incomingCtx := metadata.NewIncomingContext(context.TODO(), metadata.Pairs("authorization", "bearer somebadtoken"))
-		_, err := AuthFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
+		_, err := authFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
 		require.NotNil(t, err)
 		require.Equal(t, err, api.Errorf(api.Code_UNAUTHENTICATED, "Failed to validate access token"))
 	})
 
 	t.Run("enforcing mode: Bad token 2", func(t *testing.T) {
 		incomingCtx := metadata.NewIncomingContext(context.TODO(), metadata.Pairs("authorization", "bearer some.bad.token"))
-		_, err := AuthFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
+		_, err := authFunction(incomingCtx, &validator.Validator{}, &enforcedAuthConfig, cache)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Failed to validate access token")
 	})

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -178,9 +178,8 @@ func SetNamespace(ctx context.Context, namespace string) context.Context {
 
 func GetAccessToken(ctx context.Context) (*AccessToken, error) {
 	// read token
-	value := ctx.Value(RequestMetadataCtxKey{})
-	if value != nil {
-		if requestMetadata, ok := value.(*RequestMetadata); ok {
+	if value := ctx.Value(RequestMetadataCtxKey{}); value != nil {
+		if requestMetadata, ok := value.(*RequestMetadata); ok && requestMetadata.accessToken != nil {
 			return requestMetadata.accessToken, nil
 		}
 	}
@@ -189,8 +188,7 @@ func GetAccessToken(ctx context.Context) (*AccessToken, error) {
 
 func GetNamespace(ctx context.Context) (string, error) {
 	// read token
-	value := ctx.Value(RequestMetadataCtxKey{})
-	if value != nil {
+	if value := ctx.Value(RequestMetadataCtxKey{}); value != nil {
 		if requestMetadata, ok := value.(*RequestMetadata); ok {
 			return requestMetadata.namespace, nil
 		}
@@ -205,13 +203,11 @@ func (tokenNamespaceExtractor *AccessTokenNamespaceExtractor) Extract(ctx contex
 		return "unknown", nil
 	}
 
-	if token != nil {
-		namespace := token.Namespace
-		if namespace != "" {
-			return namespace, nil
-		}
+	if namespace := token.Namespace; namespace != "" {
+		return namespace, nil
 	}
-	return "", api.Errorf(api.Code_INVALID_ARGUMENT, "Namespace does not exist")
+
+	return "", api.Errorf(api.Code_INVALID_ARGUMENT, "Namespace is empty in the token")
 }
 
 func IsAdminApi(fullMethodName string) bool {


### PR DESCRIPTION
* Allow getAccessToken to proceed with default_namespace, when
  called with app_id/app_secret credentials instead of token.
* Return and error if namespace is empty in the token
* Set namespace to "unknown" if token is not present in the request
* Set namespace to "default_namespace" if we know that token should not
  be present or request is across namespaces
* Use default namespace if namespace isolation is disabled by config