### PR TITLE
fix: wrong error tag on some metrics

### DIFF
--- a/server/metrics/auth.go
+++ b/server/metrics/auth.go
@@ -45,7 +45,7 @@ func getAuthErrorTagKeys() []string {
 		"version",
 		"tigris_tenant",
 		"error_source",
-		"error_code",
+		"error_value",
 	}
 }
 

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -50,7 +50,7 @@ func getRequestErrorTagKeys() []string {
 		"env",
 		"db",
 		"collection",
-		"error_code",
+		"error_source",
 		"error_value",
 		"read_type",
 		"search_type",

--- a/server/metrics/search.go
+++ b/server/metrics/search.go
@@ -47,7 +47,7 @@ func getSearchErrorTagKeys() []string {
 		"env",
 		"db",
 		"collection",
-		"error_code",
+		"error_source",
 		"error_value",
 		"search_method",
 	}

--- a/server/metrics/session.go
+++ b/server/metrics/session.go
@@ -47,7 +47,7 @@ func getSessionErrorTagKeys() []string {
 		"env",
 		"db",
 		"collection",
-		"error_code",
+		"error_source",
 		"error_value",
 		"session_method",
 	}


### PR DESCRIPTION
Some metrics had error_code tags. The value tags are error_source and error_value. 