### PR TITLE
Do not build Docker images on pushing to release branch

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-      - alpha
-      - beta
   release:
     types: [published]
   workflow_call:

--- a/.github/workflows/push-docker-local-image.yaml
+++ b/.github/workflows/push-docker-local-image.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-      - alpha
-      - beta
   release:
     types: [published]
   workflow_call:


### PR DESCRIPTION
We build Docker images twice:
  * on release
  * on push

It's not guaranteed which one finishes first, so "on push" may overwrite the image from "on release" leading to wrong "tigris server version" output, so as release tag is not available on push.