### PR TITLE
feat: Add codefresh step to GHA

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -74,3 +74,15 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: report image
+        uses: codefresh-io/codefresh-report-image@latest
+        with:
+          CF_RUNTIME_NAME: "codefresh-dev"
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          CF_IMAGE: "tigrisdata/tigris:main"
+          CF_CONTAINER_REGISTRY_INTEGRATION: "tigrisdata-dockerhub"
+          CF_GIT_BRANCH: "main"
+          CF_GITHUB_TOKEN: ${{ secrets.CF_GITHUB_ACCESS_TOKEN }}
+          # CF_JIRA_PROJECT_PREFIX: '[jira-project-prefix]'
+          # CF_JIRA_MESSAGE: '[issue-id]'


### PR DESCRIPTION
Feeds our image release process to Codefresh:
- https://g.codefresh.io/2.0/workflows/image-report-executor-2mbfw
- Extra step added to GHA: https://github.com/tigrisdata/tigris/actions/runs/3106854096/jobs/5034981542

Image reported:
- https://g.codefresh.io/2.0/images/tigrisdata%2Ftigris