### PR TITLE
feat: Realtime v1

### DIFF
--- a/api/server/v1/marshaler_realtime.go
+++ b/api/server/v1/marshaler_realtime.go
@@ -1,0 +1,172 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+func (x *RealTimeMessage) MarshalJSON() ([]byte, error) {
+	resp := struct {
+		Event     jsoniter.RawMessage `json:"event,omitempty"`
+		EventType EventType           `json:"event_type,omitempty"`
+	}{
+		Event:     x.Event,
+		EventType: x.EventType,
+	}
+	return jsoniter.Marshal(resp)
+}
+
+func (x *AuthEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "accessToken":
+			x.AccessToken = value
+		}
+	}
+
+	return nil
+}
+
+func (x *UnsubscribeEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "channel":
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		}
+	}
+
+	return nil
+}
+
+func (x *SubscribeEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "channel":
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		case "position":
+			var position string
+			if err := jsoniter.Unmarshal(value, &position); err != nil {
+				return err
+			}
+			x.Position = position
+		}
+	}
+
+	return nil
+}
+
+func (x *MessageEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "id":
+			var id string
+			if err := jsoniter.Unmarshal(value, &id); err != nil {
+				return err
+			}
+			x.Id = id
+		case "channel":
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		case "name":
+			var name string
+			if err := jsoniter.Unmarshal(value, &name); err != nil {
+				return err
+			}
+			x.Name = name
+		case "data":
+			x.Data = value
+		}
+	}
+
+	return nil
+}
+
+func (x *RealTimeMessage) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "event_type":
+			var eventType EventType
+			if err := jsoniter.Unmarshal(value, &eventType); err != nil {
+				return err
+			}
+			x.EventType = eventType
+		case "event":
+			x.Event = value
+		}
+	}
+
+	return nil
+}
+
+func (x *Message) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+
+	for key, value := range mp {
+		var v interface{}
+
+		switch key {
+		case "id":
+			v = &x.Id
+		case "name":
+			v = &x.Name
+		case "data":
+			// to avoid decoding data
+			x.Data = value
+			continue
+		default:
+			continue
+		}
+		if err := jsoniter.Unmarshal(value, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/api/server/v1/realtime.go
+++ b/api/server/v1/realtime.go
@@ -12,24 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package api
 
-import (
-	"testing"
+func EventStrToEnumCode(eventType string) (int32, bool) {
+	if val, ok := EventType_value[eventType]; ok {
+		return val, ok
+	}
 
-	"github.com/stretchr/testify/require"
-)
-
-func TestSessionTracker(t *testing.T) {
-	s := newSessionTracker()
-	require.Equal(t, 0, len(s.sessions))
-	require.NotNil(t, s.sessions)
-
-	// get is empty
-	require.Nil(t, s.get("abc"))
-
-	// put and get
-	sess := &QuerySession{}
-	s.add("abc", sess)
-	require.Equal(t, sess, s.get("abc"))
+	return -1, false
 }

--- a/cmd/websocket/websocket.go
+++ b/cmd/websocket/websocket.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"fmt"
+)
+
+func StartSubscriber(url url.URL) {
+	c, _, err := websocket.DefaultDialer.Dial(url.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	defer c.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				log.Println("read:", err)
+				return
+			}
+			log.Printf("recv: %s", message)
+		}
+	}()
+
+	err = c.WriteMessage(websocket.TextMessage, []byte(`{"event_type":4, "event": {"channel": "test"}}`))
+	if err != nil {
+		log.Println("write:", err)
+		return
+	}
+	wg.Wait()
+}
+
+func StartPublisher(url url.URL) {
+	c, _, err := websocket.DefaultDialer.Dial(url.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	defer c.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				log.Println("read:", err)
+				return
+			}
+			log.Printf("recv: %s", message)
+		}
+	}()
+
+	for i := 0; i < 10000; i++ {
+		time.Sleep(1 * time.Second)
+		if err := c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"event_type":3, "event": {"channel": "test", "data": {"a": %d}}}`, i))); err != nil {
+			log.Fatalf("write: %v\n", err)
+			return
+		}
+	}
+
+	wg.Wait()
+}
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	u := url.URL{Scheme: "ws", Host: "localhost:8082", Path: "/v1/projects/p1/realtime"}
+	log.Printf("connecting to %s", u.String())
+
+	go StartSubscriber(u)
+	go StartPublisher(u)
+	select {}
+}

--- a/errors/websocket_errors.go
+++ b/errors/websocket_errors.go
@@ -1,0 +1,44 @@
+package errors
+
+import (
+	"fmt"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+)
+
+type WSErrorCode int32
+
+const (
+	CodeOK                                   = 0
+	CloseNormalClosure           WSErrorCode = 1000
+	CloseGoingAway               WSErrorCode = 1001
+	CloseProtocolError           WSErrorCode = 1002
+	CloseUnsupportedData         WSErrorCode = 1003
+	CloseNoStatusReceived        WSErrorCode = 1005
+	CloseAbnormalClosure         WSErrorCode = 1006
+	CloseInvalidFramePayloadData WSErrorCode = 1007
+	ClosePolicyViolation         WSErrorCode = 1008
+	CloseMessageTooBig           WSErrorCode = 1009
+	CloseMandatoryExtension      WSErrorCode = 1010
+	CloseInternalServerErr       WSErrorCode = 1011
+	CloseServiceRestart          WSErrorCode = 1012
+	CloseTryAgainLater           WSErrorCode = 1013
+	CloseTLSHandshake            WSErrorCode = 1015
+)
+
+func InternalWS(format string, args ...any) *api.ErrorEvent {
+	return Errorf(CloseInternalServerErr, format, args...)
+}
+
+func Errorf(c WSErrorCode, format string, a ...interface{}) *api.ErrorEvent {
+	if c == CodeOK {
+		return nil
+	}
+
+	e := &api.ErrorEvent{
+		Code:    int32(c),
+		Message: fmt.Sprintf(format, a...),
+	}
+
+	return e
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gnostic v0.6.9
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3 h1:hRcWZ7716+E1tkMSZJ/QeeC2dPGGB1R/4z4m9RsL8Qg=

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -20,8 +20,9 @@ import (
 )
 
 // NewStreamData returns a stream data for anything that we need to store in streams.
-func NewStreamData(data []byte) *StreamData {
+func NewStreamData(md []byte, data []byte) *StreamData {
 	return &StreamData{
+		Metadata:  md,
 		RawData:   data,
 		CreatedAt: NewTimestamp(),
 	}

--- a/internal/data.go
+++ b/internal/data.go
@@ -40,8 +40,8 @@ type DataType byte
 const (
 	Unknown DataType = iota
 	TableDataType
-	CacheDataType
 	StreamDataType
+	CacheDataType
 )
 
 const (

--- a/internal/data.proto
+++ b/internal/data.proto
@@ -40,7 +40,21 @@ message TableData {
 // are used by channels to store channel metadata but these can be ignored for storing some regular stream data.
 message StreamData {
   // the id generated for this data, in most cases will be filled when returning this in response
-  int32 id = 1;
+  string id = 1;
+  // ver is the version for the raw bytes, this may be the version of the event
+  int32 ver = 2;
+  // encoding represents encoding of the event field.
+  int32 encoding = 3;
+  Timestamp created_at = 4;
+  // metadata is the metadata of this stream data.
+  bytes metadata=5;
+  // raw_data is the raw bytes stored, caller controls how they want to store these raw bytes in event store.
+  bytes raw_data = 6;
+}
+
+message CacheData {
+  // the user key for this data, in most cases will be filled when returning this in response
+  string key = 1;
   // ver is the version for the raw bytes, this may be the version of the event
   int32 ver = 2;
   // encoding represents encoding of the event field.
@@ -50,15 +64,3 @@ message StreamData {
   bytes raw_data = 5;
 }
 
-// CacheData is used to store a serialized data that has user data and some Tigris metadata in Cache
-message CacheData {
-  // the id generated for this data, in most cases will be filled when returning this in response
-  int32 id = 1;
-  // ver is the version for the raw bytes, this may be the version of the event
-  int32 ver = 2;
-  // encoding represents encoding of the event field.
-  int32 encoding = 3;
-  Timestamp created_at = 4;
-  // raw_data is the raw bytes stored, caller controls how they want to store these raw bytes in event store.
-  bytes raw_data = 5;
-}

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -20,10 +20,17 @@ import (
 	"github.com/tigrisdata/tigris/util/log"
 )
 
+const (
+	DatabaseServerType = "database"
+	RealtimeServerType = "realtime"
+)
+
 type ServerConfig struct {
-	Host        string
-	Port        int16
-	FDBHardDrop bool `mapstructure:"fdb_hard_drop" yaml:"fdb_hard_drop" json:"fdb_hard_drop"`
+	Host         string
+	Port         int16
+	ServerType   string `mapstructure:"server_type" yaml:"server_type" json:"server_type"`
+	FDBHardDrop  bool   `mapstructure:"fdb_hard_drop" yaml:"fdb_hard_drop" json:"fdb_hard_drop"`
+	RealtimePort int16  `mapstructure:"realtime_port" yaml:"realtime_port" json:"realtime_port"`
 }
 
 type Config struct {
@@ -190,9 +197,11 @@ var DefaultConfig = Config{
 		SampleRate: 0.01,
 	},
 	Server: ServerConfig{
-		Host:        "0.0.0.0",
-		Port:        8081,
-		FDBHardDrop: false,
+		Host:         "0.0.0.0",
+		Port:         8081,
+		RealtimePort: 8082,
+		FDBHardDrop:  false,
+		ServerType:   DatabaseServerType,
 	},
 	Auth: AuthConfig{
 		Enabled:          false,

--- a/server/lifecycle/lifecycle.go
+++ b/server/lifecycle/lifecycle.go
@@ -1,0 +1,32 @@
+package lifecycle
+
+import "context"
+
+type Hook interface {
+	OnStart(context.Context) error
+	OnStop(context.Context) error
+}
+
+type Lifecycle struct {
+	hooks []Hook
+}
+
+func NewLifecycle() *Lifecycle {
+	return &Lifecycle{}
+}
+
+func (l *Lifecycle) AddHook(h Hook) {
+	l.hooks = append(l.hooks, h)
+}
+
+func (l *Lifecycle) OnStart(ctx context.Context) {
+	for _, h := range l.hooks {
+		h.OnStart(ctx)
+	}
+}
+
+func (l *Lifecycle) OnStop(ctx context.Context) {
+	for _, h := range l.hooks {
+		h.OnStart(ctx)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -90,15 +90,19 @@ func mainWithCode() int {
 		return 1
 	}
 
+	cfg := &config.DefaultConfig
 	request.Init(tenantMgr)
-	_ = quota.Init(tenantMgr, &config.DefaultConfig)
+	_ = quota.Init(tenantMgr, cfg)
 	defer quota.Cleanup()
 
-	mx := muxer.NewMuxer(&config.DefaultConfig)
-	mx.RegisterServices(kvStore, searchStore, tenantMgr, txMgr)
-
-	if err := mx.Start(config.DefaultConfig.Server.Host, config.DefaultConfig.Server.Port); err != nil {
-		log.Error().Err(err).Msgf("error starting server")
+	mx := muxer.NewMuxer(cfg)
+	mx.RegisterServices(cfg, kvStore, searchStore, tenantMgr, txMgr)
+	port := cfg.Server.Port
+	if cfg.Server.ServerType == config.RealtimeServerType {
+		port = cfg.Server.RealtimePort
+	}
+	if err := mx.StartServers(cfg.Server.Host, port); err != nil {
+		log.Error().Err(err).Msgf("error starting realtime server")
 		return 1
 	}
 

--- a/server/metadata/key_encoder.go
+++ b/server/metadata/key_encoder.go
@@ -53,6 +53,10 @@ type Encoder interface {
 	DecodeIndexName(indexName []byte) uint32
 }
 
+func NewCacheEncoder() CacheEncoder {
+	return &DictKeyEncoder{}
+}
+
 // NewEncoder creates Dictionary metaStore to encode keys.
 func NewEncoder() Encoder {
 	return &DictKeyEncoder{}

--- a/server/middleware/middleware_http.go
+++ b/server/middleware/middleware_http.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/request"
+)
+
+func HTTPAuthMiddleware(config *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			if authFunc := getAuthFunction(config); authFunc != nil {
+				authFunc(context.TODO())
+			}
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}
+
+func HTTPMetadataExtractorMiddleware(_ *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			reqMetadata := request.NewRequestMetadata(r.Context())
+			r = r.WithContext(reqMetadata.SaveToContext(r.Context()))
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/server/muxer/http.go
+++ b/server/muxer/http.go
@@ -36,22 +36,36 @@ type HTTPServer struct {
 }
 
 func NewHTTPServer(cfg *config.Config) *HTTPServer {
-	r := chi.NewRouter()
+	server := &HTTPServer{
+		Inproc: &inprocgrpc.Channel{},
+		Router: chi.NewRouter(),
+	}
 
-	r.Use(cors.AllowAll().Handler)
-	r.Mount("/debug", chi_middleware.Profiler())
+	server.SetupMiddlewares(cfg)
 
+	// mount debug handler after adding all middlewares
+	server.Router.Mount("/debug", chi_middleware.Profiler())
+
+	return server
+}
+
+func (s *HTTPServer) SetupMiddlewares(cfg *config.Config) {
 	unary, stream := middleware.Get(cfg)
 
-	inproc := &inprocgrpc.Channel{}
-	inproc.WithServerStreamInterceptor(stream)
-	inproc.WithServerUnaryInterceptor(unary)
+	s.Inproc.WithServerStreamInterceptor(stream)
+	s.Inproc.WithServerUnaryInterceptor(unary)
 
-	return &HTTPServer{Inproc: inproc, Router: r}
+	s.Router.Use(cors.AllowAll().Handler)
+
+	// now if it is realtime servers then setup HTTP handlers
+	if cfg.Server.ServerType == config.RealtimeServerType {
+		s.Router.Use(middleware.HTTPMetadataExtractorMiddleware(cfg))
+		s.Router.Use(middleware.HTTPAuthMiddleware(cfg))
+	}
 }
 
 func (s *HTTPServer) Start(mux cmux.CMux) error {
-	match := mux.Match(cmux.HTTP1Fast())
+	match := mux.Match(cmux.HTTP1Fast(), cmux.HTTP1HeaderField("Upgrade", "websocket"))
 	go func() {
 		srv := &http.Server{Handler: s.Router, ReadHeaderTimeout: readHeaderTimeout}
 		err := srv.Serve(match)

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -65,6 +65,13 @@ func Init(tg metadata.TenantGetter) {
 	tenantGetter = tg
 }
 
+func NewRequestMetadata(ctx context.Context) Metadata {
+	ns, utype, sub := GetMetadataFromHeader(ctx)
+	md := Metadata{IsHuman: utype, Sub: sub}
+	md.SetNamespace(ctx, ns)
+	return md
+}
+
 func NewRequestEndpointMetadata(ctx context.Context, serviceName string, methodInfo grpc.MethodInfo, db string, coll string) Metadata {
 	ns, utype, sub := GetMetadataFromHeader(ctx)
 	md := Metadata{serviceName: serviceName, methodInfo: methodInfo, IsHuman: utype, Sub: sub}

--- a/server/services/v1/database/key_generator.go
+++ b/server/services/v1/database/key_generator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/mutator.go
+++ b/server/services/v1/database/mutator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"strconv"

--- a/server/services/v1/database/mutator_test.go
+++ b/server/services/v1/database/mutator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"
@@ -485,9 +485,9 @@ func (runner *ImportQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    InsertedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    InsertedStatus,
 	}, ctx, nil
 }
 
@@ -527,9 +527,9 @@ func (runner *InsertQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    InsertedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    InsertedStatus,
 	}, ctx, nil
 }
 
@@ -565,9 +565,9 @@ func (runner *ReplaceQueryRunner) Run(ctx context.Context, tx transaction.Tx, te
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    ReplacedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    ReplacedStatus,
 	}, ctx, nil
 }
 
@@ -703,9 +703,9 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 
 	ctx = metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 	return &Response{
-		status:        UpdatedStatus,
-		updatedAt:     ts,
-		modifiedCount: modifiedCount,
+		Status:        UpdatedStatus,
+		UpdatedAt:     ts,
+		ModifiedCount: modifiedCount,
 	}, ctx, err
 }
 
@@ -800,9 +800,9 @@ func (runner *DeleteQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 
 	ctx = metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 	return &Response{
-		status:        DeletedStatus,
-		deletedAt:     ts,
-		modifiedCount: modifiedCount,
+		Status:        DeletedStatus,
+		DeletedAt:     ts,
+		ModifiedCount: modifiedCount,
 	}, ctx, nil
 }
 
@@ -1350,7 +1350,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		}
 
 		return &Response{
-			status: DroppedStatus,
+			Status: DroppedStatus,
 		}, ctx, nil
 	case runner.createOrUpdateReq != nil:
 		db, err := runner.getDatabase(ctx, tx, tenant, runner.createOrUpdateReq.GetProject())
@@ -1383,7 +1383,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		}
 
 		return &Response{
-			status: CreatedStatus,
+			Status: CreatedStatus,
 		}, ctx, nil
 	case runner.listReq != nil:
 		db, err := runner.getDatabase(ctx, tx, tenant, runner.listReq.GetProject())
@@ -1487,7 +1487,7 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		}
 
 		return &Response{
-			status: DroppedStatus,
+			Status: DroppedStatus,
 		}, ctx, nil
 	case runner.create != nil:
 		dbMetadata, err := createDatabaseMetadata(ctx)
@@ -1503,11 +1503,10 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		}
 
 		return &Response{
-			status: CreatedStatus,
+			Status: CreatedStatus,
 		}, ctx, nil
 	case runner.list != nil:
 		databaseList := tenant.ListDatabases(ctx)
-
 		databases := make([]*api.ProjectInfo, len(databaseList))
 		for i, l := range databaseList {
 			databases[i] = &api.ProjectInfo{

--- a/server/services/v1/database/query_runner_test.go
+++ b/server/services/v1/database/query_runner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"testing"

--- a/server/services/v1/database/request.go
+++ b/server/services/v1/database/request.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	api "github.com/tigrisdata/tigris/api/server/v1"
@@ -40,18 +40,18 @@ type SearchStreaming interface {
 
 // ReqOptions are options used by queryLifecycle to execute a query.
 type ReqOptions struct {
-	txCtx              *api.TransactionCtx
-	metadataChange     bool
-	instantVerTracking bool
+	TxCtx              *api.TransactionCtx
+	MetadataChange     bool
+	InstantVerTracking bool
 }
 
 // Response is a wrapper on api.Response.
 type Response struct {
 	api.Response
-	status        string
-	createdAt     *internal.Timestamp
-	updatedAt     *internal.Timestamp
-	deletedAt     *internal.Timestamp
-	modifiedCount int32
-	allKeys       [][]byte
+	Status        string
+	CreatedAt     *internal.Timestamp
+	UpdatedAt     *internal.Timestamp
+	DeletedAt     *internal.Timestamp
+	ModifiedCount int32
+	AllKeys       [][]byte
 }

--- a/server/services/v1/database/row_reader.go
+++ b/server/services/v1/database/row_reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/database/search_indexer.go
+++ b/server/services/v1/database/search_indexer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/search_indexer_test.go
+++ b/server/services/v1/database/search_indexer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"encoding/json"

--- a/server/services/v1/database/search_reader.go
+++ b/server/services/v1/database/search_reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/database/sessions_test.go
+++ b/server/services/v1/database/sessions_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionTracker(t *testing.T) {
+	s := newSessionTracker()
+	require.Equal(t, 0, len(s.sessions))
+	require.NotNil(t, s.sessions)
+
+	// get is empty
+	require.Nil(t, s.get("abc"))
+
+	// put and get
+	sess := &QuerySession{}
+	s.add("abc", sess)
+	require.Equal(t, sess, s.get("abc"))
+}

--- a/server/services/v1/database/tx_listener.go
+++ b/server/services/v1/database/tx_listener.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/realtime.go
+++ b/server/services/v1/realtime.go
@@ -1,0 +1,189 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/fullstorydev/grpchan/inprocgrpc"
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/services/v1/realtime"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/cache"
+	"github.com/tigrisdata/tigris/store/kv"
+	"github.com/tigrisdata/tigris/store/search"
+	"google.golang.org/grpc"
+)
+
+const (
+	realtimePathPattern = fullProjectPath + "/realtime/*"
+)
+
+type realtimeService struct {
+	api.UnimplementedRealtimeServer
+
+	cache     cache.Cache
+	devices   *realtime.Sessions
+	rtmRunner *realtime.RTMRunnerFactory
+}
+
+func newRealtimeService(_ kv.KeyValueStore, _ search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) *realtimeService {
+	cacheS := cache.NewCache(&config.DefaultConfig.Cache)
+	encoder := metadata.NewCacheEncoder()
+	heartbeatF := realtime.NewHeartbeatFactory(cacheS, encoder)
+	channelFactory := realtime.NewChannelFactory(cacheS, encoder, heartbeatF)
+
+	return &realtimeService{
+		cache:     cacheS,
+		rtmRunner: realtime.NewRTMRunnerFactory(cacheS, channelFactory),
+		devices:   realtime.NewSessionMgr(cacheS, tenantMgr, txMgr, heartbeatF, channelFactory),
+	}
+}
+
+func (s *realtimeService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel) error {
+	mux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &api.CustomMarshaler{JSONBuiltin: &runtime.JSONBuiltin{}}),
+		runtime.WithIncomingHeaderMatcher(api.CustomMatcher),
+		runtime.WithOutgoingHeaderMatcher(api.CustomMatcher),
+	)
+
+	if err := api.RegisterRealtimeHandlerClient(context.TODO(), mux, api.NewRealtimeClient(inproc)); err != nil {
+		return err
+	}
+
+	api.RegisterRealtimeServer(inproc, s)
+
+	router.HandleFunc(apiPathPrefix+"/projects/{project}/realtime", s.DeviceConnectionHandler)
+	router.HandleFunc(apiPathPrefix+realtimePathPattern, func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r)
+	})
+
+	return nil
+}
+
+func (s *realtimeService) RegisterGRPC(grpc *grpc.Server) error {
+	api.RegisterRealtimeServer(grpc, s)
+	return nil
+}
+
+var upgradeToSocket = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func (s *realtimeService) extractConnParams(r *http.Request) realtime.ConnectionParams {
+	var params realtime.ConnectionParams
+
+	// project name is part of path
+	params.ProjectName = chi.URLParam(r, "project")
+
+	// query params
+	params.SessionId = r.URL.Query().Get("session_id")
+
+	return params
+}
+
+func (s *realtimeService) DeviceConnectionHandler(w http.ResponseWriter, r *http.Request) {
+	params := s.extractConnParams(r)
+	conn, err := upgradeToSocket.Upgrade(w, r, nil)
+	if err != nil {
+		// ToDo: Change to WS errors
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "%s"}`, err.Error())))
+		return
+	}
+
+	ctx := r.Context()
+	session, err := s.devices.AddDevice(ctx, conn, params)
+	if err != nil {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"error": "%s"}`, err.Error())))
+		_ = conn.Close()
+		return
+	}
+	defer func() {
+		_ = session.Close()
+		s.devices.RemoveDevice(ctx, session)
+	}()
+	conn.SetPingHandler(session.OnPing)
+	conn.SetPongHandler(session.OnPong)
+	conn.SetCloseHandler(session.OnClose)
+
+	_ = session.SendConnectionEstablished()
+	_ = session.Start(ctx)
+}
+
+func (s *realtimeService) Ping(_ context.Context, _ *api.HeartbeatEvent) (*api.HeartbeatEvent, error) {
+	return &api.HeartbeatEvent{}, nil
+}
+
+func (s *realtimeService) GetRTChannel(ctx context.Context, req *api.GetRTChannelRequest) (*api.GetRTChannelResponse, error) {
+	runner := s.rtmRunner.GetChannelRunner()
+	runner.SetChannelReq(req)
+
+	resp, err := s.devices.ExecuteRunner(ctx, runner)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response.(*api.GetRTChannelResponse), nil
+}
+
+func (s *realtimeService) GetRTChannels(ctx context.Context, req *api.GetRTChannelsRequest) (*api.GetRTChannelsResponse, error) {
+	runner := s.rtmRunner.GetChannelRunner()
+	runner.SetChannelsReq(req)
+
+	resp, err := s.devices.ExecuteRunner(ctx, runner)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response.(*api.GetRTChannelsResponse), nil
+}
+
+func (s *realtimeService) ReadMessages(req *api.ReadMessagesRequest, stream api.Realtime_ReadMessagesServer) error {
+	runner := s.rtmRunner.GetReadMessagesRunner(req, stream)
+
+	_, err := s.devices.ExecuteRunner(stream.Context(), runner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *realtimeService) Messages(ctx context.Context, req *api.MessagesRequest) (*api.MessagesResponse, error) {
+	runner := s.rtmRunner.GetMessagesRunner(req)
+	resp, err := s.devices.ExecuteRunner(ctx, runner)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response.(*api.MessagesResponse), nil
+}
+
+func (s *realtimeService) ListSubscriptions(ctx context.Context, req *api.ListSubscriptionRequest) (*api.ListSubscriptionResponse, error) {
+	runner := s.rtmRunner.GetChannelRunner()
+	runner.SetListSubscriptionsReq(req)
+
+	resp, err := s.devices.ExecuteRunner(ctx, runner)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response.(*api.ListSubscriptionResponse), nil
+}

--- a/server/services/v1/realtime/channel.go
+++ b/server/services/v1/realtime/channel.go
@@ -1,0 +1,157 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+type Channel struct {
+	sync.RWMutex
+
+	encName  string
+	tenant   uint32
+	project  uint32
+	stream   cache.Stream
+	watchers map[string]*ChannelWatcher
+}
+
+func NewChannel(encName string, stream cache.Stream) *Channel {
+	return &Channel{
+		encName:  encName,
+		stream:   stream,
+		watchers: make(map[string]*ChannelWatcher),
+	}
+}
+
+func (ch *Channel) Name() string {
+	return ch.encName
+}
+
+func (ch *Channel) Read(ctx context.Context, pos string) (*cache.StreamMessages, bool, error) {
+	return ch.stream.Read(ctx, pos)
+}
+
+func (ch *Channel) PublishPresence(ctx context.Context, data *internal.StreamData) (string, error) {
+	return ch.stream.Add(ctx, data)
+}
+
+func (ch *Channel) PublishMessage(ctx context.Context, data *internal.StreamData) (string, error) {
+	return ch.stream.Add(ctx, data)
+}
+
+func (ch *Channel) getWatcher(watcher string) *ChannelWatcher {
+	ch.RLock()
+	defer ch.RUnlock()
+
+	return ch.watchers[watcher]
+}
+
+func (ch *Channel) getWatcherFromRedis(ctx context.Context, watcher string, resume string) (*ChannelWatcher, bool, error) {
+	group, exists, err := ch.stream.GetConsumerGroup(ctx, watcher)
+	if err != nil {
+		return nil, exists, err
+	}
+
+	if !exists {
+		return nil, exists, err
+	}
+
+	if len(resume) == 0 {
+		if group.LastDeliveredID == basePos {
+			resume = streamFromCurrentPosRead
+		} else {
+			resume = group.LastDeliveredID
+		}
+	}
+
+	return CreateWatcher(ctx, watcher, resume, ch.stream), true, nil
+}
+
+func (ch *Channel) ListWatchers() []string {
+	ch.RLock()
+	defer ch.RUnlock()
+
+	var watchersList []string
+	for _, w := range ch.watchers {
+		watchersList = append(watchersList, w.name)
+	}
+
+	return watchersList
+}
+
+func (ch *Channel) GetWatcher(ctx context.Context, watcherName string, resume string) (*ChannelWatcher, error) {
+	if watcher := ch.getWatcher(watcherName); watcher != nil {
+		// already cached in-memory
+		watcher.Move(resume)
+		return watcher, nil
+	}
+
+	watcher, exists, err := ch.getWatcherFromRedis(ctx, watcherName, resume)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		ch.Lock()
+		ch.watchers[watcherName] = watcher
+		ch.Unlock()
+		return watcher, nil
+	}
+
+	// Create new and attach to the topic
+	if watcher, err = CreateAndRegisterWatcher(ctx, watcherName, resume, ch.stream); err != nil {
+		return nil, err
+	}
+
+	ch.Lock()
+	ch.watchers[watcherName] = watcher
+	ch.Unlock()
+
+	return watcher, nil
+}
+
+// DestroyWatcher ToDo: call it during leave
+func (ch *Channel) DestroyWatcher(_ context.Context, watcher string) {
+	ch.Lock()
+	defer ch.Unlock()
+
+	_, ok := ch.watchers[watcher]
+	if !ok {
+		return
+	}
+
+	ch.watchers[watcher].Close()
+	delete(ch.watchers, watcher)
+}
+
+func (ch *Channel) Close(ctx context.Context) {
+	ch.Lock()
+	defer ch.Unlock()
+
+	for _, w := range ch.watchers {
+		w.Close()
+		delete(ch.watchers, w.name)
+	}
+
+	if err := ch.stream.Delete(ctx); err != nil {
+		log.Err(err).Str("channel", ch.encName).Msg("deleting stream failed")
+		return
+	}
+}

--- a/server/services/v1/realtime/channel_runner.go
+++ b/server/services/v1/realtime/channel_runner.go
@@ -1,0 +1,280 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+// RTMRunner is used to run the realtime HTTP APIs related to channel like accessing a channel, subscribing to a channel, etc
+type RTMRunner interface {
+	Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error)
+}
+
+type RTMRunnerFactory struct {
+	cache   cache.Cache
+	factory *ChannelFactory
+}
+
+// NewRTMRunnerFactory returns RTMRunnerFactory object.
+func NewRTMRunnerFactory(cache cache.Cache, factory *ChannelFactory) *RTMRunnerFactory {
+	return &RTMRunnerFactory{
+		cache:   cache,
+		factory: factory,
+	}
+}
+
+func (f *RTMRunnerFactory) GetMessagesRunner(r *api.MessagesRequest) *MessagesRunner {
+	return &MessagesRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+		req:        r,
+	}
+}
+
+func (f *RTMRunnerFactory) GetReadMessagesRunner(r *api.ReadMessagesRequest, streaming Streaming) *ReadMessagesRunner {
+	return &ReadMessagesRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+		req:        r,
+		streaming:  streaming,
+	}
+}
+
+func (f *RTMRunnerFactory) GetChannelRunner() *ChannelRunner {
+	return &ChannelRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+	}
+}
+
+type baseRunner struct {
+	cache   cache.Cache
+	factory *ChannelFactory
+}
+
+func newBaseRunner(cache cache.Cache, factory *ChannelFactory) *baseRunner {
+	return &baseRunner{
+		cache:   cache,
+		factory: factory,
+	}
+}
+
+func (runner *baseRunner) getProject(ctx context.Context, tenant *metadata.Tenant, project string) (*metadata.Database, error) {
+	proj, err := tenant.GetDatabase(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		return nil, errors.NotFound("project doesn't exist '%s'", project)
+	}
+	return proj, err
+}
+
+// MessagesRunner is to publish messages to a channel
+type MessagesRunner struct {
+	*baseRunner
+
+	req *api.MessagesRequest
+}
+
+func (runner *MessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	if err != nil {
+		return nil, err
+	}
+
+	channel, err := runner.factory.GetOrCreateChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.req.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, m := range runner.req.Messages {
+		streamData, err := NewEventDataFromMessage("", "", m.Name, m)
+		if err != nil {
+			return nil, err
+		}
+
+		id, err := channel.PublishMessage(ctx, streamData)
+		if err != nil {
+			return nil, err
+		}
+
+		ids = append(ids, id)
+	}
+
+	return &Response{
+		Response: &api.MessagesResponse{
+			Ids: ids,
+		},
+	}, nil
+}
+
+type ReadMessagesRunner struct {
+	*baseRunner
+
+	req       *api.ReadMessagesRequest
+	streaming Streaming
+}
+
+func (runner *ReadMessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	if err != nil {
+		return nil, err
+	}
+
+	channel, err := runner.factory.GetChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.req.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	pos := runner.req.GetStart()
+	if len(pos) == 0 {
+		pos = streamFromCurrentPos
+	}
+
+	var count = int64(0)
+	for {
+		resp, exists, err := channel.Read(ctx, pos)
+		if !exists {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		var id string
+		for _, m := range resp.Messages {
+			data, err := resp.Decode(m)
+			if err != nil {
+				return nil, err
+			}
+
+			md, err := DecodeStreamMD(data.Metadata)
+			if err != nil {
+				return nil, err
+			}
+			runner.streaming.Send(&api.ReadMessagesResponse{
+				Message: &api.Message{
+					Id:   &m.ID,
+					Name: md.EventName,
+					Data: data.RawData,
+				},
+			})
+			count++
+			if runner.req.GetLimit() > 0 && count == runner.req.GetLimit() {
+				return nil, nil
+			}
+
+			id = m.ID
+		}
+
+		if len(id) > 0 {
+			split := strings.Split(id, "-")
+			incrId, _ := strconv.ParseInt(strings.Split(id, "-")[1], 10, 64)
+			pos = fmt.Sprintf("%s-%d", split[0], incrId+1)
+		}
+	}
+}
+
+type ChannelRunner struct {
+	*baseRunner
+
+	channelReq        *api.GetRTChannelRequest
+	channelsReq       *api.GetRTChannelsRequest
+	listSubscriptions *api.ListSubscriptionRequest
+}
+
+func (runner *ChannelRunner) SetChannelReq(req *api.GetRTChannelRequest) {
+	runner.channelReq = req
+}
+
+func (runner *ChannelRunner) SetChannelsReq(req *api.GetRTChannelsRequest) {
+	runner.channelsReq = req
+}
+
+func (runner *ChannelRunner) SetListSubscriptionsReq(req *api.ListSubscriptionRequest) {
+	runner.listSubscriptions = req
+}
+
+func (runner *ChannelRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	if runner.listSubscriptions != nil {
+		project, err := runner.getProject(ctx, tenant, runner.listSubscriptions.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channel, err := runner.factory.GetChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.listSubscriptions.Channel)
+		if err != nil {
+			return nil, err
+		}
+
+		watchers := channel.ListWatchers()
+		return &Response{
+			Response: &api.ListSubscriptionResponse{
+				Devices: watchers,
+			},
+		}, nil
+	} else if runner.channelsReq != nil {
+		project, err := runner.getProject(ctx, tenant, runner.channelsReq.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channels, err := runner.factory.ListChannels(ctx, tenant.GetNamespace().Id(), project.Id(), "*")
+		if err != nil {
+			return nil, err
+		}
+
+		var channelsResp []*api.ChannelMetadata
+		for _, c := range channels {
+			channelsResp = append(channelsResp, &api.ChannelMetadata{
+				Channel: c,
+			})
+		}
+
+		return &Response{
+			Response: &api.GetRTChannelsResponse{
+				Channels: channelsResp,
+			},
+		}, nil
+	} else {
+		project, err := runner.getProject(ctx, tenant, runner.channelReq.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channels, err := runner.factory.ListChannels(ctx, tenant.GetNamespace().Id(), project.Id(), runner.channelReq.Channel)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(channels) == 0 {
+			return nil, errors.NotFound("channel '%s' not present ", runner.channelReq.Channel)
+		}
+
+		return &Response{
+			Response: &api.GetRTChannelResponse{
+				Channel: channels[0],
+			},
+		}, nil
+	}
+}

--- a/server/services/v1/realtime/channel_test.go
+++ b/server/services/v1/realtime/channel_test.go
@@ -1,0 +1,127 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+func TestChannel(t *testing.T) {
+	cache.BlockReadGroupDuration = 100 * time.Millisecond
+
+	ctx := context.TODO()
+	cacheS := cache.NewCache(config.GetTestCacheConfig())
+
+	stream, err := cacheS.CreateOrGetStream(ctx, "test")
+	require.NoError(t, err)
+	stream.Delete(ctx)
+
+	t.Run("publish_read", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "test")
+		require.NoError(t, err)
+		channel := NewChannel("test", stream)
+		defer channel.Close(ctx)
+
+		first := []byte(`{"a": 1}`)
+		id1, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, first))
+		require.NoError(t, err)
+
+		second := []byte(`{"b": 2}`)
+		id2, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, second))
+		require.NoError(t, err)
+
+		streamMessages, hasData, err := channel.Read(ctx, "0")
+		require.True(t, hasData)
+		require.NoError(t, err)
+
+		out, err := streamMessages.Decode(streamMessages.Messages[0])
+		require.Equal(t, first, out.RawData)
+		require.Equal(t, id1, out.Id)
+
+		streamMessages, hasData, err = channel.Read(ctx, out.Id)
+		require.True(t, hasData)
+		require.NoError(t, err)
+		out, err = streamMessages.Decode(streamMessages.Messages[0])
+		require.Equal(t, second, out.RawData)
+		require.Equal(t, id2, out.Id)
+
+		streamMessages, hasData, err = channel.Read(ctx, out.Id)
+		require.False(t, hasData)
+		require.Nil(t, streamMessages)
+	})
+	t.Run("watcher", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "test")
+		require.NoError(t, err)
+		channel := NewChannel("test", stream)
+		defer channel.Close(ctx)
+
+		watcher, err := channel.GetWatcher(ctx, "watch", streamFromCurrentPos)
+		require.NoError(t, err)
+		require.Equal(t, watcher, channel.watchers["watch"])
+
+		dummyWatch := &dummyWatch{
+			t:       t,
+			eventNo: 0,
+		}
+
+		totalEvents := 16
+		for i := 0; i < totalEvents; i++ {
+			dummyWatch.expEvents = append(dummyWatch.expEvents, []byte(fmt.Sprintf(`{"a": %d}`, i)))
+		}
+
+		watcher.StartWatching(dummyWatch.watch)
+
+		var expectedIds []string
+		for i := 0; i < totalEvents; i++ {
+			id, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, dummyWatch.expEvents[i]))
+			require.NoError(t, err)
+			expectedIds = append(expectedIds, id)
+		}
+
+		time.Sleep(1 * time.Second)
+
+		for i := 0; i < totalEvents; i++ {
+			require.Equal(t, expectedIds[i], dummyWatch.receivedIds[i])
+		}
+	})
+}
+
+type dummyWatch struct {
+	t           *testing.T
+	eventNo     int
+	expEvents   [][]byte
+	receivedIds []string
+}
+
+func (dummy *dummyWatch) watch(events *cache.StreamMessages, err error) ([]string, error) {
+	var ids []string
+	for _, m := range events.Messages {
+		data, err := events.Decode(m)
+		require.NoError(dummy.t, err)
+		require.Equal(dummy.t, dummy.expEvents[dummy.eventNo], data.RawData, string(dummy.expEvents[dummy.eventNo]), string(data.RawData))
+		dummy.eventNo++
+		dummy.receivedIds = append(dummy.receivedIds, data.Id)
+		ids = append(ids, data.Id)
+	}
+	return ids, nil
+}

--- a/server/services/v1/realtime/device_session.go
+++ b/server/services/v1/realtime/device_session.go
@@ -1,0 +1,299 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/lib/uuid"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/request"
+	"google.golang.org/protobuf/proto"
+)
+
+type Session struct {
+	sync.RWMutex
+
+	id           string
+	clientId     string
+	socketId     string
+	closed       bool
+	conn         *websocket.Conn
+	lastReceived time.Time
+	chFactory    *ChannelFactory
+	heartbeat    *HeartbeatTable
+	tenant       *metadata.Tenant
+	project      *metadata.Database
+	watchers     map[string]*ChannelWatcher
+}
+
+func (s *Sessions) CreateDeviceSession(ctx context.Context, conn *websocket.Conn, params ConnectionParams) (*Session, error) {
+	var sessionId = params.SessionId
+	if len(sessionId) == 0 {
+		sessionId = uuid.NewUUIDAsString()
+	}
+
+	namespaceForThisSession, err := request.GetNamespace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tenant, err := s.tenantMgr.GetTenant(ctx, namespaceForThisSession)
+	if err != nil {
+		return nil, errors.NotFound("tenant '%s' not found", namespaceForThisSession)
+	}
+
+	proj, err := tenant.GetDatabase(ctx, params.ProjectName)
+	if err != nil {
+		return nil, errors.NotFound("project '%s' not found", params.ProjectName)
+	}
+	if proj == nil {
+		tx, err := s.txMgr.StartTx(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var version metadata.Version
+		if version, err = s.versionH.Read(ctx, tx, false); err != nil {
+			return nil, err
+		}
+
+		if err = tenant.Reload(ctx, tx, version); err != nil {
+			return nil, err
+		}
+
+		if proj, _ = tenant.GetDatabase(ctx, params.ProjectName); proj == nil {
+			return nil, errors.NotFound("project '%s' not found", params.ProjectName)
+		}
+	}
+
+	return &Session{
+		id:        sessionId,
+		conn:      conn,
+		tenant:    tenant,
+		project:   proj,
+		chFactory: s.channelFactory,
+		watchers:  make(map[string]*ChannelWatcher),
+		heartbeat: s.heartbeatFactory.GetHeartbeatTable(tenant.GetNamespace().Id(), proj.Id()),
+	}, nil
+}
+
+func (session *Session) IsActive() bool {
+	if time.Since(session.lastReceived) > 30*time.Second {
+		return false
+	}
+
+	return true
+}
+
+func (session *Session) OnPong(_ string) error {
+	return session.SendHeartbeat()
+}
+
+func (session *Session) OnPing(_ string) error {
+	return session.SendHeartbeat()
+}
+
+func (session *Session) OnClose(code int, _ string) error {
+	if code == 1006 {
+		return nil
+	}
+
+	return session.Close()
+}
+
+func (session *Session) Close() error {
+	session.Lock()
+	defer session.Unlock()
+
+	if session.closed {
+		return nil
+	}
+
+	session.closed = true
+	for _, w := range session.watchers {
+		w.Close()
+	}
+
+	return session.conn.Close()
+}
+
+// Start an entry point for handling all the events from a device
+func (session *Session) Start(ctx context.Context) error {
+	for {
+		_ = session.heartbeat.Ping(session.id)
+		if session.closed {
+			return nil
+		}
+
+		_, message, err := session.conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		session.lastReceived = time.Now()
+		if errEvent := session.onMessage(ctx, message); errEvent != nil {
+			session.SendReply(api.EventType_error, errEvent)
+		}
+	}
+}
+
+func (session *Session) onMessage(ctx context.Context, message []byte) *api.ErrorEvent {
+	rtm, err := DecodeRealtime(jsonEncoding, message)
+	if err != nil {
+		return errors.InternalWS(err.Error())
+	}
+
+	return session.handleMessage(ctx, rtm)
+}
+
+func (session *Session) handleMessage(ctx context.Context, req *api.RealTimeMessage) *api.ErrorEvent {
+	decoded, err := DecodeEvent(jsonEncoding, req.EventType, req.Event)
+	if err != nil {
+		return errors.InternalWS(err.Error())
+	}
+
+	switch req.EventType {
+	case api.EventType_disconnect:
+		event, ok := decoded.(*api.DisconnectEvent)
+		if !ok {
+			return errors.InternalWS("expecting disconnect event")
+		}
+
+		if len(event.Channel) > 0 {
+			watcher := session.watchers[event.Channel]
+			watcher.Close()
+			delete(session.watchers, event.Channel)
+		} else {
+			if err := session.Close(); err != nil {
+				return errors.InternalWS(err.Error())
+			}
+		}
+
+		return nil
+	case api.EventType_heartbeat:
+		if err := session.SendHeartbeat(); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		return nil
+	case api.EventType_subscribe:
+		event, ok := decoded.(*api.SubscribeEvent)
+		if !ok {
+			return errors.InternalWS("expecting subscribe event")
+		}
+
+		channel, err := session.chFactory.GetOrCreateChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		if _, ok := session.watchers[event.Channel]; ok {
+			// if already watching ignore
+			return nil
+		}
+
+		watcher, err := channel.GetWatcher(ctx, session.id, event.Position)
+		if err != nil {
+			return nil
+		}
+		session.watchers[event.Channel] = watcher
+		watcher.StartWatching(NewDevicePusher(session, event.Channel).Watch)
+		session.SendReply(api.EventType_subscribed, &api.SubscribedEvent{
+			Channel: event.Channel,
+		})
+		return nil
+	case api.EventType_message:
+		event, ok := decoded.(*api.MessageEvent)
+		if !ok {
+			return errors.InternalWS("expecting message event")
+		}
+
+		ch, err := session.chFactory.GetOrCreateChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		streamData, err := NewMessageData(session.clientId, session.socketId, event.Name, event)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		if _, err := ch.PublishMessage(ctx, streamData); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		return nil
+	case api.EventType_presence_message:
+		event, ok := decoded.(*api.MessageEvent)
+		if !ok {
+			return errors.InternalWS("expecting presence event")
+		}
+
+		ch, err := session.chFactory.GetOrCreateChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		streamData, err := NewPresenceData(session.clientId, session.socketId, event.Name, event)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		if _, err := ch.PublishPresence(ctx, streamData); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+	default:
+		// ToDo: presence channel subscribe by adding a different watcher name
+	}
+	return nil
+}
+
+func (session *Session) SendReply(eventType api.EventType, event proto.Message) {
+	eventEnc, err := EncodeEvent(jsonEncoding, eventType, event)
+	if err != nil {
+		panic(err)
+	}
+
+	msg := &api.RealTimeMessage{
+		EventType: eventType,
+		Event:     eventEnc,
+	}
+
+	encRealtime, err := EncodeRealtime(jsonEncoding, msg)
+	if err != nil {
+		panic(err)
+	}
+
+	_ = session.conn.WriteMessage(
+		websocket.TextMessage,
+		encRealtime,
+	)
+}
+
+func (session *Session) SendHeartbeat() error {
+	b, _ := EncodeRealtime(jsonEncoding, &api.RealTimeMessage{EventType: api.EventType_heartbeat})
+	return session.conn.WriteMessage(websocket.TextMessage, b)
+}
+
+func (session *Session) SendConnectionEstablished() error {
+	session.socketId = uuid.New().String()
+	var event = &api.ConnectedMessage{
+		SessionId: session.id,
+		SocketId:  session.socketId,
+	}
+
+	session.SendReply(api.EventType_connected, event)
+	return nil
+}

--- a/server/services/v1/realtime/device_session_test.go
+++ b/server/services/v1/realtime/device_session_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/tigrisdata/tigris/internal"
+)
+
+func TestPusher(t *testing.T) {
+	/**
+	r := cache.NewCache()
+	mgr := NewSessionMgr(r)
+	session := mgr.CreateDeviceSession(nil, "abc")
+	session.chFactory.CreateChannel(context.TODO(), "test")
+	streamPusher, err := NewDevicePusher(session, &api.SubscribeEvent{
+		Channel: "test",
+	})
+	require.NoError(t, err)
+
+	streamPusher.StartPushing()
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(10 * time.Second)
+		require.NoError(t, streamPusher.channel.Publish(context.TODO(), getEvent()))
+	}*/
+}
+
+func getEvent() *internal.StreamData {
+	payload := []byte(fmt.Sprintf(`{"key": %s}`, randStringRunes(64)))
+	return &internal.StreamData{
+		RawData: payload,
+	}
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/server/services/v1/realtime/factory.go
+++ b/server/services/v1/realtime/factory.go
@@ -1,0 +1,183 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const monitorChannelDuration = 2 * time.Minute
+
+type ChannelFactory struct {
+	sync.RWMutex
+
+	cache      cache.Cache
+	encoder    metadata.CacheEncoder
+	heartbeatF *HeartbeatFactory
+	channels   map[string]*Channel
+}
+
+func NewChannelFactory(cache cache.Cache, encoder metadata.CacheEncoder, heartbeatF *HeartbeatFactory) *ChannelFactory {
+	factory := &ChannelFactory{
+		cache:      cache,
+		encoder:    encoder,
+		heartbeatF: heartbeatF,
+		channels:   make(map[string]*Channel),
+	}
+
+	go factory.monitorStreams()
+	return factory
+}
+
+func (factory *ChannelFactory) monitorStreams() {
+	ticker := time.NewTicker(monitorChannelDuration)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			for _, c := range factory.channels {
+				_ = factory.deleteChannelIfInactive(c)
+			}
+		}
+	}
+}
+
+func (factory *ChannelFactory) deleteChannelIfInactive(c *Channel) error {
+	groups, err := c.stream.GetConsumerGroups(context.TODO())
+	if err != nil {
+		log.Err(err).Str("channel", c.encName).Msg("reading consumers failed")
+		return err
+	}
+
+	var groupsName []string
+	for _, g := range groups {
+		groupsName = append(groupsName, g.Name)
+	}
+
+	heartbeat := factory.heartbeatF.GetHeartbeatTable(c.tenant, c.project)
+	if heartbeat.GroupsExpired(groupsName) {
+		factory.DeleteChannel(context.TODO(), c)
+	}
+
+	return nil
+}
+
+func (factory *ChannelFactory) getChannel(encStream string) (*Channel, bool) {
+	factory.RLock()
+	defer factory.RUnlock()
+
+	ch, ok := factory.channels[encStream]
+	return ch, ok
+}
+
+func (factory *ChannelFactory) getOrCreateChannelFromCache(ctx context.Context, encStream string) (*Channel, error) {
+	stream, err := factory.cache.CreateOrGetStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewChannel(encStream, stream), nil
+}
+
+func (factory *ChannelFactory) ListChannels(ctx context.Context, tenantId uint32, projId uint32, prefix string) ([]string, error) {
+	encProj, err := factory.encoder.EncodeCacheTableName(tenantId, projId, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.cache.ListStreams(ctx, encProj)
+}
+
+func (factory *ChannelFactory) GetChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if ch, ok := factory.getChannel(encStream); ok {
+		return ch, nil
+	}
+
+	stream, err := factory.cache.GetStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := NewChannel(encStream, stream)
+
+	factory.Lock()
+	factory.channels[encStream] = ch
+	factory.Unlock()
+	return ch, nil
+}
+
+func (factory *ChannelFactory) GetOrCreateChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if ch, ok := factory.getChannel(encStream); ok {
+		return ch, nil
+	}
+
+	factory.Lock()
+	defer factory.Unlock()
+
+	ch, err := factory.getOrCreateChannelFromCache(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	factory.channels[encStream] = ch
+	return ch, nil
+}
+
+// CreateChannel will throw an error if stream already exists. Use CreateOrGet to create if not exists primitive.
+func (factory *ChannelFactory) CreateChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := factory.getChannel(encStream); ok {
+		return nil, cache.ErrStreamAlreadyExists
+	}
+
+	factory.Lock()
+	defer factory.Unlock()
+	stream, err := factory.cache.CreateStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := NewChannel(encStream, stream)
+	factory.channels[ch.encName] = ch
+	return ch, nil
+}
+
+func (factory *ChannelFactory) DeleteChannel(ctx context.Context, ch *Channel) {
+	factory.Lock()
+	defer factory.Unlock()
+
+	ch.Close(ctx)
+	delete(factory.channels, ch.encName)
+}

--- a/server/services/v1/realtime/factory_test.go
+++ b/server/services/v1/realtime/factory_test.go
@@ -1,0 +1,49 @@
+package realtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+func TestFactory(t *testing.T) {
+	ctx := context.TODO()
+	factory := newFactory(t)
+
+	t.Run("get_list_channels", func(t *testing.T) {
+		channel, err := factory.GetOrCreateChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		defer factory.DeleteChannel(ctx, channel)
+
+		channels, err := factory.ListChannels(ctx, 1, 1, "*")
+		require.NoError(t, err)
+		require.Equal(t, []string{"cache:1:1:test"}, channels)
+	})
+	t.Run("strict_create_channel", func(t *testing.T) {
+		channel1, err := factory.GetOrCreateChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		defer factory.DeleteChannel(ctx, channel1)
+
+		channel2, err := factory.CreateChannel(ctx, 1, 1, "test")
+		require.Equal(t, cache.ErrStreamAlreadyExists, err)
+		require.Nil(t, channel2)
+
+		channels, err := factory.ListChannels(ctx, 1, 1, "*")
+		require.NoError(t, err)
+		require.Equal(t, []string{"cache:1:1:test"}, channels)
+
+		channel3, err := factory.GetChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		require.Equal(t, channel1, channel3)
+	})
+}
+
+func newFactory(t *testing.T) *ChannelFactory {
+	cacheS := cache.NewCache(config.GetTestCacheConfig())
+	encoder := metadata.NewCacheEncoder()
+	return NewChannelFactory(cacheS, encoder, NewHeartbeatFactory(cacheS, encoder))
+}

--- a/server/services/v1/realtime/heartbeat.go
+++ b/server/services/v1/realtime/heartbeat.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sync"
+
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const (
+	heartbeatTable    = "heartbeat"
+	defaultExpiryTime = 120 * time.Second
+)
+
+type HeartbeatFactory struct {
+	sync.Mutex
+
+	cache      cache.Cache
+	encoder    metadata.CacheEncoder
+	heartbeats map[string]*HeartbeatTable
+}
+
+func NewHeartbeatFactory(cache cache.Cache, encoder metadata.CacheEncoder) *HeartbeatFactory {
+	return &HeartbeatFactory{
+		cache:      cache,
+		encoder:    encoder,
+		heartbeats: make(map[string]*HeartbeatTable),
+	}
+}
+
+func (factory *HeartbeatFactory) GetHeartbeatTable(tenantId uint32, projectId uint32) *HeartbeatTable {
+	factory.Lock()
+	defer factory.Unlock()
+
+	tableName, _ := factory.encoder.EncodeCacheTableName(tenantId, projectId, heartbeatTable)
+	if table, ok := factory.heartbeats[tableName]; ok {
+		return table
+	}
+
+	return NewHeartbeat(factory.cache, tableName)
+}
+
+type HeartbeatTable struct {
+	cache         cache.Cache
+	tableName     string
+	lastHeartbeat time.Time
+}
+
+func NewHeartbeat(cache cache.Cache, tableName string) *HeartbeatTable {
+	return &HeartbeatTable{
+		cache:     cache,
+		tableName: tableName,
+	}
+}
+
+func (h *HeartbeatTable) timeToPing() bool {
+	return time.Since(h.lastHeartbeat) >= 5*time.Second
+}
+
+func (h *HeartbeatTable) Ping(sessionId string) error {
+	if !h.timeToPing() {
+		return nil
+	}
+
+	err := h.cache.Set(
+		context.TODO(),
+		h.tableName,
+		sessionId,
+		internal.NewCacheData([]byte(fmt.Sprintf("%d", time.Now().UnixNano()))),
+		&cache.SetOptions{EX: defaultExpiryTime},
+	)
+	h.lastHeartbeat = time.Now()
+	return err
+}
+
+func (h *HeartbeatTable) GroupsExpired(groupsName []string) bool {
+	if h.lastHeartbeat.IsZero() {
+		return false
+	}
+	if count, err := h.cache.Exists(context.TODO(), h.tableName, groupsName...); err == nil && count == 0 {
+		return true
+	}
+
+	return false
+}

--- a/server/services/v1/realtime/pusher.go
+++ b/server/services/v1/realtime/pusher.go
@@ -1,0 +1,90 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+type DevicePusher struct {
+	channel    string
+	sessionId  string
+	socketId   string
+	connection *websocket.Conn
+}
+
+func NewDevicePusher(session *Session, channel string) *DevicePusher {
+	return &DevicePusher{
+		channel:    channel,
+		sessionId:  session.id,
+		socketId:   session.socketId,
+		connection: session.conn,
+	}
+}
+
+func (pusher *DevicePusher) Watch(events *cache.StreamMessages, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	var processed []string
+	for _, m := range events.Messages {
+		data, err := events.Decode(m)
+		if err != nil {
+			continue
+		}
+
+		md, err := DecodeStreamMD(data.Metadata)
+		if err != nil {
+			continue
+		}
+		processed = append(processed, m.ID)
+		if md.ClientId == pusher.sessionId {
+			continue
+		}
+		pusher.sendMessage(m.ID, md, data)
+	}
+
+	return processed, nil
+
+}
+
+func (pusher *DevicePusher) sendMessage(msgId string, md *StreamMessageMD, data *internal.StreamData) {
+	msgEventBytes := fmt.Sprintf(`{"id": "%s", "name": "%s", "channel": "%s", "timestamp": "%d", "data": "%s"}`,
+		msgId, md.EventName, pusher.channel, data.CreatedAt.UnixNano(), data.RawData)
+
+	/**msg := &api.RealTimeMessage{
+		SessionId: pusher.id,
+		SocketId:  pusher.socketId,
+		Event:     []byte(msgEventBytes),
+		EventType: api.EventType_message.String(),
+	}*/
+	var msgBytes string
+	if md.DataType == PresenceChannelData {
+		msgBytes = fmt.Sprintf(`{"action": "presence", "eventType": "%s", "event": "%s"}`, api.EventType_message.String(), msgEventBytes)
+	} else {
+		msgBytes = fmt.Sprintf(`{"eventType": "%s", "event": "%s"}`, api.EventType_message.String(), msgEventBytes)
+	}
+
+	_ = pusher.connection.WriteMessage(
+		websocket.TextMessage,
+		[]byte(msgBytes),
+	)
+}

--- a/server/services/v1/realtime/request.go
+++ b/server/services/v1/realtime/request.go
@@ -1,0 +1,22 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+// ConnectionParams do we need serial here as well?
+type ConnectionParams struct {
+	ProjectName string
+	SessionId   string
+	Position    string
+}

--- a/server/services/v1/realtime/response.go
+++ b/server/services/v1/realtime/response.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import api "github.com/tigrisdata/tigris/api/server/v1"
+
+type Streaming interface {
+	api.Realtime_ReadMessagesServer
+}
+
+type Response struct {
+	api.Response
+}

--- a/server/services/v1/realtime/serialization.go
+++ b/server/services/v1/realtime/serialization.go
@@ -1,0 +1,196 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"bytes"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/internal"
+	ulog "github.com/tigrisdata/tigris/util/log"
+	"github.com/ugorji/go/codec"
+	"google.golang.org/protobuf/proto"
+)
+
+type wsEncodingType int8
+
+const (
+	msgpackEncoding wsEncodingType = 1
+	jsonEncoding    wsEncodingType = 2
+)
+
+const (
+	PresenceChannelData = "presence"
+	MessageChannelData  = "message"
+)
+
+var bh codec.BincHandle
+
+type StreamMessageMD struct {
+	ClientId string
+	SocketId string
+	// DataType is the type of data it is storing for example "presence" or "message" data
+	DataType string
+	// EventName is the named identifier of this message like in case of presence "enter"/"left", etc
+	EventName string
+}
+
+func NewStreamMessageMD(dataType string, clientId string, socketId string, eventName string) *StreamMessageMD {
+	return &StreamMessageMD{
+		DataType:  dataType,
+		ClientId:  clientId,
+		SocketId:  socketId,
+		EventName: eventName,
+	}
+}
+
+func EncodeStreamMD(md *StreamMessageMD) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, &bh)
+	if err := enc.Encode(md); ulog.E(err) {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func DecodeStreamMD(enc []byte) (*StreamMessageMD, error) {
+	dec := codec.NewDecoderBytes(enc, &bh)
+
+	var v *StreamMessageMD
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func NewPresenceData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(PresenceChannelData, clientId, socketId, eventName, msg.Data)
+}
+
+func NewEventDataFromMessage(clientId string, socketId string, eventName string, msg *api.Message) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+}
+
+func NewMessageData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+}
+
+func newStreamData(dataType string, clientId string, socketId string, eventName string, rawData []byte) (*internal.StreamData, error) {
+	md := NewStreamMessageMD(dataType, clientId, socketId, eventName)
+	enc, err := EncodeStreamMD(md)
+	if err != nil {
+		return nil, err
+	}
+
+	return internal.NewStreamData(enc, rawData), nil
+}
+
+func EncodeRealtime(encodingType wsEncodingType, msg *api.RealTimeMessage) ([]byte, error) {
+	switch encodingType {
+	case msgpackEncoding:
+		var buf bytes.Buffer
+		enc := codec.NewEncoder(&buf, &bh)
+		if err := enc.Encode(msg); ulog.E(err) {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case jsonEncoding:
+		return jsoniter.Marshal(msg)
+	}
+
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func EncodeEvent(encodingType wsEncodingType, eventType api.EventType, event proto.Message) ([]byte, error) {
+	switch encodingType {
+	case msgpackEncoding:
+		return EncodeAsMsgPack(eventType, event)
+	case jsonEncoding:
+		return EncodeAsJSON(eventType, event)
+	}
+
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func EncodeAsJSON(_ api.EventType, event proto.Message) ([]byte, error) {
+	return jsoniter.Marshal(event)
+}
+
+func EncodeAsMsgPack(eventType api.EventType, event proto.Message) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := buf.WriteByte(byte(eventType)); err != nil {
+		return nil, err
+	}
+
+	enc := codec.NewEncoder(&buf, &bh)
+	if err := enc.Encode(event); ulog.E(err) {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeRealtime(encodingType wsEncodingType, message []byte) (*api.RealTimeMessage, error) {
+	switch encodingType {
+	case msgpackEncoding:
+	case jsonEncoding:
+		var req *api.RealTimeMessage
+		err := jsoniter.Unmarshal(message, &req)
+		return req, err
+	}
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func DecodeEvent(encodingType wsEncodingType, eventType api.EventType, message []byte) (proto.Message, error) {
+	switch encodingType {
+	case msgpackEncoding:
+	case jsonEncoding:
+		switch eventType {
+		case api.EventType_auth:
+			var event *api.AuthEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_subscribe:
+			var event *api.SubscribeEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_presence_subscribe:
+			var event *api.SubscribeEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_subscribed:
+			var event *api.SubscribedEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_message:
+			var event *api.MessageEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_presence_message:
+			var event *api.Message
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_disconnect:
+			var event *api.DisconnectEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		default:
+			return nil, fmt.Errorf("unsupported '%d'", eventType)
+		}
+	}
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}

--- a/server/services/v1/realtime/sessions.go
+++ b/server/services/v1/realtime/sessions.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/request"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+var (
+	ping = []byte(`{"event": "heartbeat"}`)
+)
+
+type Sessions struct {
+	sync.RWMutex
+
+	cache            cache.Cache
+	devices          map[string]*Session
+	txMgr            *transaction.Manager
+	tenantMgr        *metadata.TenantManager
+	channelFactory   *ChannelFactory
+	heartbeatFactory *HeartbeatFactory
+	versionH         *metadata.VersionHandler
+}
+
+func NewSessionMgr(cache cache.Cache, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager, heartbeatF *HeartbeatFactory, factory *ChannelFactory) *Sessions {
+	return &Sessions{
+		cache:            cache,
+		txMgr:            txMgr,
+		tenantMgr:        tenantMgr,
+		heartbeatFactory: heartbeatF,
+		devices:          make(map[string]*Session),
+		channelFactory:   factory,
+	}
+}
+
+func (s *Sessions) TrackSessions() {
+	go func() {
+		for {
+			time.Sleep(30 * time.Second)
+			s.destroyInactiveSessions()
+		}
+	}()
+
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			s.pingSessions()
+		}
+	}()
+}
+
+func (s *Sessions) pingSessions() {
+	s.RLock()
+	defer s.RUnlock()
+
+	for _, d := range s.devices {
+		if !d.IsActive() {
+			_ = d.SendHeartbeat()
+		}
+	}
+}
+
+func (s *Sessions) destroyInactiveSessions() {
+	s.Lock()
+	defer s.Unlock()
+
+	for _, d := range s.devices {
+		if !d.IsActive() {
+			s.RemoveDevice(context.TODO(), d)
+		}
+	}
+}
+
+func (s *Sessions) RemoveDevice(_ context.Context, session *Session) {
+	if session, ok := s.devices[session.id]; ok {
+		delete(s.devices, session.id)
+	}
+}
+
+func (s *Sessions) AddDevice(ctx context.Context, conn *websocket.Conn, params ConnectionParams) (*Session, error) {
+	if device, ok := s.devices[params.SessionId]; ok {
+		return device, nil
+	}
+
+	sess, err := s.CreateDeviceSession(ctx, conn, params)
+	if err != nil {
+		return nil, err
+	}
+	s.devices[sess.id] = sess
+	return sess, nil
+}
+
+func (s *Sessions) ExecuteRunner(ctx context.Context, runner RTMRunner) (*Response, error) {
+	namespaceForThisSession, err := request.GetNamespace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tenant, err := s.tenantMgr.GetTenant(ctx, namespaceForThisSession)
+	if err != nil {
+		return nil, errors.NotFound("tenant '%s' not found", namespaceForThisSession)
+	}
+
+	return runner.Run(ctx, tenant)
+}

--- a/server/services/v1/realtime/watcher.go
+++ b/server/services/v1/realtime/watcher.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const (
+	basePos = "0-0"
+
+	// streamFromCurrentPos is for creating a consumer group that sets the position as current
+	streamFromCurrentPos = "$"
+
+	// streamFromCurrentPosRead is to let stream know that reads needs to happen from current
+	streamFromCurrentPosRead = ">"
+)
+
+// Watch is called when an event is received by ChannelWatcher.
+type Watch func(*cache.StreamMessages, error) ([]string, error)
+
+// ChannelWatcher is to watch events for a single channel. It accepts a watch that will be notified when a new event
+// is read from the stream. As ChannelWatcher is mapped to a consumer group on a stream therefore the state is restored
+// from the cache during restart which means a watcher is only created if it doesn’t exist otherwise the existing one
+// is returned.
+type ChannelWatcher struct {
+	ctx      context.Context
+	name     string
+	pos      string
+	watch    Watch
+	stream   cache.Stream
+	sigClose chan struct{}
+}
+
+func CreateWatcher(ctx context.Context, id string, pos string, stream cache.Stream) *ChannelWatcher {
+	if len(pos) == 0 {
+		pos = streamFromCurrentPosRead
+	}
+
+	return newWatcher(ctx, id, pos, stream)
+}
+
+func CreateAndRegisterWatcher(ctx context.Context, id string, pos string, stream cache.Stream) (*ChannelWatcher, error) {
+	if len(pos) == 0 {
+		pos = streamFromCurrentPos
+	}
+
+	if err := stream.CreateConsumerGroup(ctx, id, pos); err != nil {
+		return nil, err
+	}
+
+	if pos == streamFromCurrentPos {
+		pos = streamFromCurrentPosRead
+	}
+
+	return newWatcher(ctx, id, pos, stream), nil
+}
+
+func newWatcher(ctx context.Context, id string, pos string, stream cache.Stream) *ChannelWatcher {
+	return &ChannelWatcher{
+		ctx:      ctx,
+		name:     id,
+		pos:      pos,
+		stream:   stream,
+		sigClose: make(chan struct{}),
+	}
+}
+
+func (watcher *ChannelWatcher) StartWatching(watch Watch) {
+	watcher.watch = watch
+	go watcher.watchEvents()
+}
+
+func (watcher *ChannelWatcher) Move(newPos string) {
+	if len(newPos) == 0 {
+		return
+	}
+
+	watcher.pos = newPos
+}
+
+func (watcher *ChannelWatcher) Position() string {
+	return watcher.pos
+}
+
+func (watcher *ChannelWatcher) Close() {
+	close(watcher.sigClose)
+}
+
+func (watcher *ChannelWatcher) watchEvents() {
+	for {
+		select {
+		case <-watcher.sigClose:
+			_ = watcher.stream.RemoveConsumerGroup(watcher.ctx, watcher.name)
+			return
+		default:
+			resp, hasData, err := watcher.stream.ReadGroup(watcher.ctx, watcher.name, watcher.pos)
+			if err != nil {
+				continue
+			}
+
+			if !hasData && watcher.pos == streamFromCurrentPosRead {
+				continue
+			}
+
+			if !hasData {
+				watcher.pos = streamFromCurrentPosRead
+				continue
+			}
+
+			if ids, err := watcher.watch(resp, nil); err == nil {
+				watcher.ack(watcher.ctx, ids)
+			}
+		}
+	}
+}
+
+func (watcher *ChannelWatcher) ack(ctx context.Context, ids []string) error {
+	if err := watcher.stream.Ack(ctx, watcher.name, ids...); err != nil {
+		return err
+	}
+
+	/**
+	split := strings.Split(ids[len(ids)-1], "-")
+	incrId, _ := strconv.ParseInt(split[1], 10, 64)
+	watcher.pos = fmt.Sprintf("%s-%d", split[0], incrId+1)*/
+	return nil
+}

--- a/server/services/v1/realtime/watcher_test.go
+++ b/server/services/v1/realtime/watcher_test.go
@@ -1,0 +1,5 @@
+package realtime
+
+import "testing"
+
+func TestWatcher(t *testing.T) {}

--- a/server/services/v1/service.go
+++ b/server/services/v1/service.go
@@ -37,6 +37,14 @@ type Service interface {
 	RegisterGRPC(grpc *grpc.Server) error
 }
 
+func GetRegisteredServicesRealtime(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
+	var v1Services []Service
+	v1Services = append(v1Services, newRealtimeService(kvStore, searchStore, tenantMgr, txMgr))
+	v1Services = append(v1Services, newHealthService(txMgr))
+	v1Services = append(v1Services, newObservabilityService(tenantMgr))
+	return v1Services
+}
+
 func GetRegisteredServices(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
 	var v1Services []Service
 	v1Services = append(v1Services, newHealthService(txMgr))


### PR DESCRIPTION
Update 12/23/21: This diff is broken down and superseded by the following PRs

- https://github.com/tigrisdata/tigris/pull/682
- https://github.com/tigrisdata/tigris/pull/684
- https://github.com/tigrisdata/tigris/pull/692
- https://github.com/tigrisdata/tigris/pull/693

Closing this draft POC!

Prev:
This diff is implementing WebSocket protocol to support real-time event passing using Channels i.e. a functionality where Tigris is responsible for broadcasting events to connected devices/clients at low latency. The events will be stored in the in-memory cache during the lifetime of a channel. 

The diff has the following things implemented,
- Websocket protocol to handle events - 
  - Disconnect
  - Subscribe
  - Message
  - Heartbeat
- A session manager to manage device sessions
- HTTP APIs
  - To Get information about the channel
  - Post messages to a channel
  - Read messages from a channel
  - List Channels
  - List Subscriptions
- A real-time server accepting WebSocket as well as HTTP requests. 
- A couple of middlewares that are attached to the real-time server
- Logic to manage the lifecycle of a channel, device, and stream. 
- Logic to reload channels during restart, and reconnect devices back to the channel if they join in a short window.

ToDo:
- To implement remaining events
- Still need to do a lot of testing to make it production ready


