### PR TITLE
Quota fixes

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -21,31 +21,38 @@ import (
 )
 
 const (
-	methodPrefix = "/tigrisdata.v1.Tigris/"
+	HealthMethodName = "/HealthAPI/Health"
 
-	InsertMethodName  = methodPrefix + "Insert"
-	ReplaceMethodName = methodPrefix + "Replace"
-	UpdateMethodName  = methodPrefix + "Update"
-	DeleteMethodName  = methodPrefix + "Delete"
-	ReadMethodName    = methodPrefix + "Read"
+	apiMethodPrefix = "/tigrisdata.v1.Tigris/"
 
-	SearchMethodName = methodPrefix + "Search"
+	InsertMethodName  = apiMethodPrefix + "Insert"
+	ReplaceMethodName = apiMethodPrefix + "Replace"
+	UpdateMethodName  = apiMethodPrefix + "Update"
+	DeleteMethodName  = apiMethodPrefix + "Delete"
+	ReadMethodName    = apiMethodPrefix + "Read"
 
-	SubscribeMethodName = methodPrefix + "Subscribe"
+	SearchMethodName = apiMethodPrefix + "Search"
 
-	EventsMethodName = methodPrefix + "Events"
+	SubscribeMethodName = apiMethodPrefix + "Subscribe"
 
-	CommitTransactionMethodName   = methodPrefix + "CommitTransaction"
-	RollbackTransactionMethodName = methodPrefix + "RollbackTransaction"
+	EventsMethodName = apiMethodPrefix + "Events"
 
-	CreateOrUpdateCollectionMethodName = methodPrefix + "CreateOrUpdateCollection"
-	DropCollectionMethodName           = methodPrefix + "DropCollection"
+	CommitTransactionMethodName   = apiMethodPrefix + "CommitTransaction"
+	RollbackTransactionMethodName = apiMethodPrefix + "RollbackTransaction"
 
-	ListDatabasesMethodName   = methodPrefix + "ListDatabases"
-	ListCollectionsMethodName = methodPrefix + "ListCollections"
+	CreateOrUpdateCollectionMethodName = apiMethodPrefix + "CreateOrUpdateCollection"
+	DropCollectionMethodName           = apiMethodPrefix + "DropCollection"
 
-	DescribeDatabaseMethodName   = methodPrefix + "DescribeDatabase"
-	DescribeCollectionMethodName = methodPrefix + "DescribeCollection"
+	DropDatabaseMethodName = apiMethodPrefix + "DropDatabase"
+
+	ListDatabasesMethodName   = apiMethodPrefix + "ListDatabases"
+	ListCollectionsMethodName = apiMethodPrefix + "ListCollections"
+
+	DescribeDatabaseMethodName   = apiMethodPrefix + "DescribeDatabase"
+	DescribeCollectionMethodName = apiMethodPrefix + "DescribeCollection"
+
+	ObservabilityMethodPrefix = "/tigrisdata.observability.v1.Observability/"
+	ManagementMethodPrefix    = "/tigrisdata.management.v1.Management/"
 )
 
 func IsTxSupported(ctx context.Context) bool {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -46,7 +46,7 @@ func Unauthenticated(format string, args ...any) error {
 }
 
 // ResourceExhausted constructs too many requests error (HTTP: 429).
-func ResourceExhausted(format string, args ...any) error {
+func ResourceExhausted(format string, args ...any) *api.TigrisError {
 	return api.Errorf(api.Code_RESOURCE_EXHAUSTED, format, args...)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/DataDog/datadog-api-client-go v1.16.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.3.1
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
 	github.com/auth0/go-auth0 v0.9.3
 	github.com/auth0/go-jwt-middleware/v2 v2.0.1
@@ -37,6 +38,7 @@ require (
 	github.com/ugorji/go/codec v1.2.7
 	github.com/valyala/bytebufferpool v1.0.0
 	go.uber.org/atomic v1.9.0
+	golang.org/x/net v0.0.0-20220726230323-06994584191e
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
 	google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b
 	google.golang.org/grpc v1.48.0
@@ -118,7 +120,6 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
-	golang.org/x/net v0.0.0-20220726230323-06994584191e // indirect
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/DataDog/datadog-agent/pkg/obfuscate v0.38.0 h1:Mk1GqUitDrsZBvNIR4G/GF
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.38.0/go.mod h1:MxVcCIC42tBIjPm93BHdh9/vw2LivRiptj3HygI+GGQ=
 github.com/DataDog/datadog-api-client-go v1.16.0 h1:5jOZv1m98criCvYTa3qpW8Hzv301nbZX3K9yJtwGyWY=
 github.com/DataDog/datadog-api-client-go v1.16.0/go.mod h1:PgrP2ABuJWL3Auw2iEkemAJ/r72ghG4DQQmb5sgnKW4=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1 h1:+0FHme5n4AuJEGmzaN8+n3OWKFLiJoBP+FNI60EqvuU=
+github.com/DataDog/datadog-api-client-go/v2 v2.3.1/go.mod h1:98b/MtTwSAr/yhTfhCR1oxAqQ/4tMkdrgKH7fYiDA0g=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.0.2/go.mod h1:ZI9JFB4ewXbw1sBnF4sxsR2k1H3xjV+PUAOUsHvKpcU=

--- a/server/metrics/quota.go
+++ b/server/metrics/quota.go
@@ -81,5 +81,5 @@ func UpdateQuotaCurrentNodeLimit(namespaceName string, value int, isWrite bool) 
 		counter = "write_limit"
 	}
 
-	QuotaSet.Tagged(getQuotaUsageTags(namespaceName)).Counter(counter).Inc(int64(value))
+	QuotaSet.Tagged(getQuotaUsageTags(namespaceName)).Gauge(counter).Update(float64(value))
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -39,7 +39,7 @@ var (
 	headerAuthorize           = "authorization"
 	UnknownNamespace          = "unknown"
 	BypassAuthForTheseMethods = container.NewHashSet(
-		"/HealthAPI/Health",
+		api.HealthMethodName,
 		"/tigrisdata.auth.v1.Auth/GetAccessToken",
 		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 	)

--- a/server/middleware/measure.go
+++ b/server/middleware/measure.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/request"
 	"github.com/tigrisdata/tigris/util"
@@ -37,7 +38,7 @@ type wrappedStream struct {
 
 func getNoMeasurementMethods() []string {
 	return []string{
-		"/HealthAPI/Health",
+		api.HealthMethodName,
 	}
 }
 

--- a/server/middleware/namespace.go
+++ b/server/middleware/namespace.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/lib/container"
 	"github.com/tigrisdata/tigris/server/request"
 	"google.golang.org/grpc"
@@ -25,7 +26,7 @@ import (
 
 var (
 	excludedMethods = container.NewHashSet(
-		"/HealthAPI/Health",
+		api.HealthMethodName,
 		"/tigrisdata.admin.v1.Admin/createNamespace",
 		"/tigrisdata.admin.v1.Admin/listNamespaces",
 	)

--- a/server/quota/datadog.go
+++ b/server/quota/datadog.go
@@ -31,12 +31,12 @@ type Datadog struct {
 }
 
 func (d *Datadog) CurRates(ctx context.Context, namespace string) (int64, int64, error) {
-	r, err := d.Datadog.GetCurrentMetricValue(ctx, namespace, "tigris.quota.usage.read_units", api.TigrisOperation_ALL, RunningAverageLength)
+	r, err := d.Datadog.GetCurrentMetricValue(ctx, namespace, "tigris.quota_usage_read_units.count", api.TigrisOperation_ALL, RunningAverageLength)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	w, err := d.Datadog.GetCurrentMetricValue(ctx, namespace, "tigris.quota.usage.write_units", api.TigrisOperation_ALL, RunningAverageLength)
+	w, err := d.Datadog.GetCurrentMetricValue(ctx, namespace, "tigris.quota_usage_write_units.count", api.TigrisOperation_ALL, RunningAverageLength)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/server/quota/limiter.go
+++ b/server/quota/limiter.go
@@ -64,9 +64,9 @@ func (l *Limiter) Allow(size int) (err error) {
 
 	if !rt.OK() || rt.Delay() > 0 {
 		if l.isWrite {
-			return ErrWriteUnitsExceeded
+			return ErrWriteUnitsExceeded.WithRetry(rt.Delay())
 		}
-		return ErrReadUnitsExceeded
+		return ErrReadUnitsExceeded.WithRetry(rt.Delay())
 	}
 
 	return nil
@@ -97,9 +97,9 @@ func (l *Limiter) Wait(ctx context.Context, size int) (err error) {
 
 	if !rt.OK() || dur < rt.DelayFrom(now) {
 		if l.isWrite {
-			return ErrWriteUnitsExceeded
+			return ErrWriteUnitsExceeded.WithRetry(rt.DelayFrom(now))
 		}
-		return ErrReadUnitsExceeded
+		return ErrReadUnitsExceeded.WithRetry(rt.DelayFrom(now))
 	}
 
 	delay := rt.DelayFrom(now)

--- a/server/request/request_test.go
+++ b/server/request/request_test.go
@@ -26,7 +26,7 @@ import (
 func TestRequestMetadata(t *testing.T) {
 	t.Run("extraction of namespace name", func(t *testing.T) {
 		ctx := context.TODO()
-		ctx = context.WithValue(ctx, RequestMetadataCtxKey{}, &RequestMetadata{
+		ctx = context.WithValue(ctx, MetadataCtxKey{}, &Metadata{
 			accessToken: &AccessToken{
 				Namespace: "test-namespace-1",
 				Sub:       "test@tigrisdata.com",
@@ -41,7 +41,7 @@ func TestRequestMetadata(t *testing.T) {
 
 	t.Run("extraction of token", func(t *testing.T) {
 		ctx := context.TODO()
-		ctx = context.WithValue(ctx, RequestMetadataCtxKey{}, &RequestMetadata{
+		ctx = context.WithValue(ctx, MetadataCtxKey{}, &Metadata{
 			accessToken: &AccessToken{
 				Namespace: "test-namespace-1",
 				Sub:       "test@tigrisdata.com",


### PR DESCRIPTION
* Allow blacklisting of namespaces
* Optionally limited default_namespace
* Attach retry info to rate errors
* Fix Datadog connection
* Return throttling statistics in quota usage API
* Return non-retriable error if request hard limit exceeded
* Properly categorize observability, management and admin APIs
* Other bugfixes and refactoring
* Exclude DropDatabase/DropCollection from storage quota checking
