### PR TITLE
feat: Allow receiving big integer(int64) values as string as well

### DIFF
--- a/lib/container/set.go
+++ b/lib/container/set.go
@@ -28,6 +28,10 @@ func NewHashSet(s ...string) HashSet {
 	return set
 }
 
+func (set *HashSet) Length() int {
+	return len(set.stringMap)
+}
+
 func (set *HashSet) Insert(s ...string) {
 	for _, ss := range s {
 		set.stringMap[ss] = struct{}{}

--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -386,3 +386,63 @@ func TestCollection_Object(t *testing.T) {
 		require.NoError(t, coll.Validate(v))
 	}
 }
+
+func TestCollection_Int64(t *testing.T) {
+	reqSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer"
+			},
+			"simple_object": {
+				"type": "object"
+			},
+			"nested_object": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"obj": {
+						"type": "object",
+						"properties": {
+							"intField": { "type": "integer" }
+						}
+					}
+				}
+			},
+			"array_items": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"item_name": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"array_simple_items": {
+				"type": "array",
+				"items": {
+					"type": "integer"
+				}
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	schFactory, err := Build("t1", reqSchema)
+	require.NoError(t, err)
+	coll := NewDefaultCollection("t1", 1, 1, schFactory.CollectionType, schFactory.Fields, schFactory.Indexes, schFactory.Schema, "t1")
+	require.Equal(t, 4, len(coll.Int64FieldsPath))
+	_, ok := coll.Int64FieldsPath["id"]
+	require.True(t, ok)
+	_, ok = coll.Int64FieldsPath["nested_object.obj.intField"]
+	require.True(t, ok)
+	_, ok = coll.Int64FieldsPath["array_items.id"]
+	require.True(t, ok)
+	_, ok = coll.Int64FieldsPath["array_simple_items"]
+	require.True(t, ok)
+}

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -379,6 +379,16 @@ func (f *Field) IsCompatible(f1 *Field) error {
 	return nil
 }
 
+func (f *Field) GetNestedField(name string) *Field {
+	for _, r := range f.Fields {
+		if r.FieldName == name {
+			return r
+		}
+	}
+
+	return nil
+}
+
 type QueryableField struct {
 	FieldName     string
 	InMemoryAlias string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -241,10 +241,15 @@ func deserializeProperties(properties jsoniter.RawMessage, primaryKeysSet contai
 			// fields
 			var nestedFields []*Field
 			if len(builder.Items.Properties) > 0 {
+				builder.Fields = []*Field{
+					{
+						DataType: ObjectType,
+					},
+				}
 				if nestedFields, err = deserializeProperties(builder.Items.Properties, primaryKeysSet); err != nil {
 					return err
 				}
-				builder.Fields = nestedFields
+				builder.Fields[0].Fields = nestedFields
 			} else {
 				// if it is simple item type
 				var f *Field

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -198,13 +198,15 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		require.Equal(t, "name", coll.Fields[5].Fields[0].FieldName)
 
 		require.Equal(t, "product_items", coll.Fields[6].FieldName)
-		require.Equal(t, 3, len(coll.Fields[6].Fields))
-		require.Equal(t, Int64Type, coll.Fields[6].Fields[0].DataType)
-		require.Equal(t, "id", coll.Fields[6].Fields[0].FieldName)
-		require.Equal(t, StringType, coll.Fields[6].Fields[1].DataType)
-		require.Equal(t, "item_name", coll.Fields[6].Fields[1].FieldName)
-		require.Equal(t, ArrayType, coll.Fields[6].Fields[2].DataType)
-		require.Equal(t, "nested_array", coll.Fields[6].Fields[2].FieldName)
+		require.Equal(t, ArrayType, coll.Fields[6].DataType)
+		require.Equal(t, 1, len(coll.Fields[6].Fields))
+		require.Equal(t, ObjectType, coll.Fields[6].Fields[0].DataType)
+		require.Equal(t, Int64Type, coll.Fields[6].Fields[0].Fields[0].DataType)
+		require.Equal(t, "id", coll.Fields[6].Fields[0].Fields[0].FieldName)
+		require.Equal(t, StringType, coll.Fields[6].Fields[0].Fields[1].DataType)
+		require.Equal(t, "item_name", coll.Fields[6].Fields[0].Fields[1].FieldName)
+		require.Equal(t, ArrayType, coll.Fields[6].Fields[0].Fields[2].DataType)
+		require.Equal(t, "nested_array", coll.Fields[6].Fields[0].Fields[2].FieldName)
 	})
 	t.Run("test_array_missing_items_error", func(t *testing.T) {
 		schema := []byte(`{

--- a/server/services/v1/conversion.go
+++ b/server/services/v1/conversion.go
@@ -1,0 +1,90 @@
+package v1
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tigrisdata/tigris/schema"
+)
+
+type payloadMutator struct {
+	collection *schema.DefaultCollection
+	mutated    bool
+}
+
+func newPayloadMutator(collection *schema.DefaultCollection) *payloadMutator {
+	return &payloadMutator{
+		collection: collection,
+		mutated:    false,
+	}
+}
+
+func (p *payloadMutator) isMutated() bool {
+	return p.mutated
+}
+
+func (p *payloadMutator) convertStringToInt64(doc map[string]any) error {
+	for key := range p.collection.GetInt64FieldsPath() {
+		keys := strings.Split(key, ".")
+		value, ok := doc[keys[0]]
+		if !ok {
+			continue
+		}
+
+		field := p.collection.GetField(keys[0])
+		if field == nil {
+			continue
+		}
+
+		if err := p.traverse(doc, value, keys[1:], field); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *payloadMutator) traverse(parentMap map[string]any, value any, keys []string, parentField *schema.Field) error {
+	var err error
+	if parentField.Type() == schema.Int64Type {
+		if conv, ok := value.(string); ok {
+			if parentMap[parentField.FieldName], err = strconv.ParseInt(conv, 10, 64); err != nil {
+				return err
+			}
+			p.mutated = true
+			return nil
+		}
+	}
+
+	switch converted := value.(type) {
+	case map[string]any:
+		value, ok := converted[keys[0]]
+		if !ok {
+			return nil
+		}
+
+		return p.traverse(converted, value, keys[1:], parentField.GetNestedField(keys[0]))
+	case []any:
+		// array should have a single nested field either as object or primitive type
+		field := parentField.Fields[0]
+		if field.DataType == schema.ObjectType {
+			// is object or simple type
+			for _, va := range converted {
+				if err := p.traverse(va.(map[string]any), va, keys, field); err != nil {
+					return err
+				}
+			}
+		} else if field.DataType == schema.Int64Type {
+			for idx := range converted {
+				if conv, ok := converted[idx].(string); ok {
+					if converted[idx], err = strconv.ParseInt(conv, 10, 64); err != nil {
+						return err
+					}
+					p.mutated = true
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/services/v1/conversion_test.go
+++ b/server/services/v1/conversion_test.go
@@ -1,0 +1,189 @@
+package v1
+
+import (
+	"bytes"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/lib/json"
+	"github.com/tigrisdata/tigris/schema"
+)
+
+func TestMutatePayload(t *testing.T) {
+	reqSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer"
+			},
+			"simple_object": {
+				"type": "object"
+			},
+			"nested_object": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"obj": {
+						"type": "object",
+						"properties": {
+							"intField": { "type": "integer" }
+						}
+					}
+				}
+			},
+			"array_items": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"item_name": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"array_simple_items": {
+				"type": "array",
+				"items": {
+					"type": "integer"
+				}
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	schFactory, err := schema.Build("t1", reqSchema)
+	require.NoError(t, err)
+	coll := schema.NewDefaultCollection("t1", 1, 1, schFactory.CollectionType, schFactory.Fields, schFactory.Indexes, schFactory.Schema, "t1")
+	require.Equal(t, 4, len(coll.Int64FieldsPath))
+
+	cases := []struct {
+		input   []byte
+		mutated bool
+		output  []byte
+	}{
+		// top level
+		{
+			[]byte(`{"name":"test","id":"9223372036854775800","brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// nested object
+		{
+			[]byte(`{"name":"test","id":"9223372036854775800","brand":"random","nested_object":{"obj": {"intField": "9223372036854775800"}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// all elements of array
+
+		{
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": "9223372036854775801"}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// all elements of primitive array
+
+		{
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":["9223372036854775800", "9223372036854775801", "9223372036854775802"]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// mixed int and string combos
+		{
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": "9223372036854775800"}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, "9223372036854775801", 9223372036854775802]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// mixed int and string combos
+		{
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": "9223372036854775800"}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, "9223372036854775801", 9223372036854775802]}`),
+			true,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+		// no changes
+		{
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+			false,
+			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
+		},
+	}
+	for _, c := range cases {
+		doc, err := json.Decode(c.input)
+		require.NoError(t, err)
+
+		p := newPayloadMutator(coll)
+		require.NoError(t, p.convertStringToInt64(doc))
+		require.Equal(t, c.mutated, p.isMutated())
+
+		actualJS, err := json.Encode(doc)
+		require.NoError(t, err)
+		require.JSONEq(t, string(c.output), string(actualJS))
+	}
+}
+
+func BenchmarkStringToInteger(b *testing.B) {
+	reqSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer"
+			},
+			"simple_object": {
+				"type": "object"
+			},
+			"nested_object": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"obj": {
+						"type": "object",
+						"properties": {
+							"intField": { "type": "integer" }
+						}
+					}
+				}
+			},
+			"array_items": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"item_name": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"array_simple_items": {
+				"type": "array",
+				"items": {
+					"type": "integer"
+				}
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	schFactory, err := schema.Build("t1", reqSchema)
+	require.NoError(b, err)
+	coll := schema.NewDefaultCollection("t1", 1, 1, schFactory.CollectionType, schFactory.Fields, schFactory.Indexes, schFactory.Schema, "t1")
+	require.Equal(b, 4, len(coll.Int64FieldsPath))
+
+	data := []byte(`{"name":"fiona handbag","id":9223372036854775800,"brand":"michael kors","nested_object":{"obj": {"intField": "9223372036854775800"}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, "9223372036854775801", 9223372036854775802]}`)
+	var deserializedDoc map[string]interface{}
+	dec := jsoniter.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		p := newPayloadMutator(coll)
+		require.NoError(b, p.convertStringToInt64(deserializedDoc))
+	}
+}

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -381,6 +381,57 @@ func TestInsert_SingleRow(t *testing.T) {
 	require.Equal(t, expDoc, actualDoc)
 }
 
+func TestInsert_StringInt64(t *testing.T) {
+	db, coll := setupTests(t)
+	defer cleanupTests(t, db)
+
+	inputDocument := []Doc{
+		{
+			"pkey_int":     "9223372036854775799",
+			"int_value":    "9223372036854775800",
+			"string_value": "simple_insert",
+			"array_value": []Doc{
+				{
+					"id":      "9223372036854775801",
+					"product": "foo",
+				}, {
+					"id":      9223372036854775802,
+					"product": "foo",
+				},
+			},
+			"object_value": Map{
+				"bignumber": "9223372036854775751",
+			},
+		},
+	}
+
+	tstart := time.Now().UTC()
+	expect(t).POST(getDocumentURL(db, coll, "insert")).
+		WithJSON(Map{
+			"documents": inputDocument,
+		}).
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().
+		ValueEqual("status", "inserted").
+		ValueEqual("keys", []map[string]interface{}{{"pkey_int": 9223372036854775799}}).
+		Path("$.metadata").Object().
+		Value("created_at").String().DateTime(time.RFC3339Nano).InRange(tstart, time.Now().UTC().Add(1*time.Second))
+
+	readResp := readByFilter(t, db, coll, Map{
+		"pkey_int": 9223372036854775799,
+	}, nil, nil)
+
+	var doc map[string]json.RawMessage
+	require.Equal(t, 1, len(readResp))
+	require.NoError(t, json.Unmarshal(readResp[0]["result"], &doc))
+
+	var actualDoc = []byte(doc["data"])
+	expDoc := []byte(`{"pkey_int":9223372036854776000,"int_value":9223372036854776000,"string_value":"simple_insert","array_value":[{"id":9223372036854776000,"product":"foo"},{"id":9223372036854776000,"product":"foo"}],"object_value":{"bignumber":9223372036854776000}}`)
+	require.JSONEq(t, string(expDoc), string(actualDoc))
+}
+
 func TestInsert_MultipleRows(t *testing.T) {
 	db, coll := setupTests(t)
 	defer cleanupTests(t, db)

--- a/test/v1/server/integration_test.go
+++ b/test/v1/server/integration_test.go
@@ -37,76 +37,79 @@ var (
 type Map map[string]interface{}
 type Doc Map
 
-var testCreateSchema = map[string]interface{}{
-	"schema": map[string]interface{}{
+var testCreateSchema = Map{
+	"schema": Map{
 		"title":       testCollection,
 		"description": "this schema is for integration tests",
-		"properties": map[string]interface{}{
-			"pkey_int": map[string]interface{}{
+		"properties": Map{
+			"pkey_int": Map{
 				"description": "primary key field",
 				"type":        "integer",
 			},
-			"int_value": map[string]interface{}{
+			"int_value": Map{
 				"description": "simple int field",
 				"type":        "integer",
 			},
-			"string_value": map[string]interface{}{
+			"string_value": Map{
 				"description": "simple string field",
 				"type":        "string",
 				"maxLength":   128,
 			},
-			"added_string_value": map[string]interface{}{
+			"added_string_value": Map{
 				"description": "simple string field",
 				"type":        "string",
 			},
-			"bool_value": map[string]interface{}{
+			"bool_value": Map{
 				"description": "simple boolean field",
 				"type":        "boolean",
 			},
-			"double_value": map[string]interface{}{
+			"double_value": Map{
 				"description": "simple double field",
 				"type":        "number",
 			},
-			"added_value_double": map[string]interface{}{
+			"added_value_double": Map{
 				"description": "simple double field",
 				"type":        "number",
 			},
-			"bytes_value": map[string]interface{}{
+			"bytes_value": Map{
 				"description": "simple bytes field",
 				"type":        "string",
 				"format":      "byte",
 			},
-			"uuid_value": map[string]interface{}{
+			"uuid_value": Map{
 				"description": "uuid field",
 				"type":        "string",
 				"format":      "uuid",
 			},
-			"date_time_value": map[string]interface{}{
+			"date_time_value": Map{
 				"description": "date time field",
 				"type":        "string",
 				"format":      "date-time",
 			},
-			"array_value": map[string]interface{}{
+			"array_value": Map{
 				"description": "array field",
 				"type":        "array",
-				"items": map[string]interface{}{
+				"items": Map{
 					"type": "object",
-					"properties": map[string]interface{}{
-						"id": map[string]interface{}{
+					"properties": Map{
+						"id": Map{
 							"type": "integer",
 						},
-						"product": map[string]interface{}{
+						"product": Map{
 							"type": "string",
 						},
 					},
 				},
 			},
-			"object_value": map[string]interface{}{
+			"object_value": Map{
 				"description": "object field",
 				"type":        "object",
-				"properties": map[string]interface{}{
-					"name": map[string]interface{}{
+				"properties": Map{
+					"name": Map{
 						"type": "string",
+					},
+					"bignumber": Map{
+						"type": "integer",
 					},
 				},
 			},


### PR DESCRIPTION
- The schema validation for these numbers will still be performed as an integer. 
- This allows us to support language clients in JavaScript and TypeScript where bigInt is getting serialized as a string and the caller needs to send a big integer as a string on the wire.  