### PR TITLE
feat: Support filtering on array of objects or  array of primitive types

### DIFF
--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -222,12 +222,16 @@ func (factory *Factory) ParseSelector(k []byte, v []byte, dataType jsonparser.Va
 
 	switch dataType {
 	case jsonparser.Boolean, jsonparser.Number, jsonparser.String:
+		tigrisType := field.DataType
+		if tigrisType == schema.ArrayType {
+			tigrisType = field.SubType
+		}
 		var val value.Value
 		var err error
 		if factory.collation != nil {
-			val, err = value.NewValueUsingCollation(field.DataType, v, factory.collation)
+			val, err = value.NewValueUsingCollation(tigrisType, v, factory.collation)
 		} else {
-			val, err = value.NewValue(field.DataType, v)
+			val, err = value.NewValue(tigrisType, v)
 		}
 		if err != nil {
 			return nil, err
@@ -281,11 +285,15 @@ func buildValueMatcher(input jsoniter.RawMessage, field *schema.QueryableField) 
 		case EQ, GT, GTE, LT, LTE:
 			switch dataType {
 			case jsonparser.Boolean, jsonparser.Number, jsonparser.String, jsonparser.Null:
+				tigrisType := field.DataType
+				if dataType == jsonparser.Array {
+					tigrisType = field.SubType
+				}
 				var val value.Value
 				if collation != nil {
-					val, err = value.NewValueUsingCollation(field.DataType, v, collation)
+					val, err = value.NewValueUsingCollation(tigrisType, v, collation)
 				} else {
-					val, err = value.NewValue(field.DataType, v)
+					val, err = value.NewValue(tigrisType, v)
 				}
 				if err != nil {
 					return err

--- a/query/filter/logical_test.go
+++ b/query/filter/logical_test.go
@@ -24,18 +24,18 @@ import (
 func TestLogicalToSearch(t *testing.T) {
 	factory := Factory{
 		fields: []*schema.QueryableField{
-			schema.NewQueryableField("f1", schema.Int64Type),
-			schema.NewQueryableField("f2", schema.Int64Type),
-			schema.NewQueryableField("f3", schema.Int64Type),
-			schema.NewQueryableField("f4", schema.Int64Type),
-			schema.NewQueryableField("f5", schema.Int64Type),
-			schema.NewQueryableField("f6", schema.Int64Type),
-			schema.NewQueryableField("a", schema.Int64Type),
-			schema.NewQueryableField("b", schema.Int64Type),
-			schema.NewQueryableField("c", schema.Int64Type),
-			schema.NewQueryableField("d", schema.Int64Type),
-			schema.NewQueryableField("e", schema.Int64Type),
-			schema.NewQueryableField("f", schema.Int64Type),
+			schema.NewSimpleQueryableField("f1", schema.Int64Type),
+			schema.NewSimpleQueryableField("f2", schema.Int64Type),
+			schema.NewSimpleQueryableField("f3", schema.Int64Type),
+			schema.NewSimpleQueryableField("f4", schema.Int64Type),
+			schema.NewSimpleQueryableField("f5", schema.Int64Type),
+			schema.NewSimpleQueryableField("f6", schema.Int64Type),
+			schema.NewSimpleQueryableField("a", schema.Int64Type),
+			schema.NewSimpleQueryableField("b", schema.Int64Type),
+			schema.NewSimpleQueryableField("c", schema.Int64Type),
+			schema.NewSimpleQueryableField("d", schema.Int64Type),
+			schema.NewSimpleQueryableField("e", schema.Int64Type),
+			schema.NewSimpleQueryableField("f", schema.Int64Type),
 		},
 	}
 

--- a/query/search/search_test.go
+++ b/query/search/search_test.go
@@ -27,9 +27,9 @@ import (
 func TestSearchBuilder(t *testing.T) {
 	js := []byte(`{"a": 4, "$and": [{"int_value":1}, {"string_value1": "shoe"}]}`)
 	f := filter.NewFactory([]*schema.QueryableField{
-		schema.NewQueryableField("a", schema.Int64Type),
-		schema.NewQueryableField("int_value", schema.Int64Type),
-		schema.NewQueryableField("string_value1", schema.StringType),
+		schema.NewSimpleQueryableField("a", schema.Int64Type),
+		schema.NewSimpleQueryableField("int_value", schema.Int64Type),
+		schema.NewSimpleQueryableField("string_value1", schema.StringType),
 	}, nil)
 	wrappedF, err := f.WrappedFilter(js)
 	require.NoError(t, err)

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -142,12 +142,10 @@ func TestQueryableField_ShouldPack(t *testing.T) {
 		})
 	}
 
-	for _, f := range [...]FieldType{ArrayType, DateTimeType} {
-		t.Run(fmt.Sprintf("%s should be packed", FieldNames[f]), func(t *testing.T) {
-			q := &QueryableField{FieldName: "myField", DataType: f}
-			require.True(t, q.ShouldPack())
-		})
-	}
+	t.Run(fmt.Sprintf("%s should be packed", FieldNames[DateTimeType]), func(t *testing.T) {
+		q := &QueryableField{FieldName: "myField", DataType: DateTimeType}
+		require.True(t, q.ShouldPack())
+	})
 
 	shouldNotPack := [...]FieldType{
 		UnknownType,
@@ -159,6 +157,7 @@ func TestQueryableField_ShouldPack(t *testing.T) {
 		StringType,
 		ByteType,
 		ObjectType,
+		ArrayType,
 	}
 	for _, f := range shouldNotPack {
 		t.Run(fmt.Sprintf("%s should not be packed", FieldNames[f]), func(t *testing.T) {
@@ -166,6 +165,11 @@ func TestQueryableField_ShouldPack(t *testing.T) {
 			require.False(t, q.ShouldPack())
 		})
 	}
+
+	t.Run(fmt.Sprintf("%s should not be packed", FieldNames[ArrayType]), func(t *testing.T) {
+		q := &QueryableField{FieldName: "myField", DataType: ArrayType, PackThis: true}
+		require.True(t, q.ShouldPack())
+	})
 }
 
 func TestQueryableField_IsReserved(t *testing.T) {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -369,6 +369,35 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 			}
 		}
 	})
+	t.Run("test_setting_indexing_version", func(t *testing.T) {
+		schema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"K1": {
+				"type": "integer"
+			},
+			"K2": {
+				"type": "int"
+			}
+		},
+		"primary_key": ["K1"]
+	}`)
+		outSchema, err := SetIndexingVersion(schema)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"title": "t1",
+				"properties": {
+				"K1": {
+					"type": "integer"
+				},
+				"K2": {
+					"type": "int"
+				}
+			},
+			"primary_key": ["K1"],
+			"indexing_version": "v1"
+	}`, string(outSchema))
+	})
 }
 
 func TestGetCollectionType(t *testing.T) {

--- a/scripts/install_local_docker_deps.sh
+++ b/scripts/install_local_docker_deps.sh
@@ -61,9 +61,10 @@ echo "docker:docker@127.0.0.1:4500" >/etc/foundationdb/fdb.cluster
 dpkg --force-confold --configure foundationdb-server
 rm -f "$FDB_PACKAGE_PATH"
 
-TS_PACKAGE_NAME="typesense-server-0.23.0-${ARCH}.deb"
+TS_RELEASE_VERSION="0.23.1"
+TS_PACKAGE_NAME="typesense-server-${TS_RELEASE_VERSION}-${ARCH}.deb"
 TS_PACKAGE_PATH="$(mktemp -p /tmp/ -u)/${TS_PACKAGE_NAME}"
-curl --create-dirs -Lo "$TS_PACKAGE_PATH" "https://dl.typesense.org/releases/0.23.0/${TS_PACKAGE_NAME}"
+curl --create-dirs -Lo "$TS_PACKAGE_PATH" "https://dl.typesense.org/releases/${TS_RELEASE_VERSION}/${TS_PACKAGE_NAME}"
 
 dpkg --unpack "$TS_PACKAGE_PATH"
 rm -f /var/lib/dpkg/info/typesense-server.postinst

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -296,6 +296,10 @@ func (s *apiService) CreateOrUpdateCollection(ctx context.Context, r *api.Create
 		return nil, errors.Internal("not able to extract collection type from the schema")
 	}
 
+	if r.Schema, err = schema.SetIndexingVersion(r.Schema); err != nil {
+		return nil, errors.Internal("not able to set indexing version")
+	}
+
 	runner := s.runnerFactory.GetCollectionQueryRunner()
 	runner.SetCreateOrUpdateCollectionReq(r)
 

--- a/server/services/v1/query_runner_test.go
+++ b/server/services/v1/query_runner_test.go
@@ -26,11 +26,15 @@ import (
 func TestSearchQueryRunner_getFacetFields(t *testing.T) {
 	collection := &schema.DefaultCollection{
 		QueryableFields: []*schema.QueryableField{
-			schema.NewQueryableField("field_1", schema.StringType),
-			schema.NewQueryableField("parent.field_2", schema.StringType),
-			schema.NewQueryableField("field_3", schema.ByteType),
-			schema.NewQueryableField("field_4", schema.StringType),
+			schema.NewSimpleQueryableField("field_1", schema.StringType),
+			schema.NewQueryableField("parent.field_2", schema.ObjectType, schema.Int32Type, nil, false),
+			schema.NewSimpleQueryableField("field_3", schema.ByteType),
+			schema.NewSimpleQueryableField("field_4", schema.StringType),
 		},
+	}
+	collection.NameToQueryableField = make(map[string]*schema.QueryableField)
+	for _, q := range collection.QueryableFields {
+		collection.NameToQueryableField[q.FieldName] = q
 	}
 	runner := &SearchQueryRunner{req: &api.SearchRequest{}}
 
@@ -83,9 +87,13 @@ func TestSearchQueryRunner_getFacetFields(t *testing.T) {
 func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 	collection := &schema.DefaultCollection{
 		QueryableFields: []*schema.QueryableField{
-			schema.NewQueryableField("field_1", schema.StringType),
-			schema.NewQueryableField("parent.field_2", schema.StringType),
+			schema.NewSimpleQueryableField("field_1", schema.StringType),
+			schema.NewQueryableField("parent.field_2", schema.ObjectType, schema.StringType, nil, false),
 		},
+	}
+	collection.NameToQueryableField = make(map[string]*schema.QueryableField)
+	for _, q := range collection.QueryableFields {
+		collection.NameToQueryableField[q.FieldName] = q
 	}
 
 	t.Run("only include fields are provided", func(t *testing.T) {
@@ -159,13 +167,17 @@ func TestSearchQueryRunner_getFieldSelection(t *testing.T) {
 func TestSearchQueryRunner_getSortOrdering(t *testing.T) {
 	collection := &schema.DefaultCollection{
 		QueryableFields: []*schema.QueryableField{
-			schema.NewQueryableField("field_1", schema.StringType),
-			schema.NewQueryableField("parent.field_2", schema.StringType),
-			schema.NewQueryableField("field_3", schema.ByteType),
+			schema.NewSimpleQueryableField("field_1", schema.StringType),
+			schema.NewQueryableField("parent.field_2", schema.ObjectType, schema.StringType, nil, false),
+			schema.NewSimpleQueryableField("field_3", schema.ByteType),
 		},
 	}
 	collection.QueryableFields[0].Sortable = true
 	collection.QueryableFields[1].Sortable = true
+	collection.NameToQueryableField = make(map[string]*schema.QueryableField)
+	for _, q := range collection.QueryableFields {
+		collection.NameToQueryableField[q.FieldName] = q
+	}
 
 	runner := &SearchQueryRunner{req: &api.SearchRequest{}}
 

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   tigris_search:
     container_name: tigris_search
-    image: typesense/typesense:0.23.0
+    image: typesense/typesense:0.23.1
     environment:
       - TYPESENSE_DATA_DIR=/tmp
       - TYPESENSE_API_KEY=ts_test_key


### PR DESCRIPTION
This allows to perform filtering on:
  - An array of objects
  - An object that has an array of objects
  - Primitive Arrays
  
Syntax to query remains the same,
  - For nested Array Objects: `{"filter":{"obj.arr_obj.field":"foo"}}`
  - For primitive arrays: `{"filter":{"arr_field":"foo"}}`
