### PR TITLE
fix: set db, collection and network tags only once for stream requests

### DIFF
--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -55,6 +55,8 @@ type Measurement struct {
 	stopped      bool
 	startedAt    time.Time
 	stoppedAt    time.Time
+	dbCollTags   map[string]string
+	networkTags  map[string]string
 }
 
 type MeasurementCtxKey struct{}
@@ -90,6 +92,28 @@ func (m *Measurement) CountErrorForScope(scope tally.Scope, tags map[string]stri
 
 func (m *Measurement) countError(scope tally.Scope, tags map[string]string) {
 	scope.Tagged(tags).Counter("error").Inc(1)
+}
+
+func (m *Measurement) AddDbCollTags(db string, coll string) {
+	// For stream requests we will add the tags once based on the flag rather than for every result document
+	m.dbCollTags = GetDbCollTags(db, coll)
+	m.RecursiveAddTags(m.dbCollTags)
+}
+
+func (m *Measurement) GetDBCollTags() map[string]string {
+	return m.dbCollTags
+}
+
+func (m *Measurement) AddNetworkTags() {
+	m.networkTags = m.getNetworkTags()
+	m.RecursiveAddTags(m.networkTags)
+}
+
+func (m *Measurement) GetNetworkTags() map[string]string {
+	if len(m.networkTags) == 0 {
+		m.AddNetworkTags()
+	}
+	return m.networkTags
 }
 
 func (m *Measurement) GetServiceName() string {
@@ -148,7 +172,7 @@ func (m *Measurement) GetCollectionSizeTags() map[string]string {
 	return filterTags(standardizeTags(m.tags, getCollectionSizeTagKeys()), config.DefaultConfig.Metrics.Size.FilteredTags)
 }
 
-func (m *Measurement) GetNetworkTags() map[string]string {
+func (m *Measurement) getNetworkTags() map[string]string {
 	return filterTags(standardizeTags(m.tags, getNetworkTagKeys()), config.DefaultConfig.Metrics.Network.FilteredTags)
 }
 

--- a/server/middleware/measure.go
+++ b/server/middleware/measure.go
@@ -121,17 +121,18 @@ func (w *wrappedStream) RecvMsg(m interface{}) error {
 		err := w.ServerStream.RecvMsg(m)
 		return err
 	}
-	db, coll := request.GetDbAndColl(m)
-	reqMetadata, err := request.GetRequestMetadataFromContext(w.WrappedContext)
-	if err != nil {
-		return err
+	err := w.ServerStream.RecvMsg(m)
+	if len(w.measurement.GetDBCollTags()) == 0 {
+		// The request is not tagged yet with db and collection, need to do it on the first message
+		db, coll := request.GetDbAndColl(m)
+		reqMetadata, err := request.GetRequestMetadataFromContext(w.WrappedContext)
+		if err != nil {
+			return err
+		}
+		reqMetadata.SetDb(db)
+		reqMetadata.SetCollection(coll)
+		w.measurement.AddDbCollTags(reqMetadata.GetDb(), reqMetadata.GetCollection())
 	}
-	reqMetadata.SetDb(db)
-	reqMetadata.SetCollection(coll)
-
-	err = w.ServerStream.RecvMsg(m)
-	dbCollTags := metrics.GetDbCollTags(reqMetadata.GetDb(), reqMetadata.GetCollection())
-	w.measurement.RecursiveAddTags(dbCollTags)
 	w.measurement.CountReceivedBytes(metrics.BytesReceived, w.measurement.GetNetworkTags(), proto.Size(m.(proto.Message)))
 	return err
 }
@@ -142,12 +143,15 @@ func (w *wrappedStream) SendMsg(m interface{}) error {
 		return err
 	}
 	err := w.ServerStream.SendMsg(m)
-	reqMetadata, err1 := request.GetRequestMetadataFromContext(w.WrappedContext)
-	if err1 != nil {
-		return errors.Internal("Could not handle stream send message")
+	if len(w.measurement.GetDBCollTags()) == 0 {
+		// The request is not tagged yet with db and collection, need to do it on the first message
+		reqMetadata, err1 := request.GetRequestMetadataFromContext(w.WrappedContext)
+		if err1 != nil {
+			return errors.Internal("Could not handle stream send message")
+		}
+		w.measurement.AddDbCollTags(reqMetadata.GetDb(), reqMetadata.GetCollection())
 	}
-	dbCollTags := metrics.GetDbCollTags(reqMetadata.GetDb(), reqMetadata.GetCollection())
-	w.measurement.RecursiveAddTags(dbCollTags)
+	// The network tags are cached in a top level member of the Measurement type, it won't always re-calculate tags
 	w.measurement.CountSentBytes(metrics.BytesSent, w.measurement.GetNetworkTags(), proto.Size(m.(proto.Message)))
 	return err
 }


### PR DESCRIPTION
The db, collection and network tags were re-calculated for every document in the result of a read request unnecessarily. This PR fixes that. Yesterday's fix also broke the db and collection name reporting for reads, fixed that as well.