### PR TITLE
fix: Fixed the quantile processing for metrics query requests

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -415,6 +415,10 @@ func (x *QueryTimeSeriesMetricsRequest) UnmarshalJSON(data []byte) error {
 			if err := jsoniter.Unmarshal(value, &x.MetricName); err != nil {
 				return err
 			}
+		case "quantile":
+			if err := jsoniter.Unmarshal(value, &x.Quantile); err != nil {
+				return err
+			}
 		case "tigris_operation":
 			var t string
 			if err := jsoniter.Unmarshal(value, &t); err != nil {
@@ -427,6 +431,8 @@ func (x *QueryTimeSeriesMetricsRequest) UnmarshalJSON(data []byte) error {
 				x.TigrisOperation = TigrisOperation_READ
 			case "WRITE":
 				x.TigrisOperation = TigrisOperation_WRITE
+			case "METADATA":
+				x.TigrisOperation = TigrisOperation_METADATA
 			}
 		case "space_aggregation":
 			var t string

--- a/server/services/v1/observability.go
+++ b/server/services/v1/observability.go
@@ -211,9 +211,11 @@ func formQuery(ctx context.Context, req *api.QueryTimeSeriesMetricsRequest) (str
 
 	if req.TigrisOperation != api.TigrisOperation_ALL {
 		if req.TigrisOperation == api.TigrisOperation_WRITE {
-			tags = append(tags, "grpc_method IN (insert,update) AND ")
-		} else {
-			tags = append(tags, "grpc_method:read AND ")
+			tags = append(tags, "grpc_method IN (insert,update,delete,replace,publish) AND ")
+		} else if req.TigrisOperation == api.TigrisOperation_READ {
+			tags = append(tags, "grpc_method IN (read,search,subscribe) AND ")
+		} else if req.TigrisOperation == api.TigrisOperation_METADATA {
+			tags = append(tags, "grpc_method IN (createorupdatecollection,dropcollection,listdatabases,listcollections,createdatabase,dropdatabase,describedatabase,describecollection) AND ")
 		}
 	}
 
@@ -233,7 +235,7 @@ func formQuery(ctx context.Context, req *api.QueryTimeSeriesMetricsRequest) (str
 	}
 
 	if req.Quantile != 0 {
-		tags = append(tags, "quantile:"+strconv.FormatFloat(float64(req.Quantile), 'f', -1, 64)+" AND ")
+		tags = append(tags, "quantile:"+fmt.Sprintf("%.3g", req.Quantile)+" AND ")
 	}
 
 	if len(tags) == 0 {


### PR DESCRIPTION
- Fixed the quantile processing for metrics query requests.
- Added tigris_opration:metadata to query metrics for Tigris metadata operations.