### PR TITLE
fix: search and read can now display float64 without data loss

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tigrisdata/tigris-client-go v1.0.0-beta.1
-	github.com/typesense/typesense-go v0.6.0
+	github.com/typesense/typesense-go v0.6.1
 	github.com/uber-go/tally v3.5.0+incompatible
 	github.com/ugorji/go/codec v1.2.7
 	github.com/valyala/bytebufferpool v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -887,8 +887,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/twitchtv/twirp v8.1.1+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
-github.com/typesense/typesense-go v0.6.0 h1:QcQ+1WGqFDyBhjP7Cd8mj7cs00zFTs6uBrB2u6we78o=
-github.com/typesense/typesense-go v0.6.0/go.mod h1:F9T3neLDqRr9ufFNhv1y0Qxe1Zs1GT85JlgijSjtKFo=
+github.com/typesense/typesense-go v0.6.1 h1:LPzh+HG6O4eaLqcFCux9N61c4+OiJIbdeJOs6trPd5w=
+github.com/typesense/typesense-go v0.6.1/go.mod h1:F9T3neLDqRr9ufFNhv1y0Qxe1Zs1GT85JlgijSjtKFo=
 github.com/uber-go/tally v3.5.0+incompatible h1:2vIkqVrSaspifqcJh2yQjQqqpfavvmfj/ognDrBxuSg=
 github.com/uber-go/tally v3.5.0+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -16,7 +16,10 @@ package filter
 
 import (
 	"fmt"
+
 	api "github.com/tigrisdata/tigris/api/server/v1"
+
+	"encoding/json"
 
 	"github.com/buger/jsonparser"
 	"github.com/tigrisdata/tigris/lib/date"
@@ -65,7 +68,11 @@ func (s *Selector) MatchesDoc(doc map[string]interface{}) bool {
 			return true
 		}
 	case schema.DoubleType:
-		val = value.NewDoubleUsingFloat(v.(float64))
+		var err error
+		val, err = value.NewDoubleValue(v.(json.Number).String())
+		if ulog.E(err) {
+			return true
+		}
 	default:
 		// as this method is only intended for indexing store, so we only apply filter for string and double type
 		// otherwise we rely on indexing store to only return valid results.

--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -15,11 +15,10 @@
 package filter
 
 import (
+	"encoding/json"
 	"fmt"
 
 	api "github.com/tigrisdata/tigris/api/server/v1"
-
-	"encoding/json"
 
 	"github.com/buger/jsonparser"
 	"github.com/tigrisdata/tigris/lib/date"
@@ -68,6 +67,7 @@ func (s *Selector) MatchesDoc(doc map[string]interface{}) bool {
 			return true
 		}
 	case schema.DoubleType:
+		// this method is only used with indexing store and it returns `json.Number` for all numeric types
 		var err error
 		val, err = value.NewDoubleValue(v.(json.Number).String())
 		if ulog.E(err) {

--- a/server/search/hits.go
+++ b/server/search/hits.go
@@ -15,8 +15,11 @@
 package search
 
 import (
+	"encoding/json"
+
 	"github.com/tigrisdata/tigris/lib/container"
 	"github.com/tigrisdata/tigris/query/sort"
+	ulog "github.com/tigrisdata/tigris/util/log"
 	tsApi "github.com/typesense/typesense-go/typesense/api"
 )
 
@@ -130,8 +133,17 @@ func hitsComparator(this, that *Hit, sortingOrder *sort.Ordering) int {
 		var thisV, thatV float64
 
 		switch thisVal.(type) {
-		case float32, float64, int, int64:
-			thisV, thatV = thisVal.(float64), thatVal.(float64)
+		case json.Number:
+			var err error
+			thisV, err = thisVal.(json.Number).Float64()
+			// log the number conversion error and continue to next comparison
+			if ulog.E(err) {
+				continue
+			}
+			thatV, err = thatVal.(json.Number).Float64()
+			if ulog.E(err) {
+				continue
+			}
 		case bool:
 			if thisVal.(bool) {
 				thisV = 1

--- a/server/services/v1/search_indexer_test.go
+++ b/server/services/v1/search_indexer_test.go
@@ -244,24 +244,26 @@ func TestUnpackSearchFields(t *testing.T) {
 	t.Run("created_at metadata gets populated", func(t *testing.T) {
 		doc := map[string]any{
 			"id":         "123",
-			"created_at": float64(1666054267528106000),
+			"created_at": json.Number("1666054267528106000"),
 		}
 		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
 		require.NoError(t, err)
 		require.Empty(t, unpacked)
-		require.Equal(t, doc["created_at"], float64(td.CreatedAt.UnixNano()))
+		expected, _ := doc["created_at"].(json.Number).Int64()
+		require.Equal(t, expected, td.CreatedAt.UnixNano())
 		require.Nil(t, td.UpdatedAt)
 	})
 
 	t.Run("updated_at metadata gets populated", func(t *testing.T) {
 		doc := map[string]any{
 			"id":         "123",
-			"updated_at": float64(1666054267528106000),
+			"updated_at": json.Number("1666054267528106000"),
 		}
 		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
 		require.NoError(t, err)
 		require.Empty(t, unpacked)
-		require.Equal(t, doc["updated_at"], float64(td.UpdatedAt.UnixNano()))
+		expected, _ := doc["updated_at"].(json.Number).Int64()
+		require.Equal(t, expected, td.UpdatedAt.UnixNano())
 		require.Nil(t, td.CreatedAt)
 	})
 

--- a/store/search/ts.go
+++ b/store/search/ts.go
@@ -15,13 +15,12 @@
 package search
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-
-	"bytes"
 
 	jsoniter "github.com/json-iterator/go"
 	qsearch "github.com/tigrisdata/tigris/query/search"


### PR DESCRIPTION
- Read raw bytes from indexing store
- Decode data to get numerics as json.Number `json.Number`
- Validated on both read and search path:

## Example
#### Insert
```json
{
    "documents": [
        {
            "id": 9223372036854775807,
            "brand": "Nike",
            "price": 9223372036854775800,
            "review": {
                "user": "zinky",
                "votes": {
                    "upvotes": 12,
                    "downvotes": 9223372036854999999
                }
            }
        }
    ]
}
```
#### Get /id
```json
{
    "result": {
        "data": {
            "id": 9223372036854775807,
            "brand": "Nike",
            "review": {
                "votes": {
                    "downvotes": 9223372036854999999,
                    "upvotes": 12
                },
                "user": "zinky"
            },
            "price": 9223372036854775800,
        },
        "metadata": {
            "created_at": "2022-09-22T07:08:36.170413542Z"
        },
        "resume_token": "TmlrZQ=="
    }
}
```

#### Search
```json
"hits": [
            {
                "data": {
                    "review": {
                        "user": "zinky",
                        "votes": {
                            "downvotes": 9223372036854999999,
                            "upvotes": 12
                        }
                    },
                    "brand": "Nike",
                    "id": 9223372036854775807,
                    "price": 9223372036854775800
                },
                "metadata": {
                    "created_at": "2022-09-22T07:08:36.170413542Z"
                }
            }
        ],
```