### PR TITLE
feat: Basic Realtime API stubs, separating realtime, database core logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gnostic v0.6.9
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3 h1:hRcWZ7716+E1tkMSZJ/QeeC2dPGGB1R/4z4m9RsL8Qg=

--- a/server/metadata/key_encoder.go
+++ b/server/metadata/key_encoder.go
@@ -53,6 +53,11 @@ type Encoder interface {
 	DecodeIndexName(indexName []byte) uint32
 }
 
+// NewCacheEncoder creates CacheEncoder to encode cache tenant, project and keys.
+func NewCacheEncoder() CacheEncoder {
+	return &DictKeyEncoder{}
+}
+
 // NewEncoder creates Dictionary metaStore to encode keys.
 func NewEncoder() Encoder {
 	return &DictKeyEncoder{}

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/request"
 	"github.com/tigrisdata/tigris/server/services/v1/auth"
+	"github.com/tigrisdata/tigris/server/services/v1/database"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
 	"github.com/tigrisdata/tigris/store/search"
@@ -40,8 +41,10 @@ import (
 )
 
 const (
-	projectPath        = "/projects"
-	projectPathPattern = projectPath + "*"
+	projectsPath           = "/projects"
+	fullProjectPath        = projectsPath + "/{project}"
+	databasePathPattern    = fullProjectPath + "/database/*"
+	applicationPathPattern = fullProjectPath + "/apps/*"
 
 	infoPath    = "/info"
 	metricsPath = "/metrics"
@@ -54,8 +57,8 @@ type apiService struct {
 	txMgr         *transaction.Manager
 	tenantMgr     *metadata.TenantManager
 	cdcMgr        *cdc.Manager
-	sessions      Session
-	runnerFactory *QueryRunnerFactory
+	sessions      database.Session
+	runnerFactory *database.QueryRunnerFactory
 	versionH      *metadata.VersionHandler
 	searchStore   search.Store
 	authProvider  auth.Provider
@@ -89,21 +92,21 @@ func newApiService(kv kv.KeyValueStore, searchStore search.Store, tenantMgr *met
 	}
 	ulog.E(tx.Commit(ctx))
 
-	var txListeners []TxListener
+	var txListeners []database.TxListener
 	if config.DefaultConfig.Cdc.Enabled {
 		txListeners = append(txListeners, u.cdcMgr)
 	}
 	if config.DefaultConfig.Search.WriteEnabled {
 		// just for testing so that we can disable it if needed
-		txListeners = append(txListeners, NewSearchIndexer(searchStore, tenantMgr))
+		txListeners = append(txListeners, database.NewSearchIndexer(searchStore, tenantMgr))
 	}
 
 	if config.DefaultConfig.Tracing.Enabled {
-		u.sessions = NewSessionManagerWithMetrics(u.txMgr, u.tenantMgr, u.versionH, txListeners, metadata.NewCacheTracker(tenantMgr, txMgr))
+		u.sessions = database.NewSessionManagerWithMetrics(u.txMgr, u.tenantMgr, u.versionH, txListeners, metadata.NewCacheTracker(tenantMgr, txMgr))
 	} else {
-		u.sessions = NewSessionManager(u.txMgr, u.tenantMgr, u.versionH, txListeners, metadata.NewCacheTracker(tenantMgr, txMgr))
+		u.sessions = database.NewSessionManager(u.txMgr, u.tenantMgr, u.versionH, txListeners, metadata.NewCacheTracker(tenantMgr, txMgr))
 	}
-	u.runnerFactory = NewQueryRunnerFactory(u.txMgr, u.cdcMgr, u.searchStore)
+	u.runnerFactory = database.NewQueryRunnerFactory(u.txMgr, u.cdcMgr, u.searchStore)
 
 	return u
 }
@@ -114,14 +117,28 @@ func (s *apiService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel)
 		runtime.WithIncomingHeaderMatcher(api.CustomMatcher),
 		runtime.WithOutgoingHeaderMatcher(api.CustomMatcher),
 	)
-
 	if err := api.RegisterTigrisHandlerClient(context.TODO(), mux, api.NewTigrisClient(inproc)); err != nil {
 		return err
 	}
 
 	api.RegisterTigrisServer(inproc, s)
 
-	router.HandleFunc(apiPathPrefix+projectPathPattern, func(w http.ResponseWriter, r *http.Request) {
+	// add list projects path
+	router.HandleFunc(apiPathPrefix+projectsPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r)
+	})
+	for _, projectPath := range []string{"/create", "/delete"} {
+		// explicit add project related path
+		router.HandleFunc(apiPathPrefix+fullProjectPath+projectPath, func(w http.ResponseWriter, r *http.Request) {
+			mux.ServeHTTP(w, r)
+		})
+	}
+	router.HandleFunc(apiPathPrefix+databasePathPattern, func(w http.ResponseWriter, r *http.Request) {
+		// to handle all the database related stuff
+		mux.ServeHTTP(w, r)
+	})
+	router.HandleFunc(apiPathPrefix+applicationPathPattern, func(w http.ResponseWriter, r *http.Request) {
+		// to handle app keys
 		mux.ServeHTTP(w, r)
 	})
 	router.HandleFunc(apiPathPrefix+infoPath, func(w http.ResponseWriter, r *http.Request) {
@@ -148,7 +165,7 @@ func (s *apiService) BeginTransaction(ctx context.Context, _ *api.BeginTransacti
 	}
 
 	return &api.BeginTransactionResponse{
-		TxCtx: session.txCtx,
+		TxCtx: session.GetTransactionCtx(),
 	}, nil
 }
 
@@ -163,7 +180,7 @@ func (s *apiService) CommitTransaction(ctx context.Context, _ *api.CommitTransac
 		}
 	}()
 
-	err := session.Commit(s.versionH, session.tx.Context().GetStagedDatabase() != nil, nil)
+	err := session.Commit(s.versionH, session.GetTx().Context().GetStagedDatabase() != nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -192,19 +209,19 @@ func (s *apiService) RollbackTransaction(ctx context.Context, _ *api.RollbackTra
 func (s *apiService) Insert(ctx context.Context, r *api.InsertRequest) (*api.InsertResponse, error) {
 	qm := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
-	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetInsertQueryRunner(r, &qm, accessToken), &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetInsertQueryRunner(r, &qm, accessToken), &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.InsertResponse{
-		Status: resp.status,
+		Status: resp.Status,
 		Metadata: &api.ResponseMetadata{
-			CreatedAt: resp.createdAt.GetProtoTS(),
+			CreatedAt: resp.CreatedAt.GetProtoTS(),
 		},
-		Keys: resp.allKeys,
+		Keys: resp.AllKeys,
 	}, nil
 }
 
@@ -212,56 +229,56 @@ func (s *apiService) Import(ctx context.Context, r *api.ImportRequest) (*api.Imp
 	qm := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
 
-	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetImportQueryRunner(r, &qm, accessToken), &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetImportQueryRunner(r, &qm, accessToken), &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.ImportResponse{
-		Status: resp.status,
+		Status: resp.Status,
 		Metadata: &api.ResponseMetadata{
-			CreatedAt: resp.createdAt.GetProtoTS(),
+			CreatedAt: resp.CreatedAt.GetProtoTS(),
 		},
-		Keys: resp.allKeys,
+		Keys: resp.AllKeys,
 	}, nil
 }
 
 func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.ReplaceResponse, error) {
 	qm := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
-	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetReplaceQueryRunner(r, &qm, accessToken), &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetReplaceQueryRunner(r, &qm, accessToken), &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.ReplaceResponse{
-		Status: resp.status,
+		Status: resp.Status,
 		Metadata: &api.ResponseMetadata{
-			CreatedAt: resp.createdAt.GetProtoTS(),
+			CreatedAt: resp.CreatedAt.GetProtoTS(),
 		},
-		Keys: resp.allKeys,
+		Keys: resp.AllKeys,
 	}, nil
 }
 
 func (s *apiService) Update(ctx context.Context, r *api.UpdateRequest) (*api.UpdateResponse, error) {
 	queryMetrics := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
-	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetUpdateQueryRunner(r, &queryMetrics, accessToken), &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetUpdateQueryRunner(r, &queryMetrics, accessToken), &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.UpdateResponse{
-		Status:        resp.status,
-		ModifiedCount: resp.modifiedCount,
+		Status:        resp.Status,
+		ModifiedCount: resp.ModifiedCount,
 		Metadata: &api.ResponseMetadata{
-			UpdatedAt: resp.updatedAt.GetProtoTS(),
+			UpdatedAt: resp.UpdatedAt.GetProtoTS(),
 		},
 	}, nil
 }
@@ -269,17 +286,17 @@ func (s *apiService) Update(ctx context.Context, r *api.UpdateRequest) (*api.Upd
 func (s *apiService) Delete(ctx context.Context, r *api.DeleteRequest) (*api.DeleteResponse, error) {
 	queryMetrics := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
-	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetDeleteQueryRunner(r, &queryMetrics, accessToken), &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetDeleteQueryRunner(r, &queryMetrics, accessToken), &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.DeleteResponse{
-		Status: resp.status,
+		Status: resp.Status,
 		Metadata: &api.ResponseMetadata{
-			DeletedAt: resp.deletedAt.GetProtoTS(),
+			DeletedAt: resp.DeletedAt.GetProtoTS(),
 		},
 	}, nil
 }
@@ -290,12 +307,12 @@ func (s *apiService) Read(r *api.ReadRequest, stream api.Tigris_ReadServer) erro
 	accessToken, _ := request.GetAccessToken(stream.Context())
 
 	if api.GetTransaction(stream.Context()) != nil {
-		_, err = s.sessions.Execute(stream.Context(), s.runnerFactory.GetStreamingQueryRunner(r, stream, &queryMetrics, accessToken), &ReqOptions{
-			txCtx:              api.GetTransaction(stream.Context()),
-			instantVerTracking: true,
+		_, err = s.sessions.Execute(stream.Context(), s.runnerFactory.GetStreamingQueryRunner(r, stream, &queryMetrics, accessToken), &database.ReqOptions{
+			TxCtx:              api.GetTransaction(stream.Context()),
+			InstantVerTracking: true,
 		})
 	} else {
-		_, err = s.sessions.ReadOnlyExecute(stream.Context(), s.runnerFactory.GetStreamingQueryRunner(r, stream, &queryMetrics, accessToken), &ReqOptions{})
+		_, err = s.sessions.ReadOnlyExecute(stream.Context(), s.runnerFactory.GetStreamingQueryRunner(r, stream, &queryMetrics, accessToken), &database.ReqOptions{})
 	}
 	return err
 }
@@ -303,8 +320,8 @@ func (s *apiService) Read(r *api.ReadRequest, stream api.Tigris_ReadServer) erro
 func (s *apiService) Search(r *api.SearchRequest, stream api.Tigris_SearchServer) error {
 	queryMetrics := metrics.SearchQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(stream.Context())
-	_, err := s.sessions.ReadOnlyExecute(stream.Context(), s.runnerFactory.GetSearchQueryRunner(r, stream, &queryMetrics, accessToken), &ReqOptions{
-		instantVerTracking: true,
+	_, err := s.sessions.ReadOnlyExecute(stream.Context(), s.runnerFactory.GetSearchQueryRunner(r, stream, &queryMetrics, accessToken), &database.ReqOptions{
+		InstantVerTracking: true,
 	})
 	if err != nil {
 		return err
@@ -322,17 +339,17 @@ func (s *apiService) CreateOrUpdateCollection(ctx context.Context, r *api.Create
 	runner := s.runnerFactory.GetCollectionQueryRunner(accessToken)
 	runner.SetCreateOrUpdateCollectionReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{
-		txCtx:              api.GetTransaction(ctx),
-		metadataChange:     true,
-		instantVerTracking: true,
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{
+		TxCtx:              api.GetTransaction(ctx),
+		MetadataChange:     true,
+		InstantVerTracking: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.CreateOrUpdateCollectionResponse{
-		Status:  resp.status,
+		Status:  resp.Status,
 		Message: fmt.Sprintf("collection of type '%s' created successfully", collectionType),
 	}, nil
 }
@@ -342,17 +359,17 @@ func (s *apiService) DropCollection(ctx context.Context, r *api.DropCollectionRe
 	runner := s.runnerFactory.GetCollectionQueryRunner(accessToken)
 	runner.SetDropCollectionReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{
-		txCtx:              api.GetTransaction(ctx),
-		metadataChange:     true,
-		instantVerTracking: true,
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{
+		TxCtx:              api.GetTransaction(ctx),
+		MetadataChange:     true,
+		InstantVerTracking: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.DropCollectionResponse{
-		Status:  resp.status,
+		Status:  resp.Status,
 		Message: "collection dropped successfully",
 	}, nil
 }
@@ -362,8 +379,8 @@ func (s *apiService) ListCollections(ctx context.Context, r *api.ListCollections
 	runner := s.runnerFactory.GetCollectionQueryRunner(accessToken)
 	runner.SetListCollectionReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{
-		txCtx: api.GetTransaction(ctx),
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
 	})
 	if err != nil {
 		return nil, err
@@ -377,7 +394,7 @@ func (s *apiService) ListProjects(ctx context.Context, r *api.ListProjectsReques
 	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
 	runner.SetListProjectsReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{})
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -389,16 +406,16 @@ func (s *apiService) CreateProject(ctx context.Context, r *api.CreateProjectRequ
 	accessToken, _ := request.GetAccessToken(ctx)
 	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
 	runner.SetCreateProjectReq(r)
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{
-		metadataChange:     true,
-		instantVerTracking: true,
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{
+		MetadataChange:     true,
+		InstantVerTracking: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.CreateProjectResponse{
-		Status:  resp.status,
+		Status:  resp.Status,
 		Message: "project created successfully",
 	}, nil
 }
@@ -407,9 +424,9 @@ func (s *apiService) DeleteProject(ctx context.Context, r *api.DeleteProjectRequ
 	accessToken, _ := request.GetAccessToken(ctx)
 	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
 	runner.SetDeleteProjectReq(r)
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{
-		metadataChange:     true,
-		instantVerTracking: true,
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{
+		MetadataChange:     true,
+		InstantVerTracking: true,
 	})
 	if err != nil {
 		return nil, err
@@ -423,7 +440,7 @@ func (s *apiService) DeleteProject(ctx context.Context, r *api.DeleteProjectRequ
 		}
 	}
 	return &api.DeleteProjectResponse{
-		Status:  resp.status,
+		Status:  resp.Status,
 		Message: "project deleted successfully",
 	}, nil
 }
@@ -433,7 +450,7 @@ func (s *apiService) DescribeCollection(ctx context.Context, r *api.DescribeColl
 	runner := s.runnerFactory.GetCollectionQueryRunner(accessToken)
 	runner.SetDescribeCollectionReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{})
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +463,7 @@ func (s *apiService) DescribeDatabase(ctx context.Context, r *api.DescribeDataba
 	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
 	runner.SetDescribeDatabaseReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, &ReqOptions{})
+	resp, err := s.sessions.Execute(ctx, runner, &database.ReqOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/services/v1/auth/auth0.go
+++ b/server/services/v1/auth/auth0.go
@@ -293,7 +293,6 @@ func (a *auth0) DeleteAppKeys(ctx context.Context, project string) error {
 	listKeysResp, err := a.ListAppKeys(ctx, &api.ListAppKeysRequest{
 		Project: project,
 	})
-
 	if err != nil {
 		return err
 	}

--- a/server/services/v1/database/key_generator.go
+++ b/server/services/v1/database/key_generator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/mutator.go
+++ b/server/services/v1/database/mutator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"strconv"

--- a/server/services/v1/database/mutator_test.go
+++ b/server/services/v1/database/mutator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"
@@ -485,9 +485,9 @@ func (runner *ImportQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    InsertedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    InsertedStatus,
 	}, ctx, nil
 }
 
@@ -527,9 +527,9 @@ func (runner *InsertQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    InsertedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    InsertedStatus,
 	}, ctx, nil
 }
 
@@ -565,9 +565,9 @@ func (runner *ReplaceQueryRunner) Run(ctx context.Context, tx transaction.Tx, te
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return &Response{
-		createdAt: ts,
-		allKeys:   allKeys,
-		status:    ReplacedStatus,
+		CreatedAt: ts,
+		AllKeys:   allKeys,
+		Status:    ReplacedStatus,
 	}, ctx, nil
 }
 
@@ -703,9 +703,9 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 
 	ctx = metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 	return &Response{
-		status:        UpdatedStatus,
-		updatedAt:     ts,
-		modifiedCount: modifiedCount,
+		Status:        UpdatedStatus,
+		UpdatedAt:     ts,
+		ModifiedCount: modifiedCount,
 	}, ctx, err
 }
 
@@ -800,9 +800,9 @@ func (runner *DeleteQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 
 	ctx = metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 	return &Response{
-		status:        DeletedStatus,
-		deletedAt:     ts,
-		modifiedCount: modifiedCount,
+		Status:        DeletedStatus,
+		DeletedAt:     ts,
+		ModifiedCount: modifiedCount,
 	}, ctx, nil
 }
 
@@ -1350,7 +1350,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		}
 
 		return &Response{
-			status: DroppedStatus,
+			Status: DroppedStatus,
 		}, ctx, nil
 	case runner.createOrUpdateReq != nil:
 		db, err := runner.getDatabase(ctx, tx, tenant, runner.createOrUpdateReq.GetProject())
@@ -1383,7 +1383,7 @@ func (runner *CollectionQueryRunner) Run(ctx context.Context, tx transaction.Tx,
 		}
 
 		return &Response{
-			status: CreatedStatus,
+			Status: CreatedStatus,
 		}, ctx, nil
 	case runner.listReq != nil:
 		db, err := runner.getDatabase(ctx, tx, tenant, runner.listReq.GetProject())
@@ -1487,7 +1487,7 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		}
 
 		return &Response{
-			status: DroppedStatus,
+			Status: DroppedStatus,
 		}, ctx, nil
 	case runner.create != nil:
 		dbMetadata, err := createDatabaseMetadata(ctx)
@@ -1503,11 +1503,10 @@ func (runner *DatabaseQueryRunner) Run(ctx context.Context, tx transaction.Tx, t
 		}
 
 		return &Response{
-			status: CreatedStatus,
+			Status: CreatedStatus,
 		}, ctx, nil
 	case runner.list != nil:
 		databaseList := tenant.ListDatabases(ctx)
-
 		databases := make([]*api.ProjectInfo, len(databaseList))
 		for i, l := range databaseList {
 			databases[i] = &api.ProjectInfo{

--- a/server/services/v1/database/query_runner_test.go
+++ b/server/services/v1/database/query_runner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"testing"

--- a/server/services/v1/database/request.go
+++ b/server/services/v1/database/request.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	api "github.com/tigrisdata/tigris/api/server/v1"
@@ -40,18 +40,18 @@ type SearchStreaming interface {
 
 // ReqOptions are options used by queryLifecycle to execute a query.
 type ReqOptions struct {
-	txCtx              *api.TransactionCtx
-	metadataChange     bool
-	instantVerTracking bool
+	TxCtx              *api.TransactionCtx
+	MetadataChange     bool
+	InstantVerTracking bool
 }
 
 // Response is a wrapper on api.Response.
 type Response struct {
 	api.Response
-	status        string
-	createdAt     *internal.Timestamp
-	updatedAt     *internal.Timestamp
-	deletedAt     *internal.Timestamp
-	modifiedCount int32
-	allKeys       [][]byte
+	Status        string
+	CreatedAt     *internal.Timestamp
+	UpdatedAt     *internal.Timestamp
+	DeletedAt     *internal.Timestamp
+	ModifiedCount int32
+	AllKeys       [][]byte
 }

--- a/server/services/v1/database/row_reader.go
+++ b/server/services/v1/database/row_reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/database/search_indexer.go
+++ b/server/services/v1/database/search_indexer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"bytes"

--- a/server/services/v1/database/search_indexer_test.go
+++ b/server/services/v1/database/search_indexer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"encoding/json"

--- a/server/services/v1/database/search_reader.go
+++ b/server/services/v1/database/search_reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/database/sessions_test.go
+++ b/server/services/v1/database/sessions_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"testing"

--- a/server/services/v1/database/tx_listener.go
+++ b/server/services/v1/database/tx_listener.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package database
 
 import (
 	"context"

--- a/server/services/v1/realtime.go
+++ b/server/services/v1/realtime.go
@@ -1,0 +1,137 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/fullstorydev/grpchan/inprocgrpc"
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/rs/zerolog/log"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/services/v1/realtime"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/cache"
+	"github.com/tigrisdata/tigris/store/kv"
+	"github.com/tigrisdata/tigris/store/search"
+	"google.golang.org/grpc"
+)
+
+const (
+	realtimePathPattern = fullProjectPath + "/realtime/*"
+)
+
+type realtimeService struct {
+	api.UnimplementedRealtimeServer
+
+	cache cache.Cache
+}
+
+func newRealtimeService(_ kv.KeyValueStore, _ search.Store, _ *metadata.TenantManager, _ *transaction.Manager) *realtimeService {
+	cacheS := cache.NewCache(&config.DefaultConfig.Cache)
+	return &realtimeService{
+		cache: cacheS,
+	}
+}
+
+func (s *realtimeService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel) error {
+	mux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &api.CustomMarshaler{JSONBuiltin: &runtime.JSONBuiltin{}}),
+		runtime.WithIncomingHeaderMatcher(api.CustomMatcher),
+		runtime.WithOutgoingHeaderMatcher(api.CustomMatcher),
+	)
+
+	if err := api.RegisterRealtimeHandlerClient(context.TODO(), mux, api.NewRealtimeClient(inproc)); err != nil {
+		return err
+	}
+
+	api.RegisterRealtimeServer(inproc, s)
+
+	router.HandleFunc(apiPathPrefix+"/projects/{project}/realtime", s.DeviceConnectionHandler)
+	router.HandleFunc(apiPathPrefix+realtimePathPattern, func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r)
+	})
+
+	return nil
+}
+
+func (s *realtimeService) RegisterGRPC(grpc *grpc.Server) error {
+	api.RegisterRealtimeServer(grpc, s)
+	return nil
+}
+
+var upgradeToSocket = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func (s *realtimeService) extractConnParams(r *http.Request) realtime.ConnectionParams {
+	var params realtime.ConnectionParams
+
+	// project name is part of path
+	params.ProjectName = chi.URLParam(r, "project")
+
+	// query params
+	params.SessionId = r.URL.Query().Get("session_id")
+
+	return params
+}
+
+func (s *realtimeService) DeviceConnectionHandler(w http.ResponseWriter, r *http.Request) {
+	params := s.extractConnParams(r)
+	conn, err := upgradeToSocket.Upgrade(w, r, nil)
+	if err != nil {
+		// ToDo: Change to WS errors
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "%s"}`, err.Error())))
+		return
+	}
+
+	log.Debug().Msgf("params '%v'", params)
+	_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"error": "not implemented"}`))
+	_ = conn.Close()
+}
+
+func (s *realtimeService) Ping(_ context.Context, _ *api.HeartbeatEvent) (*api.HeartbeatEvent, error) {
+	return &api.HeartbeatEvent{}, nil
+}
+
+func (s *realtimeService) GetRTChannel(ctx context.Context, req *api.GetRTChannelRequest) (*api.GetRTChannelResponse, error) {
+	return nil, errors.Unimplemented("not implemented")
+}
+
+func (s *realtimeService) GetRTChannels(ctx context.Context, req *api.GetRTChannelsRequest) (*api.GetRTChannelsResponse, error) {
+	return nil, errors.Unimplemented("not implemented")
+}
+
+func (s *realtimeService) ReadMessages(req *api.ReadMessagesRequest, stream api.Realtime_ReadMessagesServer) error {
+	return errors.Unimplemented("not implemented")
+}
+
+func (s *realtimeService) Messages(ctx context.Context, req *api.MessagesRequest) (*api.MessagesResponse, error) {
+	return nil, errors.Unimplemented("not implemented")
+}
+
+func (s *realtimeService) ListSubscriptions(ctx context.Context, req *api.ListSubscriptionRequest) (*api.ListSubscriptionResponse, error) {
+	return nil, errors.Unimplemented("not implemented")
+}

--- a/server/services/v1/realtime/request.go
+++ b/server/services/v1/realtime/request.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+type wsEncodingType int8
+
+const (
+	msgpackEncoding wsEncodingType = 1
+	jsonEncoding    wsEncodingType = 2
+)
+
+const (
+	msgPackEncodingStr = "msgpack"
+	jsonEncodingStr    = "json"
+)
+
+// ConnectionParams do we need serial here as well?
+type ConnectionParams struct {
+	ProjectName string
+	SessionId   string
+	Position    string
+	Encoding    string
+}
+
+func (params ConnectionParams) ToEncodingType() wsEncodingType {
+	if params.Encoding == jsonEncodingStr {
+		return jsonEncoding
+	}
+
+	// default is msgpack
+	return msgpackEncoding
+}

--- a/server/services/v1/service.go
+++ b/server/services/v1/service.go
@@ -37,6 +37,14 @@ type Service interface {
 	RegisterGRPC(grpc *grpc.Server) error
 }
 
+func GetRegisteredServicesRealtime(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
+	var v1Services []Service
+	v1Services = append(v1Services, newRealtimeService(kvStore, searchStore, tenantMgr, txMgr))
+	v1Services = append(v1Services, newHealthService(txMgr))
+	v1Services = append(v1Services, newObservabilityService(tenantMgr))
+	return v1Services
+}
+
 func GetRegisteredServices(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
 	var v1Services []Service
 	v1Services = append(v1Services, newHealthService(txMgr))


### PR DESCRIPTION
- Database core logic is moved to the database package
- Realtime core logic will be in real-time package
- The v1 package will have top-level files for service implementation like `api.go` for database APIs, `realtime.go`, for real-time APIs. 
- Also refactoring the HTTP paths that we added for muxer to enforce strictness and to have real-time as well in the path. 