### PR TITLE
feat: split error and ok response times in metrics

### DIFF
--- a/server/metrics/auth.go
+++ b/server/metrics/auth.go
@@ -21,21 +21,13 @@ import (
 )
 
 var (
-	AuthOkRequests    tally.Scope
-	AuthErrorRequests tally.Scope
+	AuthOkCount       tally.Scope
+	AuthErrorCount    tally.Scope
 	AuthRespTime      tally.Scope
+	AuthErrorRespTime tally.Scope
 )
 
 func getAuthOkTagKeys() []string {
-	return []string{
-		"grpc_method",
-		"env",
-		"service",
-		"version",
-	}
-}
-
-func getAuthTimerTagKeys() []string {
 	return []string{
 		"grpc_method",
 		"env",
@@ -60,7 +52,8 @@ func GetAuthBaseTags(ctx context.Context) map[string]string {
 }
 
 func initializeAuthScopes() {
-	AuthOkRequests = AuthMetrics.SubScope("count")
-	AuthErrorRequests = AuthMetrics.SubScope("count")
+	AuthOkCount = AuthMetrics.SubScope("count")
+	AuthErrorCount = AuthMetrics.SubScope("count")
 	AuthRespTime = AuthMetrics.SubScope("response")
+	AuthErrorRespTime = AuthMetrics.SubScope("error_response")
 }

--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -19,25 +19,13 @@ import (
 )
 
 var (
-	FdbOkRequests    tally.Scope
-	FdbErrorRequests tally.Scope
+	FdbOkCount       tally.Scope
+	FdbErrorCount    tally.Scope
 	FdbRespTime      tally.Scope
+	FdbErrorRespTime tally.Scope
 )
 
 func getFdbOkTagKeys() []string {
-	return []string{
-		"grpc_method",
-		"grpc_service",
-		"tigris_tenant",
-		"grpc_service_type",
-		"env",
-		"db",
-		"collection",
-		"fdb_method",
-	}
-}
-
-func getFdbTimerTagKeys() []string {
 	return []string{
 		"grpc_method",
 		"grpc_service",
@@ -84,7 +72,8 @@ func GetFdbBaseTags(reqMthodName string) map[string]string {
 }
 
 func initializeFdbScopes() {
-	FdbOkRequests = FdbMetrics.SubScope("count")
-	FdbErrorRequests = FdbMetrics.SubScope("count")
+	FdbOkCount = FdbMetrics.SubScope("count")
+	FdbErrorCount = FdbMetrics.SubScope("count")
 	FdbRespTime = FdbMetrics.SubScope("response")
+	FdbErrorRespTime = FdbMetrics.SubScope("error_response")
 }

--- a/server/metrics/fdb_test.go
+++ b/server/metrics/fdb_test.go
@@ -40,17 +40,16 @@ func TestFdbMetrics(t *testing.T) {
 
 	t.Run("Test fdb tags", func(t *testing.T) {
 		assert.Greater(t, len(getFdbOkTagKeys()), 2)
-		assert.Greater(t, len(getFdbTimerTagKeys()), 2)
 		assert.Greater(t, len(getFdbErrorTagKeys()), 2)
 	})
 
 	t.Run("Test FDB counters", func(t *testing.T) {
 		for _, tags := range testNormalTags {
-			FdbOkRequests.Tagged(tags).Counter("ok").Inc(1)
-			FdbErrorRequests.Tagged(tags).Counter("unknown").Inc(1)
+			FdbOkCount.Tagged(tags).Counter("ok").Inc(1)
+			FdbErrorCount.Tagged(tags).Counter("unknown").Inc(1)
 		}
 		for _, tags := range testKnownErrorTags {
-			FdbErrorRequests.Tagged(tags).Counter("specific").Inc(1)
+			FdbErrorCount.Tagged(tags).Counter("specific").Inc(1)
 		}
 	})
 

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -19,24 +19,13 @@ import (
 )
 
 var (
-	OkRequests       tally.Scope
-	ErrorRequests    tally.Scope
-	RequestsRespTime tally.Scope
+	RequestsOkCount       tally.Scope
+	RequestsErrorCount    tally.Scope
+	RequestsRespTime      tally.Scope
+	RequestsErrorRespTime tally.Scope
 )
 
 func getRequestOkTagKeys() []string {
-	return []string{
-		"grpc_method",
-		"grpc_service",
-		"tigris_tenant",
-		"grpc_service_type",
-		"env",
-		"db",
-		"collection",
-	}
-}
-
-func getRequestTimerTagKeys() []string {
 	return []string{
 		"grpc_method",
 		"grpc_service",
@@ -63,7 +52,8 @@ func getRequestErrorTagKeys() []string {
 }
 
 func initializeRequestScopes() {
-	OkRequests = Requests.SubScope("count")
-	ErrorRequests = Requests.SubScope("count")
+	RequestsOkCount = Requests.SubScope("count")
+	RequestsErrorCount = Requests.SubScope("count")
 	RequestsRespTime = Requests.SubScope("response")
+	RequestsErrorRespTime = Requests.SubScope("error_response")
 }

--- a/server/metrics/search.go
+++ b/server/metrics/search.go
@@ -19,25 +19,13 @@ import (
 )
 
 var (
-	SearchOkRequests    tally.Scope
-	SearchErrorRequests tally.Scope
+	SearchOkCount       tally.Scope
+	SearchErrorCount    tally.Scope
 	SearchRespTime      tally.Scope
+	SearchErrorRespTime tally.Scope
 )
 
 func getSearchOkTagKeys() []string {
-	return []string{
-		"grpc_method",
-		"grpc_service",
-		"tigris_tenant",
-		"grpc_service_type",
-		"env",
-		"db",
-		"collection",
-		"search_method",
-	}
-}
-
-func getSearchTimerTagKeys() []string {
 	return []string{
 		"grpc_method",
 		"grpc_service",
@@ -66,9 +54,10 @@ func getSearchErrorTagKeys() []string {
 }
 
 func initializeSearchScopes() {
-	SearchOkRequests = SearchMetrics.SubScope("count")
-	SearchErrorRequests = SearchMetrics.SubScope("count")
+	SearchOkCount = SearchMetrics.SubScope("count")
+	SearchErrorCount = SearchMetrics.SubScope("count")
 	SearchRespTime = SearchMetrics.SubScope("response")
+	SearchErrorRespTime = SearchMetrics.SubScope("error_response")
 }
 
 func GetSearchTags(reqMethodName string) map[string]string {

--- a/server/metrics/search_test.go
+++ b/server/metrics/search_test.go
@@ -37,14 +37,13 @@ func TestSearchMetrics(t *testing.T) {
 
 	t.Run("Test search tags", func(t *testing.T) {
 		assert.Greater(t, len(getSearchOkTagKeys()), 2)
-		assert.Greater(t, len(getSearchTimerTagKeys()), 2)
 		assert.Greater(t, len(getSearchErrorTagKeys()), 2)
 	})
 
 	t.Run("Test Search counters", func(t *testing.T) {
 		for _, tags := range testNormalTags {
-			SearchOkRequests.Tagged(tags).Counter("ok").Inc(1)
-			SearchErrorRequests.Tagged(tags).Counter("unknown").Inc(1)
+			SearchOkCount.Tagged(tags).Counter("ok").Inc(1)
+			SearchErrorCount.Tagged(tags).Counter("unknown").Inc(1)
 		}
 	})
 

--- a/server/metrics/session.go
+++ b/server/metrics/session.go
@@ -19,25 +19,13 @@ import (
 )
 
 var (
-	SessionOkRequests    tally.Scope
-	SessionErrorRequests tally.Scope
+	SessionOkCount       tally.Scope
+	SessionErrorCount    tally.Scope
 	SessionRespTime      tally.Scope
+	SessionErrorRespTime tally.Scope
 )
 
 func getSessionOkTagKeys() []string {
-	return []string{
-		"grpc_method",
-		"grpc_service",
-		"tigris_tenant",
-		"grpc_service_type",
-		"env",
-		"db",
-		"collection",
-		"session_method",
-	}
-}
-
-func getSessionTimerTagKeys() []string {
 	return []string{
 		"grpc_method",
 		"grpc_service",
@@ -72,7 +60,8 @@ func GetSessionTags(sessionMethodName string) map[string]string {
 }
 
 func initializeSessionScopes() {
-	SessionOkRequests = SessionMetrics.SubScope("count")
-	SessionErrorRequests = SessionMetrics.SubScope("count")
+	SessionOkCount = SessionMetrics.SubScope("count")
+	SessionErrorCount = SessionMetrics.SubScope("count")
 	SessionRespTime = SessionMetrics.SubScope("response")
+	SessionErrorRespTime = SessionMetrics.SubScope("error_response")
 }

--- a/server/metrics/session_test.go
+++ b/server/metrics/session_test.go
@@ -34,8 +34,8 @@ func TestSessionMetrics(t *testing.T) {
 
 	t.Run("Test Session counters", func(t *testing.T) {
 		for _, tags := range testTags {
-			SessionOkRequests.Tagged(tags).Counter("ok").Inc(1)
-			SessionErrorRequests.Tagged(tags).Counter("error").Inc(1)
+			SessionOkCount.Tagged(tags).Counter("ok").Inc(1)
+			SessionErrorCount.Tagged(tags).Counter("error").Inc(1)
 		}
 	})
 

--- a/server/metrics/tracing.go
+++ b/server/metrics/tracing.go
@@ -17,7 +17,9 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/request"
 	ulog "github.com/tigrisdata/tigris/util/log"
@@ -44,6 +46,10 @@ type SpanMeta struct {
 	tags         map[string]string
 	span         tracer.Span
 	parent       *SpanMeta
+	started      bool
+	stopped      bool
+	startedAt    time.Time
+	stoppedAt    time.Time
 }
 
 type SpanMetaCtxKey struct {
@@ -86,20 +92,12 @@ func (s *SpanMeta) GetRequestOkTags() map[string]string {
 	return standardizeTags(s.tags, getRequestOkTagKeys())
 }
 
-func (s *SpanMeta) GetRequestTimerTags() map[string]string {
-	return standardizeTags(s.tags, getRequestTimerTagKeys())
-}
-
 func (s *SpanMeta) GetRequestErrorTags(err error) map[string]string {
 	return standardizeTags(mergeTags(s.tags, getTagsForError(err, "request")), getRequestErrorTagKeys())
 }
 
 func (s *SpanMeta) GetFdbOkTags() map[string]string {
 	return standardizeTags(s.tags, getFdbOkTagKeys())
-}
-
-func (s *SpanMeta) GetFdbTimerTags() map[string]string {
-	return standardizeTags(s.tags, getFdbTimerTagKeys())
 }
 
 func (s *SpanMeta) GetFdbErrorTags(err error) map[string]string {
@@ -110,20 +108,12 @@ func (s *SpanMeta) GetSearchOkTags() map[string]string {
 	return standardizeTags(s.tags, getSearchOkTagKeys())
 }
 
-func (s *SpanMeta) GetSearchTimerTags() map[string]string {
-	return standardizeTags(s.tags, getSearchTimerTagKeys())
-}
-
 func (s *SpanMeta) GetSearchErrorTags(err error) map[string]string {
 	return standardizeTags(mergeTags(s.tags, getTagsForError(err, "search")), getSearchErrorTagKeys())
 }
 
 func (s *SpanMeta) GetSessionOkTags() map[string]string {
 	return standardizeTags(s.tags, getSessionOkTagKeys())
-}
-
-func (s *SpanMeta) GetSessionTimerTags() map[string]string {
-	return standardizeTags(s.tags, getSessionTimerTagKeys())
 }
 
 func (s *SpanMeta) GetSessionErrorTags(err error) map[string]string {
@@ -148,10 +138,6 @@ func (s *SpanMeta) GetNetworkTags() map[string]string {
 
 func (s *SpanMeta) GetAuthOkTags() map[string]string {
 	return standardizeTags(s.tags, getAuthOkTagKeys())
-}
-
-func (s *SpanMeta) GetAuthTimerTags() map[string]string {
-	return standardizeTags(s.tags, getAuthTimerTagKeys())
 }
 
 func (s *SpanMeta) GetAuthErrorTags(err error) map[string]string {
@@ -183,10 +169,19 @@ func (s *SpanMeta) AddTags(tags map[string]string) {
 	}
 }
 
+func (s *SpanMeta) RecursiveAddTags(tags map[string]string) {
+	s.AddTags(tags)
+	if s.parent != nil {
+		s.parent.RecursiveAddTags(tags)
+	}
+}
+
 func (s *SpanMeta) StartTracing(ctx context.Context, childOnly bool) context.Context {
 	if !config.DefaultConfig.Tracing.Enabled {
 		return ctx
 	}
+	s.startedAt = time.Now()
+	s.started = true
 	spanOpts := s.GetSpanOptions()
 	parentSpanMeta, parentExists := SpanMetaFromContext(ctx)
 	if parentExists {
@@ -212,6 +207,10 @@ func (s *SpanMeta) StartTracing(ctx context.Context, childOnly bool) context.Con
 }
 
 func (s *SpanMeta) FinishTracing(ctx context.Context) context.Context {
+	if !s.started {
+		log.Error().Str("service_name", s.serviceName).Str("resource_name", s.resourceName).Msg("Finish tracing called before starting the trace")
+		return ctx
+	}
 	if s.span != nil {
 		s.span.Finish()
 	}
@@ -225,7 +224,18 @@ func (s *SpanMeta) FinishTracing(ctx context.Context) context.Context {
 		// This was the top level span meta
 		ctx = ClearSpanMetaContext(ctx)
 	}
+	s.stopped = true
+	s.stoppedAt = time.Now()
 	return ctx
+}
+
+func (s *SpanMeta) RecordDuration(scope tally.Scope, tags map[string]string) {
+	// Should be called after tracing is finished
+	if !s.started || !s.stopped {
+		log.Error().Str("service_name", s.serviceName).Str("resource_name", s.resourceName).Msg("RecordDuration was called on a span that was not started ot stopped")
+		return
+	}
+	scope.Tagged(tags).Timer("time").Record(s.stoppedAt.Sub(s.startedAt))
 }
 
 func (s *SpanMeta) FinishWithError(ctx context.Context, source string, err error) context.Context {
@@ -242,5 +252,7 @@ func (s *SpanMeta) FinishWithError(ctx context.Context, source string, err error
 	s.span.Finish(finishOptions...)
 	s.span = nil
 	ClearSpanMetaContext(ctx)
+	s.stopped = true
+	s.stoppedAt = time.Now()
 	return ctx
 }

--- a/server/middleware/tracing.go
+++ b/server/middleware/tracing.go
@@ -63,21 +63,22 @@ func traceUnary() func(ctx context.Context, req interface{}, info *grpc.UnarySer
 		tags := reqMetadata.GetInitialTags()
 		spanMeta := metrics.NewSpanMeta(util.Service, info.FullMethod, metrics.GrpcSpanType, tags)
 		spanMeta.AddTags(metrics.GetDbCollTagsForReq(req))
-		defer metrics.RequestsRespTime.Tagged(spanMeta.GetRequestTimerTags()).Timer("time").Start().Stop()
 		ctx = spanMeta.StartTracing(ctx, false)
 		resp, err := handler(ctx, req)
 		if err != nil {
 			// Request had an error
-			spanMeta.CountErrorForScope(metrics.ErrorRequests, spanMeta.GetRequestErrorTags(err))
+			spanMeta.CountErrorForScope(metrics.RequestsErrorCount, spanMeta.GetRequestErrorTags(err))
 			_ = spanMeta.FinishWithError(ctx, "request", err)
+			spanMeta.RecordDuration(metrics.RequestsErrorRespTime, spanMeta.GetRequestErrorTags(err))
 			ulog.E(err)
 			return nil, err
 		}
 		// Request was ok
-		spanMeta.CountOkForScope(metrics.OkRequests, spanMeta.GetRequestOkTags())
+		spanMeta.CountOkForScope(metrics.RequestsOkCount, spanMeta.GetRequestOkTags())
 		spanMeta.CountReceivedBytes(metrics.BytesReceived, spanMeta.GetNetworkTags(), proto.Size(req.(proto.Message)))
 		spanMeta.CountSentBytes(metrics.BytesSent, spanMeta.GetNetworkTags(), proto.Size(resp.(proto.Message)))
 		_ = spanMeta.FinishTracing(ctx)
+		spanMeta.RecordDuration(metrics.RequestsRespTime, spanMeta.GetRequestOkTags())
 		return resp, err
 	}
 }
@@ -96,18 +97,19 @@ func traceStream() grpc.StreamServerInterceptor {
 		}
 		tags := reqMetadata.GetInitialTags()
 		spanMeta := metrics.NewSpanMeta(util.Service, info.FullMethod, metrics.GrpcSpanType, tags)
-		defer metrics.RequestsRespTime.Tagged(spanMeta.GetRequestTimerTags()).Timer("time").Start().Stop()
 		wrapped.spanMeta = spanMeta
 		wrapped.WrappedContext = spanMeta.StartTracing(wrapped.WrappedContext, false)
 		err = handler(srv, wrapped)
 		if err != nil {
-			spanMeta.CountErrorForScope(metrics.ErrorRequests, spanMeta.GetRequestErrorTags(err))
+			spanMeta.CountErrorForScope(metrics.RequestsErrorCount, spanMeta.GetRequestErrorTags(err))
 			wrapped.WrappedContext = spanMeta.FinishWithError(wrapped.WrappedContext, "request", err)
+			spanMeta.RecordDuration(metrics.RequestsErrorRespTime, spanMeta.GetRequestErrorTags(err))
 			ulog.E(err)
 			return err
 		}
-		spanMeta.CountOkForScope(metrics.OkRequests, spanMeta.GetRequestOkTags())
+		spanMeta.CountOkForScope(metrics.RequestsOkCount, spanMeta.GetRequestOkTags())
 		wrapped.WrappedContext = spanMeta.FinishTracing(wrapped.WrappedContext)
+		spanMeta.RecordDuration(metrics.RequestsRespTime, spanMeta.GetRequestOkTags())
 		return err
 	}
 }

--- a/server/services/v1/sessions.go
+++ b/server/services/v1/sessions.go
@@ -63,14 +63,15 @@ type SessionManagerWithMetrics struct {
 func (m *SessionManagerWithMetrics) measure(ctx context.Context, name string, f func(ctx context.Context) error) {
 	spanMeta := metrics.NewSpanMeta(metrics.SessionManagerServiceName, name, metrics.SessionSpanType, metrics.GetSessionTags(name))
 	ctx = spanMeta.StartTracing(ctx, true)
-	defer metrics.SessionRespTime.Tagged(spanMeta.GetSessionTimerTags()).Timer("time").Start().Stop()
 	if err := f(ctx); err != nil {
-		spanMeta.CountErrorForScope(metrics.SessionErrorRequests, spanMeta.GetSessionErrorTags(err))
+		spanMeta.CountErrorForScope(metrics.SessionErrorCount, spanMeta.GetSessionErrorTags(err))
 		_ = spanMeta.FinishWithError(ctx, "session", err)
+		spanMeta.RecordDuration(metrics.SessionErrorRespTime, spanMeta.GetSessionErrorTags(err))
 		return
 	}
-	spanMeta.CountOkForScope(metrics.SessionOkRequests, spanMeta.GetSessionOkTags())
+	spanMeta.CountOkForScope(metrics.SessionOkCount, spanMeta.GetSessionOkTags())
 	_ = spanMeta.FinishTracing(ctx)
+	spanMeta.RecordDuration(metrics.SessionRespTime, spanMeta.GetSessionOkTags())
 }
 
 func (m SessionManagerWithMetrics) Create(ctx context.Context, trackVerInOwnTxn bool, instantVerTracking bool, track bool) (qs *QuerySession, err error) {


### PR DESCRIPTION
* Split error and not error timers, like request counters
* Timers are tied to tracing spans now (like counters)
* Simplifies tagging (timers no longer need to have separate tags)