### PR TITLE
fix: Delete app keys associated with project while deleting project

### DIFF
--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -415,6 +415,13 @@ func (s *apiService) DeleteProject(ctx context.Context, r *api.DeleteProjectRequ
 		return nil, err
 	}
 
+	// delete app-keys associated with project
+	if config.DefaultConfig.Auth.Enabled {
+		err := s.authProvider.DeleteAppKeys(ctx, r.GetProject())
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &api.DeleteProjectResponse{
 		Status:  resp.status,
 		Message: "project deleted successfully",

--- a/server/services/v1/auth/noop.go
+++ b/server/services/v1/auth/noop.go
@@ -46,3 +46,7 @@ func (noop) DeleteAppKey(_ context.Context, _ *api.DeleteAppKeyRequest) (*api.De
 func (noop) ListAppKeys(_ context.Context, _ *api.ListAppKeysRequest) (*api.ListAppKeysResponse, error) {
 	return nil, errors.Internal("authentication not enabled on this server")
 }
+
+func (noop) DeleteAppKeys(_ context.Context, _ string) error {
+	return errors.Internal("authentication not enabled on this server")
+}

--- a/server/services/v1/auth/provider.go
+++ b/server/services/v1/auth/provider.go
@@ -49,6 +49,7 @@ type Provider interface {
 	RotateAppKey(ctx context.Context, req *api.RotateAppKeyRequest) (*api.RotateAppKeyResponse, error)
 	DeleteAppKey(ctx context.Context, req *api.DeleteAppKeyRequest) (*api.DeleteAppKeyResponse, error)
 	ListAppKeys(ctx context.Context, req *api.ListAppKeysRequest) (*api.ListAppKeysResponse, error)
+	DeleteAppKeys(ctx context.Context, project string) error
 }
 
 func NewProvider(userstore *metadata.UserSubspace, txMgr *transaction.Manager) Provider {


### PR DESCRIPTION
This PR will delete app-keys associated with project when project is undergoing deletion. 