### PR TITLE
refactor: Simplified namespace API

### DIFF
--- a/server/metadata/dictionary_test.go
+++ b/server/metadata/dictionary_test.go
@@ -424,7 +424,7 @@ func TestReservedNamespace(t *testing.T) {
 	tx, err = tm.StartTx(ctx)
 	require.NoError(t, err)
 	require.NoError(t, r.reload(ctx, tx))
-	require.Equal(t, "p1-o1", r.idToNamespaceStruct[123].Name)
+	require.Equal(t, "p1-o1", r.idToNamespaceStruct[123].StrId)
 
 	// try assigning the same namespace id to some other namespace
 	tx, err = tm.StartTx(context.TODO())

--- a/server/metadata/key_encoder_test.go
+++ b/server/metadata/key_encoder_test.go
@@ -39,10 +39,10 @@ func TestEncodeDecodeKey(t *testing.T) {
 
 	mgr := &TenantManager{
 		idToTenantMap: map[uint32]string{
-			ns.Id(): ns.Name(),
+			ns.Id(): ns.StrId(),
 		},
 		tenants: map[string]*Tenant{
-			ns.Name(): {
+			ns.StrId(): {
 				namespace: ns,
 				databases: map[string]*Database{
 					db.name: db,
@@ -71,7 +71,7 @@ func TestEncodeDecodeKey(t *testing.T) {
 	tenantName, dbName, collName, ok := mgr.GetTableNameFromIds(tenantID, dbID, collID)
 	require.True(t, ok)
 
-	require.Equal(t, ns.Name(), tenantName)
+	require.Equal(t, ns.StrId(), tenantName)
 	require.Equal(t, db.name, dbName)
 	require.Equal(t, coll.Name, collName)
 	require.True(t, ok)

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -42,7 +42,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		require.NoError(t, err)
 
 		tenant := m.tenants["ns-test1"]
-		require.Equal(t, "ns-test1", tenant.namespace.Name())
+		require.Equal(t, "ns-test1", tenant.namespace.StrId())
 		require.Equal(t, uint32(2), tenant.namespace.Id())
 		require.Equal(t, "ns-test1", m.idToTenantMap[uint32(2)])
 		require.Empty(t, tenant.databases)
@@ -60,7 +60,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		require.NoError(t, err)
 
 		tenant := m.tenants["ns-test1"]
-		require.Equal(t, "ns-test1", tenant.namespace.Name())
+		require.Equal(t, "ns-test1", tenant.namespace.StrId())
 		require.Equal(t, uint32(2), tenant.namespace.Id())
 		require.Equal(t, "ns-test1", m.idToTenantMap[uint32(2)])
 
@@ -68,7 +68,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		require.Empty(t, tenant.idToDatabaseMap)
 
 		tenant = m.tenants["ns-test2"]
-		require.Equal(t, "ns-test2", tenant.namespace.Name())
+		require.Equal(t, "ns-test2", tenant.namespace.StrId())
 		require.Equal(t, uint32(3), tenant.namespace.Id())
 		require.Equal(t, "ns-test2", m.idToTenantMap[uint32(3)])
 		require.Empty(t, tenant.databases)
@@ -84,7 +84,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 
 		// should fail now
 		_, err = m.CreateOrGetTenant(ctx, &TenantNamespace{"ns-test1", 3, NewNamespaceMetadata(3, "ns-test1", "ns-test1-display_name")})
-		require.Equal(t, "id is already assigned to 'ns-test1'", err.(*api.TigrisError).Error())
+		require.Equal(t, "id is already assigned to strId='ns-test1'", err.(*api.TigrisError).Error())
 
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
@@ -182,9 +182,9 @@ func TestTenantManager_CreateDatabases(t *testing.T) {
 		defer cancel()
 
 		_, err := m.CreateOrGetTenant(ctx, &TenantNamespace{"ns-test1", 2, NamespaceMetadata{
-			Id:          2,
-			Name:        "ns-test1",
-			DisplayName: "ns-test1-displayName",
+			Id:    2,
+			StrId: "ns-test1",
+			Name:  "ns-test1-displayName",
 		}})
 		require.NoError(t, err)
 		tenant := m.tenants["ns-test1"]

--- a/server/metadata/tenant_tracker.go
+++ b/server/metadata/tenant_tracker.go
@@ -74,8 +74,8 @@ func (cacheTracker *CacheTracker) addTenantIfNotTracked(tenant *Tenant) {
 	cacheTracker.Lock()
 	defer cacheTracker.Unlock()
 
-	if _, ok := cacheTracker.tenantVersions[tenant.namespace.Name()]; !ok {
-		cacheTracker.tenantVersions[tenant.namespace.Name()] = tenant.version
+	if _, ok := cacheTracker.tenantVersions[tenant.namespace.StrId()]; !ok {
+		cacheTracker.tenantVersions[tenant.namespace.StrId()] = tenant.version
 	}
 }
 
@@ -83,7 +83,7 @@ func (cacheTracker *CacheTracker) getTenantVersion(tenant *Tenant) (Version, boo
 	cacheTracker.RLock()
 	defer cacheTracker.RUnlock()
 
-	version, ok := cacheTracker.tenantVersions[tenant.namespace.Name()]
+	version, ok := cacheTracker.tenantVersions[tenant.namespace.StrId()]
 	return version, ok
 }
 
@@ -109,7 +109,7 @@ func (cacheTracker *CacheTracker) InstantTracking(ctx context.Context, tx transa
 
 	tracker := &Tracker{
 		endVersion:   version,
-		tenant:       tenant.namespace.Name(),
+		tenant:       tenant.namespace.StrId(),
 		startVersion: tenantVersion,
 	}
 	tracker.stopCB = func(ctx context.Context) (bool, error) {
@@ -139,7 +139,7 @@ func (cacheTracker *CacheTracker) DeferredTracking(ctx context.Context, tx trans
 
 	tracker := &Tracker{
 		future:       future,
-		tenant:       tenant.namespace.Name(),
+		tenant:       tenant.namespace.StrId(),
 		startVersion: tenantVersion,
 	}
 
@@ -178,7 +178,7 @@ func (cacheTracker *CacheTracker) stopTracking(ctx context.Context, tenant *Tena
 
 	cacheTracker.Lock()
 	defer cacheTracker.Unlock()
-	if bytes.Compare(cacheTracker.tenantVersions[tenant.namespace.Name()], tracker.endVersion) >= 0 {
+	if bytes.Compare(cacheTracker.tenantVersions[tenant.namespace.StrId()], tracker.endVersion) >= 0 {
 		// check again to avoid reloading multiple times
 		return nil
 	}
@@ -207,6 +207,6 @@ func (cacheTracker *CacheTracker) stopTracking(ctx context.Context, tenant *Tena
 		return err
 	}
 
-	cacheTracker.tenantVersions[tenant.namespace.Name()] = version
+	cacheTracker.tenantVersions[tenant.namespace.StrId()] = version
 	return nil
 }


### PR DESCRIPTION
Namespace object has been refactored as follows:

api to internal mapping:

- `id` --> `strId`
- `code` --> `id`
- `name` --> `name`

internal refactor:
- Renamed `name` --> `strId`.
- Renamed `displayName` --> `name`.