### PR TITLE
fix: tigris_tenant tag for auth metrics

### DIFF
--- a/server/metrics/auth.go
+++ b/server/metrics/auth.go
@@ -33,6 +33,7 @@ func getAuthOkTagKeys() []string {
 		"env",
 		"service",
 		"version",
+		"tigris_tenant",
 	}
 }
 
@@ -42,6 +43,7 @@ func getAuthErrorTagKeys() []string {
 		"env",
 		"service",
 		"version",
+		"tigris_tenant",
 		"error_source",
 		"error_code",
 	}


### PR DESCRIPTION
The tigris_tenant tag was missing from auth metrics. 