### PR TITLE
fix: disable codefresh step in build

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -74,15 +74,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: report image
-        uses: codefresh-io/codefresh-report-image@latest
-        with:
-          CF_RUNTIME_NAME: "codefresh-dev"
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          CF_IMAGE: "tigrisdata/tigris:main"
-          CF_CONTAINER_REGISTRY_INTEGRATION: "tigrisdata-dockerhub"
-          CF_GIT_BRANCH: "main"
-          CF_GITHUB_TOKEN: ${{ secrets.CF_GITHUB_ACCESS_TOKEN }}
-          # CF_JIRA_PROJECT_PREFIX: '[jira-project-prefix]'
-          # CF_JIRA_MESSAGE: '[issue-id]'


### PR DESCRIPTION
This reverts commit 9f2e9ee519c8be3da81f822a88fec422cfc998e6 and disables the Codefresh reporting step in the build.