### PR TITLE
fix: top level spans have db and collection tag for streaming requests

### DIFF
--- a/server/metrics/tracing.go
+++ b/server/metrics/tracing.go
@@ -165,6 +165,10 @@ func (s *SpanMeta) AddTags(tags map[string]string) {
 	for k, v := range tags {
 		if _, exists := s.tags[k]; !exists || s.tags[k] == request.UnknownValue {
 			s.tags[k] = v
+			if s.span != nil {
+				// The span already exists, set the tag there as well
+				s.span.SetTag(k, v)
+			}
 		}
 	}
 }

--- a/server/middleware/tracing.go
+++ b/server/middleware/tracing.go
@@ -123,8 +123,8 @@ func (w *wrappedStream) RecvMsg(m interface{}) error {
 	childSpanMeta := metrics.NewSpanMeta(TigrisStreamSpan, "RecvMsg", metrics.GrpcSpanType, parentSpanMeta.GetRequestOkTags())
 	w.WrappedContext = childSpanMeta.StartTracing(w.WrappedContext, true)
 	err := w.ServerStream.RecvMsg(m)
-	parentSpanMeta.AddTags(metrics.GetDbCollTagsForReq(m))
-	childSpanMeta.AddTags(metrics.GetDbCollTagsForReq(m))
+	parentSpanMeta.RecursiveAddTags(metrics.GetDbCollTagsForReq(m))
+	childSpanMeta.RecursiveAddTags(metrics.GetDbCollTagsForReq(m))
 	parentSpanMeta.CountReceivedBytes(metrics.BytesReceived, parentSpanMeta.GetNetworkTags(), proto.Size(m.(proto.Message)))
 	w.WrappedContext = childSpanMeta.FinishTracing(w.WrappedContext)
 	return err
@@ -139,8 +139,8 @@ func (w *wrappedStream) SendMsg(m interface{}) error {
 	childSpanMeta := metrics.NewSpanMeta(TigrisStreamSpan, "SendMsg", metrics.GrpcSpanType, parentSpanMeta.GetRequestOkTags())
 	w.WrappedContext = childSpanMeta.StartTracing(w.WrappedContext, true)
 	err := w.ServerStream.SendMsg(m)
-	parentSpanMeta.AddTags(metrics.GetDbCollTagsForReq(m))
-	childSpanMeta.AddTags(metrics.GetDbCollTagsForReq(m))
+	parentSpanMeta.RecursiveAddTags(metrics.GetDbCollTagsForReq(m))
+	childSpanMeta.RecursiveAddTags(metrics.GetDbCollTagsForReq(m))
 	parentSpanMeta.CountSentBytes(metrics.BytesSent, parentSpanMeta.GetNetworkTags(), proto.Size(m.(proto.Message)))
 	w.WrappedContext = childSpanMeta.FinishTracing(w.WrappedContext)
 	return err


### PR DESCRIPTION
The top level tracing spans for streaming requests didn't have the db and collection tags (they are set in SendMsg and ReceiveMsg).