### PR TITLE
feat: Add fdb metadata version read in health check

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -80,6 +80,12 @@ func Aborted(format string, args ...any) error {
 		format, args...)
 }
 
+// Unavailable constructs service unavailable error (HTTP: 503)
+func Unavailable(format string, args ...any) error {
+	return api.Errorf(api.Code_UNAVAILABLE,
+		format, args...)
+}
+
 // Unknown constructs internal server error (HTTP: 500).
 func Unknown(format string, args ...any) error {
 	return api.Errorf(api.Code_UNKNOWN,

--- a/server/services/v1/service.go
+++ b/server/services/v1/service.go
@@ -40,7 +40,7 @@ type Service interface {
 func GetRegisteredServices(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
 	var v1Services []Service
 	v1Services = append(v1Services, newApiService(kvStore, searchStore, tenantMgr, txMgr))
-	v1Services = append(v1Services, newHealthService())
+	v1Services = append(v1Services, newHealthService(txMgr))
 
 	userstore := metadata.NewUserStore(&metadata.DefaultMDNameRegistry{})
 	authProvider := getAuthProvider(userstore, txMgr)


### PR DESCRIPTION
This adds a check to read the FDB metadata version read in the health check. This will make sure the server and fdb are healthy. 



Close #168 