### PR TITLE
feat: Added cache for auth tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.0.0-20220726230323-06994584191e // indirect
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1002,6 +1002,8 @@ golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/server/main.go
+++ b/server/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	quota.Init(tenantMgr, txMgr, &config.DefaultConfig.Quota)
 
-	mx := muxer.NewMuxer(&config.DefaultConfig, tenantMgr, txMgr)
+	mx := muxer.NewMuxer(&config.DefaultConfig)
 	mx.RegisterServices(kvStore, searchStore, tenantMgr, txMgr)
 
 	if err := mx.Start(config.DefaultConfig.Server.Host, config.DefaultConfig.Server.Port); err != nil {

--- a/server/metadata/users.go
+++ b/server/metadata/users.go
@@ -43,11 +43,11 @@ func (u *UserSubspace) InsertUserMetadata(ctx context.Context, tx transaction.Tx
 	}
 	key := keys.NewKey(u.UserSubspaceName(), userVersion, UInt32ToByte(namespaceId), UInt32ToByte(uint32(userType)), []byte(userId), []byte(metadataKey))
 	if err := tx.Insert(ctx, key, internal.NewTableData(payload)); err != nil {
-		log.Debug().Str("key", key.String()).Str("value", string(payload)).Err(err).Msg("storing user failed")
+		log.Debug().Str("key", key.String()).Str("value", string(payload)).Err(err).Msg("storing user metadata failed")
 		return err
 	}
 
-	log.Debug().Str("key", key.String()).Str("value", string(payload)).Msg("storing user succeed")
+	log.Debug().Str("key", key.String()).Str("value", string(payload)).Msg("storing user metadata succeed")
 
 	return nil
 }
@@ -63,8 +63,10 @@ func (u *UserSubspace) GetUserMetadata(ctx context.Context, tx transaction.Tx, n
 	}
 	var row kv.KeyValue
 	if it.Next(&row) {
+		log.Debug().Str("key", key.String()).Str("value", string(row.Data.RawData)).Msg("reading user metadata succeed")
 		return row.Data.RawData, nil
 	}
+
 	return nil, it.Err()
 }
 
@@ -81,6 +83,7 @@ func (u *UserSubspace) UpdateUserMetadata(ctx context.Context, tx transaction.Tx
 	if err != nil {
 		return err
 	}
+	log.Debug().Str("key", key.String()).Str("value", string(payload)).Msg("update user metadata succeed")
 	return nil
 }
 
@@ -91,10 +94,10 @@ func (u *UserSubspace) DeleteUserMetadata(ctx context.Context, tx transaction.Tx
 	key := keys.NewKey(u.UserSubspaceName(), userVersion, UInt32ToByte(namespaceId), UInt32ToByte(uint32(userType)), []byte(userId), []byte(metadataKey))
 	err := tx.Delete(ctx, key)
 	if err != nil {
-		log.Debug().Str("key", key.String()).Err(err).Msg("Delete user failed")
+		log.Debug().Str("key", key.String()).Err(err).Msg("Delete user metadata failed")
 		return err
 	}
-	log.Debug().Str("key", key.String()).Msg("Delete user succeed")
+	log.Debug().Str("key", key.String()).Msg("Delete user metadata  succeed")
 	return nil
 }
 

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -24,13 +24,11 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/server/config"
 	tigrisconfig "github.com/tigrisdata/tigris/server/config"
-	"github.com/tigrisdata/tigris/server/metadata"
-	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/util"
 	"google.golang.org/grpc"
 )
 
-func Get(config *config.Config, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+func Get(config *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
 	authFunc := getAuthFunction(config)
 
 	// adding all the middlewares for the server stream

--- a/server/muxer/grpc.go
+++ b/server/muxer/grpc.go
@@ -18,9 +18,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/soheilhy/cmux"
 	"github.com/tigrisdata/tigris/server/config"
-	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/middleware"
-	"github.com/tigrisdata/tigris/server/transaction"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -29,10 +27,10 @@ type GRPCServer struct {
 	*grpc.Server
 }
 
-func NewGRPCServer(cfg *config.Config, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) *GRPCServer {
+func NewGRPCServer(cfg *config.Config) *GRPCServer {
 	s := &GRPCServer{}
 
-	unary, stream := middleware.Get(cfg, tenantMgr, txMgr)
+	unary, stream := middleware.Get(cfg)
 	s.Server = grpc.NewServer(grpc.StreamInterceptor(stream), grpc.UnaryInterceptor(unary))
 	reflection.Register(s)
 	return s

--- a/server/muxer/http.go
+++ b/server/muxer/http.go
@@ -24,9 +24,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/soheilhy/cmux"
 	"github.com/tigrisdata/tigris/server/config"
-	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/middleware"
-	"github.com/tigrisdata/tigris/server/transaction"
 )
 
 type HTTPServer struct {
@@ -34,13 +32,13 @@ type HTTPServer struct {
 	Inproc *inprocgrpc.Channel
 }
 
-func NewHTTPServer(cfg *config.Config, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) *HTTPServer {
+func NewHTTPServer(cfg *config.Config) *HTTPServer {
 	r := chi.NewRouter()
 
 	r.Use(cors.AllowAll().Handler)
 	r.Mount("/debug", chi_middleware.Profiler())
 
-	unary, stream := middleware.Get(cfg, tenantMgr, txMgr)
+	unary, stream := middleware.Get(cfg)
 
 	inproc := &inprocgrpc.Channel{}
 	inproc.WithServerStreamInterceptor(stream)

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -37,8 +37,8 @@ type Muxer struct {
 	servers []Server
 }
 
-func NewMuxer(cfg *config.Config, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) *Muxer {
-	return &Muxer{servers: []Server{NewHTTPServer(cfg, tenantMgr, txMgr), NewGRPCServer(cfg, tenantMgr, txMgr)}}
+func NewMuxer(cfg *config.Config) *Muxer {
+	return &Muxer{servers: []Server{NewHTTPServer(cfg), NewGRPCServer(cfg)}}
 }
 
 func (m *Muxer) RegisterServices(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) {

--- a/server/services/v1/auth.go
+++ b/server/services/v1/auth.go
@@ -47,8 +47,8 @@ func newAuthService(authProvider AuthProvider) *authService {
 	}
 }
 
-func (a *authService) GetAccessToken(_ context.Context, req *api.GetAccessTokenRequest) (*api.GetAccessTokenResponse, error) {
-	return a.AuthProvider.GetAccessToken(req)
+func (a *authService) GetAccessToken(ctx context.Context, req *api.GetAccessTokenRequest) (*api.GetAccessTokenResponse, error) {
+	return a.AuthProvider.GetAccessToken(ctx, req)
 }
 
 func (a *authService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel) error {

--- a/server/services/v1/user.go
+++ b/server/services/v1/user.go
@@ -39,14 +39,14 @@ type userService struct {
 	UserMetadataProvider
 }
 
-func newUserService(authProvider AuthProvider, txMgr *transaction.Manager, tenantMgr *metadata.TenantManager) *userService {
+func newUserService(authProvider AuthProvider, txMgr *transaction.Manager, tenantMgr *metadata.TenantManager, userstore *metadata.UserSubspace) *userService {
 	if authProvider == nil && config.DefaultConfig.Auth.EnableOauth {
 		log.Error().Str("AuthProvider", config.DefaultConfig.Auth.OAuthProvider).Msg("Unable to configure external auth provider")
 		panic("Unable to configure external auth provider")
 	}
 
 	userMetadataProvider := &DefaultUserMetadataProvider{
-		userStore: metadata.NewUserStore(&metadata.DefaultMDNameRegistry{}),
+		userStore: userstore,
 		txMgr:     txMgr,
 		tenantMgr: tenantMgr,
 	}


### PR DESCRIPTION
- User metadata will store machine application's access token that is expiration aware.
- It will keep the metadata in sync with app rotation/deletion.
- multiple node deployment will not result in multiple external calls now.