### PR TITLE
fix: Fixed the auth bypass method with RPC method rename

### DIFF
--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -42,7 +42,7 @@ var (
 	UnknownNamespace          = "unknown"
 	BypassAuthForTheseMethods = container.NewHashSet(
 		"/HealthAPI/Health",
-		"/tigrisdata.auth.v1.Auth/getAccessToken",
+		"/tigrisdata.auth.v1.Auth/GetAccessToken",
 		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 	)
 )


### PR DESCRIPTION
The RPC method was renamed from `/tigrisdata.auth.v1.Auth/getAccessToken` to `/tigrisdata.auth.v1.Auth/GetAccessToken`. And It was missed to update in bypass methods. 