### PR TITLE
feat: endpoint to get details for all namespaces

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -51,10 +51,11 @@ const (
 	DescribeDatabaseMethodName   = apiMethodPrefix + "DescribeDatabase"
 	DescribeCollectionMethodName = apiMethodPrefix + "DescribeCollection"
 
-	ObservabilityMethodPrefix = "/tigrisdata.observability.v1.Observability/"
-	ManagementMethodPrefix    = "/tigrisdata.management.v1.Management/"
-	CreateNamespaceMethodName = ManagementMethodPrefix + "CreateNamespace"
-	ListNamespaceMethodName   = ManagementMethodPrefix + "ListNamespaces"
+	ObservabilityMethodPrefix    = "/tigrisdata.observability.v1.Observability/"
+	ManagementMethodPrefix       = "/tigrisdata.management.v1.Management/"
+	CreateNamespaceMethodName    = ManagementMethodPrefix + "CreateNamespace"
+	ListNamespaceMethodName      = ManagementMethodPrefix + "ListNamespaces"
+	DescribeNamespacesMethodName = ManagementMethodPrefix + "DescribeNamespaces"
 
 	AuthMethodPrefix         = "/tigrisdata.auth.v1.Auth/"
 	GetAccessTokenMethodName = AuthMethodPrefix + "GetAccessToken"

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -41,7 +41,7 @@ const (
 	UnknownValue = "unknown"
 )
 
-var adminMethods = container.NewHashSet(api.CreateNamespaceMethodName, api.ListNamespaceMethodName)
+var adminMethods = container.NewHashSet(api.CreateNamespaceMethodName, api.ListNamespaceMethodName, api.DescribeNamespacesMethodName)
 
 type MetadataCtxKey struct{}
 


### PR DESCRIPTION
Get details for all namespaces in the form of:
```
{
	"ns1": {
		"db1": {
			"coll1": {
				"schema": {},
				"size": x,  
			}
		},
		"db2": {
			...
		}
	},
	"ns2": {}
}
```