### PR TITLE
feat: Core realtime functionality

### DIFF
--- a/errors/errors_ws.go
+++ b/errors/errors_ws.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+)
+
+type WSErrorCode int32
+
+const (
+	CodeOK                                   = 0
+	CloseNormalClosure           WSErrorCode = 1000
+	CloseGoingAway               WSErrorCode = 1001
+	CloseProtocolError           WSErrorCode = 1002
+	CloseUnsupportedData         WSErrorCode = 1003
+	CloseNoStatusReceived        WSErrorCode = 1005
+	CloseAbnormalClosure         WSErrorCode = 1006
+	CloseInvalidFramePayloadData WSErrorCode = 1007
+	ClosePolicyViolation         WSErrorCode = 1008
+	CloseMessageTooBig           WSErrorCode = 1009
+	CloseMandatoryExtension      WSErrorCode = 1010
+	CloseInternalServerErr       WSErrorCode = 1011
+	CloseServiceRestart          WSErrorCode = 1012
+	CloseTryAgainLater           WSErrorCode = 1013
+	CloseTLSHandshake            WSErrorCode = 1015
+)
+
+func InternalWS(format string, args ...any) *api.ErrorEvent {
+	return Errorf(CloseInternalServerErr, format, args...)
+}
+
+func Errorf(c WSErrorCode, format string, a ...interface{}) *api.ErrorEvent {
+	if c == CodeOK {
+		return nil
+	}
+
+	e := &api.ErrorEvent{
+		Code:    int32(c),
+		Message: fmt.Sprintf(format, a...),
+	}
+
+	return e
+}

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -20,8 +20,9 @@ import (
 )
 
 // NewStreamData returns a stream data for anything that we need to store in streams.
-func NewStreamData(data []byte) *StreamData {
+func NewStreamData(md []byte, data []byte) *StreamData {
 	return &StreamData{
+		Md:        md,
 		RawData:   data,
 		CreatedAt: NewTimestamp(),
 	}

--- a/internal/data.proto
+++ b/internal/data.proto
@@ -40,14 +40,16 @@ message TableData {
 // are used by channels to store channel metadata but these can be ignored for storing some regular stream data.
 message StreamData {
   // the id generated for this data, in most cases will be filled when returning this in response
-  int32 id = 1;
+  string id = 1;
   // ver is the version for the raw bytes, this may be the version of the event
   int32 ver = 2;
   // encoding represents encoding of the event field.
   int32 encoding = 3;
   Timestamp created_at = 4;
+  // md is the is the metadata of this stream data.
+  bytes md = 5;
   // raw_data is the raw bytes stored, caller controls how they want to store these raw bytes in event store.
-  bytes raw_data = 5;
+  bytes raw_data = 6;
 }
 
 // CacheData is used to store a serialized data that has user data and some Tigris metadata in Cache

--- a/server/services/v1/realtime/channel.go
+++ b/server/services/v1/realtime/channel.go
@@ -1,0 +1,165 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+type Channel struct {
+	sync.RWMutex
+
+	encName  string
+	tenant   uint32
+	project  uint32
+	stream   cache.Stream
+	watchers map[string]*ChannelWatcher
+}
+
+func NewChannel(encName string, stream cache.Stream) *Channel {
+	return &Channel{
+		encName:  encName,
+		stream:   stream,
+		watchers: make(map[string]*ChannelWatcher),
+	}
+}
+
+func (ch *Channel) Name() string {
+	return ch.encName
+}
+
+func (ch *Channel) Read(ctx context.Context, pos string) (*cache.StreamMessages, bool, error) {
+	return ch.stream.Read(ctx, pos)
+}
+
+func (ch *Channel) PublishPresence(ctx context.Context, data *internal.StreamData) (string, error) {
+	return ch.stream.Add(ctx, data)
+}
+
+func (ch *Channel) PublishMessage(ctx context.Context, data *internal.StreamData) (string, error) {
+	return ch.stream.Add(ctx, data)
+}
+
+func (ch *Channel) getWatcher(watcher string) *ChannelWatcher {
+	ch.RLock()
+	defer ch.RUnlock()
+
+	return ch.watchers[watcher]
+}
+
+func (ch *Channel) getWatcherFromRedis(ctx context.Context, watcherName string, resume string) (*ChannelWatcher, bool, error) {
+	group, exists, err := ch.stream.GetConsumerGroup(ctx, watcherName)
+	if err != nil {
+		return nil, exists, err
+	}
+
+	if !exists {
+		return nil, exists, err
+	}
+
+	watcher, err := CreateWatcher(ctx, watcherName, resume, group.LastDeliveredID, ch.stream)
+	if err != nil {
+		return nil, false, err
+	}
+	return watcher, true, nil
+}
+
+func (ch *Channel) ListWatchers() []string {
+	ch.RLock()
+	defer ch.RUnlock()
+
+	watchersList := make([]string, len(ch.watchers))
+	i := 0
+	for _, w := range ch.watchers {
+		watchersList[i] = w.name
+		i++
+	}
+
+	return watchersList
+}
+
+func (ch *Channel) GetWatcher(ctx context.Context, watcherName string, resume string) (*ChannelWatcher, error) {
+	if watcher := ch.getWatcher(watcherName); watcher != nil {
+		// already cached in-memory
+		if err := watcher.move(ctx, resume); err != nil {
+			return nil, err
+		}
+
+		return watcher, nil
+	}
+
+	watcher, exists, err := ch.getWatcherFromRedis(ctx, watcherName, resume)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		ch.Lock()
+		ch.watchers[watcherName] = watcher
+		ch.Unlock()
+		return watcher, nil
+	}
+
+	// Create new and attach to the topic
+	if watcher, err = CreateAndRegisterWatcher(ctx, watcherName, resume, ch.stream); err != nil {
+		return nil, err
+	}
+
+	ch.Lock()
+	ch.watchers[watcherName] = watcher
+	ch.Unlock()
+
+	return watcher, nil
+}
+
+// DisconnectWatcher ToDo: call it during leave.
+func (ch *Channel) DisconnectWatcher(watcher string) {
+	ch.Lock()
+	defer ch.Unlock()
+
+	if w, ok := ch.watchers[watcher]; ok {
+		w.Disconnect()
+		delete(ch.watchers, watcher)
+	}
+}
+
+func (ch *Channel) StopWatcher(watcher string) {
+	ch.Lock()
+	defer ch.Unlock()
+
+	if w, ok := ch.watchers[watcher]; ok {
+		w.Stop()
+		delete(ch.watchers, watcher)
+	}
+}
+
+func (ch *Channel) Close(ctx context.Context) {
+	ch.Lock()
+	defer ch.Unlock()
+
+	for _, w := range ch.watchers {
+		w.Disconnect()
+		delete(ch.watchers, w.name)
+	}
+
+	if err := ch.stream.Delete(ctx); err != nil {
+		log.Err(err).Str("channel", ch.encName).Msg("deleting stream failed")
+		return
+	}
+}

--- a/server/services/v1/realtime/channel_test.go
+++ b/server/services/v1/realtime/channel_test.go
@@ -1,0 +1,211 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+func TestChannel(t *testing.T) {
+	cache.BlockReadGroupDuration = 100 * time.Millisecond
+
+	ctx := context.TODO()
+	cacheS := cache.NewCache(config.GetTestCacheConfig())
+	_ = cacheS.DeleteStream(ctx, "ch_test")
+
+	t.Run("publish_read", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "ch_test")
+		require.NoError(t, err)
+		channel := NewChannel("ch_test", stream)
+		defer channel.Close(ctx)
+
+		first := []byte(`{"a": 1}`)
+		id1, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, first))
+		require.NoError(t, err)
+
+		second := []byte(`{"b": 2}`)
+		id2, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, second))
+		require.NoError(t, err)
+
+		streamMessages, hasData, err := channel.Read(ctx, "0")
+		require.NoError(t, err)
+		require.True(t, hasData)
+		require.NoError(t, err)
+
+		out, err := streamMessages.Decode(streamMessages.Messages[0])
+		require.NoError(t, err)
+		require.Equal(t, first, out.RawData)
+		require.Equal(t, id1, out.Id)
+
+		streamMessages, hasData, err = channel.Read(ctx, out.Id)
+		require.True(t, hasData)
+		require.NoError(t, err)
+		out, err = streamMessages.Decode(streamMessages.Messages[0])
+		require.NoError(t, err)
+		require.Equal(t, second, out.RawData)
+		require.Equal(t, id2, out.Id)
+
+		streamMessages, hasData, err = channel.Read(ctx, out.Id)
+		require.NoError(t, err)
+		require.False(t, hasData)
+		require.Nil(t, streamMessages)
+	})
+	t.Run("watcher", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "ch_test")
+		require.NoError(t, err)
+		channel := NewChannel("ch_test", stream)
+		defer channel.Close(ctx)
+
+		watcher, err := channel.GetWatcher(ctx, "watch", cache.ConsumerGroupDefaultCurrentPos)
+		require.NoError(t, err)
+		require.Equal(t, watcher, channel.watchers["watch"])
+
+		totalEvents := 16
+		dummyWatch := &dummyWatch{
+			t: t,
+		}
+		for i := 0; i < totalEvents; i++ {
+			dummyWatch.expEvents = append(dummyWatch.expEvents, []byte(fmt.Sprintf(`{"a": %d}`, i)))
+		}
+
+		watcher.StartWatching(dummyWatch.watch)
+
+		var expectedIds []string
+		for i := 0; i < totalEvents; i++ {
+			id, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, dummyWatch.expEvents[i]))
+			require.NoError(t, err)
+			expectedIds = append(expectedIds, id)
+		}
+
+		dummyWatch.wait(16)
+
+		receivedIds := dummyWatch.atomicIds.Load().([]string)
+		for i := 0; i < totalEvents; i++ {
+			require.Equal(t, expectedIds[i], receivedIds[i])
+		}
+	})
+	t.Run("watcher-pause-rejoin", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "ch_test")
+		require.NoError(t, err)
+		channel := NewChannel("ch_test", stream)
+		defer channel.Close(ctx)
+
+		watcher, err := channel.GetWatcher(ctx, "watch", cache.ConsumerGroupDefaultCurrentPos)
+		require.NoError(t, err)
+		require.Equal(t, watcher, channel.watchers["watch"])
+
+		totalEvents := 16
+		publishedEvents := make([][]byte, totalEvents)
+		for i := 0; i < totalEvents; i++ {
+			publishedEvents[i] = []byte(fmt.Sprintf(`{"a": %d}`, i))
+		}
+
+		var idsAtomic atomic.Value
+		idsAtomic.Store(make([]string, totalEvents))
+
+		var shouldStartPublishing atomic.Bool
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			watcherTest := func(from int, to int, expEvents int, pos string) {
+				watcher, err := channel.GetWatcher(ctx, "watch", pos)
+				require.NoError(t, err)
+				require.Equal(t, watcher, channel.watchers["watch"])
+
+				watch := &dummyWatch{t: t, expEvents: publishedEvents[from:to]}
+				watcher.StartWatching(watch.watch)
+				shouldStartPublishing.Store(true)
+				watch.wait(int32(expEvents))
+				channel.StopWatcher(watcher.name)
+
+				watchIds := watch.atomicIds.Load().([]string)
+				j := 0
+				for i := from; i < to; i++ {
+					require.Equal(t, idsAtomic.Load().([]string)[i], watchIds[j])
+					j++
+				}
+			}
+
+			watcherTest(0, 4, 4, cache.ConsumerGroupDefaultCurrentPos)
+			watcherTest(4, 8, 4, idsAtomic.Load().([]string)[3])
+			watcherTest(8, 12, 4, idsAtomic.Load().([]string)[7])
+			watcherTest(12, 16, 4, idsAtomic.Load().([]string)[11])
+		}()
+
+		for !shouldStartPublishing.Load() {
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		for i := 0; i < totalEvents; i++ {
+			id, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, publishedEvents[i]))
+			require.NoError(t, err)
+			v := idsAtomic.Load().([]string)
+			v[i] = id
+			idsAtomic.Store(v)
+		}
+
+		wg.Wait()
+	})
+}
+
+type dummyWatch struct {
+	sync.RWMutex
+
+	t           *testing.T
+	eventNo     atomic.Int32
+	expEvents   [][]byte
+	receivedIds []string
+	atomicIds   atomic.Value
+}
+
+func (dummy *dummyWatch) wait(expTotal int32) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	for range ticker.C {
+		if dummy.eventNo.Load() == expTotal {
+			return
+		}
+	}
+}
+
+func (dummy *dummyWatch) watch(events *cache.StreamMessages, err error) ([]string, error) {
+	ids := make([]string, len(events.Messages))
+	for i, m := range events.Messages {
+		if dummy.eventNo.Load() >= int32(len(dummy.expEvents)) {
+			// drop the event
+			continue
+		}
+
+		data, err := events.Decode(m)
+		require.NoError(dummy.t, err)
+		require.Equal(dummy.t, dummy.expEvents[dummy.eventNo.Load()], data.RawData)
+		dummy.eventNo.Add(1)
+		dummy.receivedIds = append(dummy.receivedIds, data.Id)
+		dummy.atomicIds.Store(dummy.receivedIds)
+		ids[i] = data.Id
+	}
+	return ids, nil
+}

--- a/server/services/v1/realtime/device_session.go
+++ b/server/services/v1/realtime/device_session.go
@@ -1,0 +1,340 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/lib/uuid"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/request"
+	"google.golang.org/protobuf/proto"
+)
+
+type Session struct {
+	sync.RWMutex
+
+	id           string
+	clientId     string
+	socketId     string
+	closed       bool
+	encType      WSEncodingType
+	conn         *websocket.Conn
+	lastReceived time.Time
+	chFactory    *ChannelFactory
+	heartbeat    *HeartbeatTable
+	tenant       *metadata.Tenant
+	project      *metadata.Database
+	watchers     map[string]*ChannelWatcher
+}
+
+func (s *Sessions) CreateDeviceSession(ctx context.Context, conn *websocket.Conn, params ConnectionParams) (*Session, error) {
+	sessionId := params.SessionId
+	if len(sessionId) == 0 {
+		sessionId = uuid.NewUUIDAsString()
+	}
+
+	namespaceForThisSession, err := request.GetNamespace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tenant, err := s.tenantMgr.GetTenant(ctx, namespaceForThisSession)
+	if err != nil {
+		return nil, errors.NotFound("tenant '%s' not found", namespaceForThisSession)
+	}
+
+	proj, err := tenant.GetDatabase(ctx, params.ProjectName)
+	if err != nil {
+		return nil, errors.NotFound("project '%s' not found", params.ProjectName)
+	}
+	if proj == nil {
+		tx, err := s.txMgr.StartTx(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var version metadata.Version
+		if version, err = s.versionH.Read(ctx, tx, false); err != nil {
+			return nil, err
+		}
+
+		if err = tenant.Reload(ctx, tx, version); err != nil {
+			return nil, err
+		}
+
+		if proj, _ = tenant.GetDatabase(ctx, params.ProjectName); proj == nil {
+			return nil, errors.NotFound("project '%s' not found", params.ProjectName)
+		}
+	}
+
+	return &Session{
+		id:        sessionId,
+		conn:      conn,
+		tenant:    tenant,
+		project:   proj,
+		encType:   params.ToEncodingType(),
+		chFactory: s.channelFactory,
+		watchers:  make(map[string]*ChannelWatcher),
+		heartbeat: s.heartbeatFactory.GetHeartbeatTable(tenant.GetNamespace().Id(), proj.Id()),
+	}, nil
+}
+
+func (session *Session) IsActive() bool {
+	return time.Since(session.lastReceived) <= 30*time.Second
+}
+
+func (session *Session) OnPong(_ string) error {
+	return session.sendHeartbeat()
+}
+
+func (session *Session) OnPing(_ string) error {
+	return session.sendHeartbeat()
+}
+
+func (session *Session) OnClose(code int, _ string) error {
+	if code == int(errors.CloseAbnormalClosure) {
+		return nil
+	}
+
+	return session.Close()
+}
+
+func (session *Session) Close() error {
+	session.Lock()
+	defer session.Unlock()
+
+	if session.closed {
+		return nil
+	}
+
+	session.closed = true
+	for _, w := range session.watchers {
+		w.Disconnect()
+	}
+
+	return session.conn.Close()
+}
+
+// Start an entry point for handling all the events from a device.
+func (session *Session) Start(ctx context.Context) error {
+	for {
+		_ = session.heartbeat.Ping(session.id)
+		if session.closed {
+			return nil
+		}
+
+		_, message, err := session.conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		session.lastReceived = time.Now()
+		if errEvent := session.onMessage(ctx, message); errEvent != nil {
+			SendReply(session.conn, session.encType, api.EventType_error, errEvent)
+		}
+	}
+}
+
+// onMessage is responsible for handling all the messages that are received on websocket.
+func (session *Session) onMessage(ctx context.Context, message []byte) *api.ErrorEvent {
+	rtm, err := DecodeRealtime(session.encType, message)
+	if err != nil {
+		return errors.InternalWS(err.Error())
+	}
+
+	return session.handleMessage(ctx, rtm)
+}
+
+// handleMessage process the message received on websocket.
+func (session *Session) handleMessage(ctx context.Context, req *api.RealTimeMessage) *api.ErrorEvent {
+	decoded, err := DecodeEvent(session.encType, req.EventType, req.Event)
+	if err != nil {
+		return errors.InternalWS(err.Error())
+	}
+
+	switch req.EventType {
+	case api.EventType_disconnect:
+		event, ok := decoded.(*api.DisconnectEvent)
+		if !ok {
+			return errors.InternalWS("expecting 'disconnect' event")
+		}
+
+		if len(event.Channel) > 0 {
+			watcher := session.watchers[event.Channel]
+			watcher.Disconnect()
+			delete(session.watchers, event.Channel)
+		} else {
+			if err := session.Close(); err != nil {
+				return errors.InternalWS(err.Error())
+			}
+		}
+
+		return nil
+	case api.EventType_heartbeat:
+		if err := session.sendHeartbeat(); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		return nil
+	case api.EventType_attach:
+		event, ok := decoded.(*api.AttachEvent)
+		if !ok {
+			return errors.InternalWS("expecting 'attach' event")
+		}
+
+		// create a channel if it doesn't exist
+		_, err := session.chFactory.GetOrCreateChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		return nil
+	case api.EventType_detach:
+		event, ok := decoded.(*api.DetachEvent)
+		if !ok {
+			return errors.InternalWS("expecting 'detach' event")
+		}
+
+		if watcher, ok := session.watchers[event.Channel]; ok {
+			watcher.Disconnect()
+			delete(session.watchers, event.Channel)
+		}
+		return nil
+	case api.EventType_unsubscribe:
+		event, ok := decoded.(*api.UnsubscribeEvent)
+		if !ok {
+			return errors.InternalWS("expecting 'detach' event")
+		}
+
+		if watcher, ok := session.watchers[event.Channel]; ok {
+			watcher.Stop()
+			delete(session.watchers, event.Channel)
+		}
+		return nil
+	case api.EventType_subscribe:
+		event, ok := decoded.(*api.SubscribeEvent)
+		if !ok {
+			return errors.InternalWS("expecting 'subscribe' event")
+		}
+
+		channel, err := session.chFactory.GetChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		if _, ok := session.watchers[event.Channel]; ok {
+			// if already watching ignore
+			return nil
+		}
+
+		watcher, err := channel.GetWatcher(ctx, session.id, event.Position)
+		if err != nil {
+			return nil
+		}
+		session.watchers[event.Channel] = watcher
+		watcher.StartWatching(NewDevicePusher(session, event.Channel).Watch)
+		SendReply(session.conn, session.encType, api.EventType_subscribed, &api.SubscribedEvent{
+			Channel: event.Channel,
+		})
+		return nil
+	case api.EventType_message:
+		event, ok := decoded.(*api.MessageEvent)
+		if !ok {
+			return errors.InternalWS("expecting message event")
+		}
+
+		ch, err := session.chFactory.GetChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		streamData, err := NewMessageData(session.clientId, session.socketId, event.Name, event)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		if _, err := ch.PublishMessage(ctx, streamData); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		return nil
+	case api.EventType_presence_member:
+		event, ok := decoded.(*api.MessageEvent)
+		if !ok {
+			return errors.InternalWS("expecting presence event")
+		}
+
+		ch, err := session.chFactory.GetChannel(ctx, session.tenant.GetNamespace().Id(), session.project.Id(), event.Channel)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+
+		streamData, err := NewPresenceData(session.clientId, session.socketId, event.Name, event)
+		if err != nil {
+			return errors.InternalWS(err.Error())
+		}
+		if _, err := ch.PublishPresence(ctx, streamData); err != nil {
+			return errors.InternalWS(err.Error())
+		}
+	default:
+		// ToDo: presence channel subscribe by adding a different watcher name
+	}
+	return nil
+}
+
+func SendReply(conn *websocket.Conn, encType WSEncodingType, eventType api.EventType, event proto.Message) {
+	eventEnc, err := EncodeEvent(encType, eventType, event)
+	if err != nil {
+		panic(err)
+	}
+
+	msg := &api.RealTimeMessage{
+		EventType: eventType,
+		Event:     eventEnc,
+	}
+
+	encRealtime, err := EncodeRealtime(encType, msg)
+	if err != nil {
+		panic(err)
+	}
+
+	if encType == MsgpackEncoding {
+		_ = conn.WriteMessage(
+			websocket.BinaryMessage,
+			encRealtime,
+		)
+	} else {
+		_ = conn.WriteMessage(
+			websocket.TextMessage,
+			encRealtime,
+		)
+	}
+}
+
+func (session *Session) sendHeartbeat() error {
+	b, _ := EncodeRealtime(session.encType, &api.RealTimeMessage{EventType: api.EventType_heartbeat})
+	return session.conn.WriteMessage(websocket.TextMessage, b)
+}
+
+func (session *Session) SendConnSuccess() error {
+	session.socketId = uuid.New().String()
+	event := &api.ConnectedEvent{
+		SessionId: session.id,
+		SocketId:  session.socketId,
+	}
+
+	SendReply(session.conn, session.encType, api.EventType_connected, event)
+	return nil
+}

--- a/server/services/v1/realtime/factory.go
+++ b/server/services/v1/realtime/factory.go
@@ -1,0 +1,180 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const monitorChannelDuration = 2 * time.Minute
+
+type ChannelFactory struct {
+	sync.RWMutex
+
+	cache      cache.Cache
+	encoder    metadata.CacheEncoder
+	heartbeatF *HeartbeatFactory
+	channels   map[string]*Channel
+}
+
+func NewChannelFactory(cache cache.Cache, encoder metadata.CacheEncoder, heartbeatF *HeartbeatFactory) *ChannelFactory {
+	factory := &ChannelFactory{
+		cache:      cache,
+		encoder:    encoder,
+		heartbeatF: heartbeatF,
+		channels:   make(map[string]*Channel),
+	}
+
+	go factory.monitorStreams()
+	return factory
+}
+
+func (factory *ChannelFactory) monitorStreams() {
+	ticker := time.NewTicker(monitorChannelDuration)
+	defer ticker.Stop()
+	for range ticker.C {
+		for _, c := range factory.channels {
+			_ = factory.deleteChannelIfInactive(c)
+		}
+	}
+}
+
+func (factory *ChannelFactory) deleteChannelIfInactive(c *Channel) error {
+	groups, err := c.stream.GetConsumerGroups(context.TODO())
+	if err != nil {
+		log.Err(err).Str("channel", c.encName).Msg("reading consumers failed")
+		return err
+	}
+
+	groupsName := make([]string, len(groups))
+	for i, g := range groups {
+		groupsName[i] = g.Name
+	}
+
+	heartbeat := factory.heartbeatF.GetHeartbeatTable(c.tenant, c.project)
+	if heartbeat.GroupsExpired(groupsName) {
+		factory.DeleteChannel(context.TODO(), c)
+	}
+
+	return nil
+}
+
+func (factory *ChannelFactory) getChannel(encStream string) (*Channel, bool) {
+	factory.RLock()
+	defer factory.RUnlock()
+
+	ch, ok := factory.channels[encStream]
+	return ch, ok
+}
+
+func (factory *ChannelFactory) getOrCreateChannelFromCache(ctx context.Context, encStream string) (*Channel, error) {
+	stream, err := factory.cache.CreateOrGetStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewChannel(encStream, stream), nil
+}
+
+func (factory *ChannelFactory) ListChannels(ctx context.Context, tenantId uint32, projId uint32, prefix string) ([]string, error) {
+	encProj, err := factory.encoder.EncodeCacheTableName(tenantId, projId, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.cache.ListStreams(ctx, encProj)
+}
+
+func (factory *ChannelFactory) GetChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if ch, ok := factory.getChannel(encStream); ok {
+		return ch, nil
+	}
+
+	stream, err := factory.cache.GetStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := NewChannel(encStream, stream)
+
+	factory.Lock()
+	factory.channels[encStream] = ch
+	factory.Unlock()
+	return ch, nil
+}
+
+func (factory *ChannelFactory) GetOrCreateChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if ch, ok := factory.getChannel(encStream); ok {
+		return ch, nil
+	}
+
+	factory.Lock()
+	defer factory.Unlock()
+
+	ch, err := factory.getOrCreateChannelFromCache(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	factory.channels[encStream] = ch
+	return ch, nil
+}
+
+// CreateChannel will throw an error if stream already exists. Use CreateOrGet to create if not exists primitive.
+func (factory *ChannelFactory) CreateChannel(ctx context.Context, tenantId uint32, projId uint32, channelName string) (*Channel, error) {
+	encStream, err := factory.encoder.EncodeCacheTableName(tenantId, projId, channelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := factory.getChannel(encStream); ok {
+		return nil, cache.ErrStreamAlreadyExists
+	}
+
+	factory.Lock()
+	defer factory.Unlock()
+	stream, err := factory.cache.CreateStream(ctx, encStream)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := NewChannel(encStream, stream)
+	factory.channels[ch.encName] = ch
+	return ch, nil
+}
+
+func (factory *ChannelFactory) DeleteChannel(ctx context.Context, ch *Channel) {
+	factory.Lock()
+	defer factory.Unlock()
+
+	ch.Close(ctx)
+	delete(factory.channels, ch.encName)
+}

--- a/server/services/v1/realtime/factory_test.go
+++ b/server/services/v1/realtime/factory_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+func TestFactory(t *testing.T) {
+	ctx := context.TODO()
+	factory := newFactory(t)
+
+	t.Run("get_list_channels", func(t *testing.T) {
+		channel, err := factory.GetOrCreateChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		defer factory.DeleteChannel(ctx, channel)
+
+		channels, err := factory.ListChannels(ctx, 1, 1, "*")
+		require.NoError(t, err)
+		require.Equal(t, []string{"cache:1:1:test"}, channels)
+	})
+	t.Run("strict_create_channel", func(t *testing.T) {
+		channel1, err := factory.GetOrCreateChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		defer factory.DeleteChannel(ctx, channel1)
+
+		channel2, err := factory.CreateChannel(ctx, 1, 1, "test")
+		require.Equal(t, cache.ErrStreamAlreadyExists, err)
+		require.Nil(t, channel2)
+
+		channels, err := factory.ListChannels(ctx, 1, 1, "*")
+		require.NoError(t, err)
+		require.Equal(t, []string{"cache:1:1:test"}, channels)
+
+		channel3, err := factory.GetChannel(ctx, 1, 1, "test")
+		require.NoError(t, err)
+		require.Equal(t, channel1, channel3)
+	})
+}
+
+func newFactory(_ *testing.T) *ChannelFactory {
+	cacheS := cache.NewCache(config.GetTestCacheConfig())
+	encoder := metadata.NewCacheEncoder()
+	return NewChannelFactory(cacheS, encoder, NewHeartbeatFactory(cacheS, encoder))
+}

--- a/server/services/v1/realtime/heartbeat.go
+++ b/server/services/v1/realtime/heartbeat.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const (
+	heartbeatTable    = "heartbeat"
+	defaultExpiryTime = 120 * time.Second
+)
+
+type HeartbeatFactory struct {
+	sync.Mutex
+
+	cache      cache.Cache
+	encoder    metadata.CacheEncoder
+	heartbeats map[string]*HeartbeatTable
+}
+
+func NewHeartbeatFactory(cache cache.Cache, encoder metadata.CacheEncoder) *HeartbeatFactory {
+	return &HeartbeatFactory{
+		cache:      cache,
+		encoder:    encoder,
+		heartbeats: make(map[string]*HeartbeatTable),
+	}
+}
+
+func (factory *HeartbeatFactory) GetHeartbeatTable(tenantId uint32, projectId uint32) *HeartbeatTable {
+	factory.Lock()
+	defer factory.Unlock()
+
+	tableName, _ := factory.encoder.EncodeCacheTableName(tenantId, projectId, heartbeatTable)
+	if table, ok := factory.heartbeats[tableName]; ok {
+		return table
+	}
+
+	return NewHeartbeat(factory.cache, tableName)
+}
+
+type HeartbeatTable struct {
+	cache         cache.Cache
+	tableName     string
+	lastHeartbeat time.Time
+}
+
+func NewHeartbeat(cache cache.Cache, tableName string) *HeartbeatTable {
+	return &HeartbeatTable{
+		cache:     cache,
+		tableName: tableName,
+	}
+}
+
+func (h *HeartbeatTable) timeToPing() bool {
+	return time.Since(h.lastHeartbeat) >= 5*time.Second
+}
+
+func (h *HeartbeatTable) Ping(sessionId string) error {
+	if !h.timeToPing() {
+		return nil
+	}
+
+	err := h.cache.Set(
+		context.TODO(),
+		h.tableName,
+		sessionId,
+		internal.NewCacheData([]byte(fmt.Sprintf("%d", time.Now().UnixNano()))),
+		&cache.SetOptions{EX: defaultExpiryTime},
+	)
+	h.lastHeartbeat = time.Now()
+	return err
+}
+
+func (h *HeartbeatTable) GroupsExpired(groupsName []string) bool {
+	if h.lastHeartbeat.IsZero() {
+		return false
+	}
+	if count, err := h.cache.Exists(context.TODO(), h.tableName, groupsName...); err == nil && count == 0 {
+		return true
+	}
+
+	return false
+}

--- a/server/services/v1/realtime/pusher.go
+++ b/server/services/v1/realtime/pusher.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"github.com/gorilla/websocket"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+type DevicePusher struct {
+	channel    string
+	sessionId  string
+	socketId   string
+	encType    WSEncodingType
+	connection *websocket.Conn
+}
+
+func NewDevicePusher(session *Session, channel string) *DevicePusher {
+	return &DevicePusher{
+		channel:    channel,
+		sessionId:  session.id,
+		socketId:   session.socketId,
+		encType:    session.encType,
+		connection: session.conn,
+	}
+}
+
+func (pusher *DevicePusher) Watch(events *cache.StreamMessages, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	processed := make([]string, len(events.Messages))
+	for i, m := range events.Messages {
+		data, err := events.Decode(m)
+		if err != nil {
+			continue
+		}
+
+		md, err := DecodeStreamMD(data.Md)
+		if err != nil {
+			continue
+		}
+		processed[i] = m.ID
+		if md.ClientId == pusher.sessionId {
+			continue
+		}
+		pusher.sendMessage(m.ID, md, data)
+	}
+
+	return processed, nil
+}
+
+func (pusher *DevicePusher) sendMessage(msgId string, md *StreamMessageMD, data *internal.StreamData) {
+	message := &api.MessageEvent{
+		Id:      msgId,
+		Name:    md.EventName,
+		Channel: pusher.channel,
+		Data:    data.RawData,
+	}
+
+	SendReply(pusher.connection, pusher.encType, api.EventType_message, message)
+}

--- a/server/services/v1/realtime/response.go
+++ b/server/services/v1/realtime/response.go
@@ -14,31 +14,12 @@
 
 package realtime
 
-type WSEncodingType int8
+import api "github.com/tigrisdata/tigris/api/server/v1"
 
-const (
-	MsgpackEncoding WSEncodingType = 1
-	JsonEncoding    WSEncodingType = 2
-)
-
-const (
-	msgPackEncodingStr = "msgpack"
-	jsonEncodingStr    = "json"
-)
-
-// ConnectionParams do we need serial here as well?
-type ConnectionParams struct {
-	ProjectName string
-	SessionId   string
-	Position    string
-	Encoding    string
+type Streaming interface {
+	api.Realtime_ReadMessagesServer
 }
 
-func (params ConnectionParams) ToEncodingType() WSEncodingType {
-	if params.Encoding == jsonEncodingStr {
-		return JsonEncoding
-	}
-
-	// default is msgpack
-	return MsgpackEncoding
+type Response struct {
+	api.Response
 }

--- a/server/services/v1/realtime/serialization.go
+++ b/server/services/v1/realtime/serialization.go
@@ -1,0 +1,143 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"bytes"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	ulog "github.com/tigrisdata/tigris/util/log"
+	"github.com/ugorji/go/codec"
+	"google.golang.org/protobuf/proto"
+)
+
+var bh codec.BincHandle
+
+func EncodeStreamMD(md *StreamMessageMD) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, &bh)
+	if err := enc.Encode(md); ulog.E(err) {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func DecodeStreamMD(enc []byte) (*StreamMessageMD, error) {
+	dec := codec.NewDecoderBytes(enc, &bh)
+
+	var v *StreamMessageMD
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func EncodeRealtime(encodingType WSEncodingType, msg *api.RealTimeMessage) ([]byte, error) {
+	switch encodingType {
+	case MsgpackEncoding:
+		var buf bytes.Buffer
+		enc := codec.NewEncoder(&buf, &bh)
+		if err := enc.Encode(msg); ulog.E(err) {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case JsonEncoding:
+		return jsoniter.Marshal(msg)
+	}
+
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func EncodeEvent(encodingType WSEncodingType, eventType api.EventType, event proto.Message) ([]byte, error) {
+	switch encodingType {
+	case MsgpackEncoding:
+		return EncodeAsMsgPack(eventType, event)
+	case JsonEncoding:
+		return EncodeAsJSON(eventType, event)
+	}
+
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func EncodeAsJSON(_ api.EventType, event proto.Message) ([]byte, error) {
+	return jsoniter.Marshal(event)
+}
+
+func EncodeAsMsgPack(eventType api.EventType, event proto.Message) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := buf.WriteByte(byte(eventType)); err != nil {
+		return nil, err
+	}
+
+	enc := codec.NewEncoder(&buf, &bh)
+	if err := enc.Encode(event); ulog.E(err) {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeRealtime(encodingType WSEncodingType, message []byte) (*api.RealTimeMessage, error) {
+	switch encodingType {
+	case MsgpackEncoding:
+	case JsonEncoding:
+		var req *api.RealTimeMessage
+		err := jsoniter.Unmarshal(message, &req)
+		return req, err
+	}
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}
+
+func DecodeEvent(encodingType WSEncodingType, eventType api.EventType, message []byte) (proto.Message, error) {
+	switch encodingType {
+	case MsgpackEncoding:
+	case JsonEncoding:
+		switch eventType {
+		case api.EventType_auth:
+			var event *api.AuthEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_subscribe:
+			var event *api.SubscribeEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_presence:
+			var event *api.PresenceEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_subscribed:
+			var event *api.SubscribedEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_message:
+			var event *api.MessageEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_presence_member:
+			var event *api.PresenceMemberEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		case api.EventType_disconnect:
+			var event *api.DisconnectEvent
+			err := jsoniter.Unmarshal(message, &event)
+			return event, err
+		default:
+			return nil, fmt.Errorf("unsupported '%d'", eventType)
+		}
+	}
+	return nil, fmt.Errorf("unsupported event '%d'", encodingType)
+}

--- a/server/services/v1/realtime/sessions.go
+++ b/server/services/v1/realtime/sessions.go
@@ -1,0 +1,113 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+const (
+	pingSessionDuration     = 1 * time.Second
+	sessionTrackingDuration = 30 * time.Second
+)
+
+type Sessions struct {
+	sync.RWMutex
+
+	cache            cache.Cache
+	devices          map[string]*Session
+	txMgr            *transaction.Manager
+	tenantMgr        *metadata.TenantManager
+	channelFactory   *ChannelFactory
+	heartbeatFactory *HeartbeatFactory
+	versionH         *metadata.VersionHandler
+}
+
+func NewSessionMgr(cache cache.Cache, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager, heartbeatF *HeartbeatFactory, factory *ChannelFactory) *Sessions {
+	return &Sessions{
+		cache:            cache,
+		txMgr:            txMgr,
+		tenantMgr:        tenantMgr,
+		heartbeatFactory: heartbeatF,
+		devices:          make(map[string]*Session),
+		channelFactory:   factory,
+	}
+}
+
+func (s *Sessions) TrackSessions() {
+	go func() {
+		ticker := time.NewTicker(sessionTrackingDuration)
+		defer ticker.Stop()
+		for range ticker.C {
+			s.destroyInactiveSessions()
+		}
+	}()
+
+	go func() {
+		ticker := time.NewTicker(pingSessionDuration)
+		defer ticker.Stop()
+		for range ticker.C {
+			s.pingSessions()
+		}
+	}()
+}
+
+func (s *Sessions) pingSessions() {
+	s.RLock()
+	defer s.RUnlock()
+
+	for _, d := range s.devices {
+		if !d.IsActive() {
+			_ = d.sendHeartbeat()
+		}
+	}
+}
+
+func (s *Sessions) destroyInactiveSessions() {
+	s.Lock()
+	defer s.Unlock()
+
+	for _, d := range s.devices {
+		if !d.IsActive() {
+			s.RemoveDevice(context.TODO(), d)
+		}
+	}
+}
+
+func (s *Sessions) RemoveDevice(_ context.Context, session *Session) {
+	if session, ok := s.devices[session.id]; ok {
+		delete(s.devices, session.id)
+	}
+}
+
+func (s *Sessions) AddDevice(ctx context.Context, conn *websocket.Conn, params ConnectionParams) (*Session, error) {
+	if device, ok := s.devices[params.SessionId]; ok {
+		return device, nil
+	}
+
+	sess, err := s.CreateDeviceSession(ctx, conn, params)
+	if err != nil {
+		return nil, err
+	}
+	s.devices[sess.id] = sess
+	return sess, nil
+}

--- a/server/services/v1/realtime/types.go
+++ b/server/services/v1/realtime/types.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/internal"
+)
+
+const (
+	PresenceChannelData = "presence"
+	MessageChannelData  = "message"
+)
+
+type StreamMessageMD struct {
+	ClientId string
+	SocketId string
+	// DataType is the type of data it is storing for example "presence" or "message" data
+	DataType string
+	// EventName is the named identifier of this message like in case of presence "enter"/"left", etc
+	EventName string
+}
+
+func NewStreamMessageMD(dataType string, clientId string, socketId string, eventName string) *StreamMessageMD {
+	return &StreamMessageMD{
+		DataType:  dataType,
+		ClientId:  clientId,
+		SocketId:  socketId,
+		EventName: eventName,
+	}
+}
+
+func NewPresenceData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(PresenceChannelData, clientId, socketId, eventName, msg.Data)
+}
+
+func NewMessageData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+}
+
+func newStreamData(dataType string, clientId string, socketId string, eventName string, rawData []byte) (*internal.StreamData, error) {
+	md := NewStreamMessageMD(dataType, clientId, socketId, eventName)
+	enc, err := EncodeStreamMD(md)
+	if err != nil {
+		return nil, err
+	}
+
+	return internal.NewStreamData(enc, rawData), nil
+}

--- a/server/services/v1/realtime/watcher.go
+++ b/server/services/v1/realtime/watcher.go
@@ -1,0 +1,126 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+// Watch is called when an event is received by ChannelWatcher.
+type Watch func(*cache.StreamMessages, error) ([]string, error)
+
+// ChannelWatcher is to watch events for a single channel. It accepts a watch that will be notified when a new event
+// is read from the stream. As ChannelWatcher is mapped to a consumer group on a stream therefore the state is restored
+// from the cache during restart which means a watcher is only created if it doesn’t exist otherwise the existing one
+// is returned.
+type ChannelWatcher struct {
+	ctx           context.Context
+	name          string
+	watch         Watch
+	stream        cache.Stream
+	sigStop       chan struct{}
+	sigDisconnect chan struct{}
+}
+
+func CreateWatcher(ctx context.Context, name string, pos string, existingPos string, stream cache.Stream) (*ChannelWatcher, error) {
+	w := newWatcher(ctx, name, stream)
+	if len(pos) == 0 {
+		// just use the existing id
+		err := w.move(ctx, existingPos)
+		return w, err
+	} else {
+		if pos > existingPos {
+			log.Warn().Msgf("new position '%s' is greater than existing pos '%s' for watch '%s'", pos, existingPos, name)
+		}
+
+		err := w.move(ctx, pos)
+		return w, err
+	}
+}
+
+func CreateAndRegisterWatcher(ctx context.Context, name string, pos string, stream cache.Stream) (*ChannelWatcher, error) {
+	if len(pos) == 0 {
+		pos = cache.ConsumerGroupDefaultCurrentPos
+	}
+
+	if err := stream.CreateConsumerGroup(ctx, name, pos); err != nil {
+		return nil, err
+	}
+
+	return newWatcher(ctx, name, stream), nil
+}
+
+func newWatcher(ctx context.Context, id string, stream cache.Stream) *ChannelWatcher {
+	return &ChannelWatcher{
+		ctx:           ctx,
+		name:          id,
+		stream:        stream,
+		sigStop:       make(chan struct{}),
+		sigDisconnect: make(chan struct{}),
+	}
+}
+
+func (watcher *ChannelWatcher) StartWatching(watch Watch) {
+	watcher.watch = watch
+	go watcher.watchEvents()
+}
+
+func (watcher *ChannelWatcher) move(ctx context.Context, newPos string) error {
+	if len(newPos) == 0 {
+		return nil
+	}
+
+	return watcher.stream.SetID(ctx, watcher.name, newPos)
+}
+
+func (watcher *ChannelWatcher) Stop() {
+	close(watcher.sigStop)
+}
+
+func (watcher *ChannelWatcher) Disconnect() {
+	close(watcher.sigDisconnect)
+}
+
+func (watcher *ChannelWatcher) watchEvents() {
+	for {
+		select {
+		case <-watcher.sigStop:
+			return
+		case <-watcher.sigDisconnect:
+			_ = watcher.stream.RemoveConsumerGroup(watcher.ctx, watcher.name)
+			return
+		default:
+			resp, hasData, err := watcher.stream.ReadGroup(watcher.ctx, watcher.name, cache.ReadGroupPosCurrent)
+			if err != nil {
+				continue
+			}
+
+			if !hasData {
+				continue
+			}
+
+			if ids, err := watcher.watch(resp, nil); err == nil {
+				_ = watcher.ack(watcher.ctx, ids)
+			}
+		}
+	}
+}
+
+func (watcher *ChannelWatcher) ack(ctx context.Context, ids []string) error {
+	return watcher.stream.Ack(ctx, watcher.name, ids...)
+}

--- a/server/services/v1/realtime/watcher_test.go
+++ b/server/services/v1/realtime/watcher_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+func TestWatcher(t *testing.T) {
+	ctx := context.TODO()
+	cacheS := cache.NewCache(config.GetTestCacheConfig())
+
+	t.Run("create_register", func(t *testing.T) {
+		stream, err := cacheS.CreateStream(ctx, "ch_test")
+		require.NoError(t, err)
+		defer func() {
+			_ = stream.Delete(ctx)
+		}()
+
+		groups, err := stream.GetConsumerGroups(ctx)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.Equal(t, cache.DefaultGroup, groups[0].Name)
+		w, err := CreateAndRegisterWatcher(ctx, "device1", "", stream)
+		require.NoError(t, err)
+		require.NotNil(t, w)
+
+		groups, err = stream.GetConsumerGroups(ctx)
+		require.NoError(t, err)
+		require.Len(t, groups, 2)
+		groupsName := make([]string, 2)
+		for i, g := range groups {
+			groupsName[i] = g.Name
+		}
+		sort.Strings(groupsName)
+		require.Equal(t, "device1", groupsName[1])
+		w.Disconnect()
+		w.watchEvents()
+		groups, err = stream.GetConsumerGroups(ctx)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+	})
+}

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -157,6 +157,11 @@ func (c *cache) GetStream(ctx context.Context, streamName string) (Stream, error
 	return NewStream(c, streamName), nil
 }
 
+func (c *cache) DeleteStream(ctx context.Context, streamName string) error {
+	_, err := c.Client.Del(ctx, streamName).Result()
+	return err
+}
+
 // CreateOrGetStream will create a stream in Redis. 'streamName' is full qualified name similar to tableName in other
 // Apis i.e. caller should be responsible for prepending it with tenant/project etc.
 func (c *cache) CreateOrGetStream(ctx context.Context, streamName string) (Stream, error) {

--- a/store/cache/store.go
+++ b/store/cache/store.go
@@ -23,14 +23,6 @@ import (
 	"github.com/tigrisdata/tigris/server/config"
 )
 
-const (
-	// StreamFromCurrentPos is for creating a consumer group that sets the position as current.
-	StreamFromCurrentPos = "$"
-
-	// StreamFromCurrentPosRead is to let stream know that reads needs to happen from current.
-	StreamFromCurrentPosRead = ">"
-)
-
 type Stream interface {
 	Name() string
 	// Add is to add streamData to a stream
@@ -39,7 +31,7 @@ type Stream interface {
 	Read(ctx context.Context, pos string) (*StreamMessages, bool, error)
 	// ReadGroup is similar to Read but with support for reading from a group. We don't have multiple consumers in a
 	// single group. Currently, it creates an internal _tigris_consumer.
-	ReadGroup(ctx context.Context, group string, pos string) (*StreamMessages, bool, error)
+	ReadGroup(ctx context.Context, group string, pos ReadGroupPos) (*StreamMessages, bool, error)
 	// CreateConsumerGroup creates a consumer group and attach it to the stream. The pos is used to specify the position
 	// for this consumer group.
 	CreateConsumerGroup(ctx context.Context, group string, pos string) error
@@ -49,6 +41,8 @@ type Stream interface {
 	GetConsumerGroups(ctx context.Context) ([]xredis.XInfoGroup, error)
 	// GetConsumerGroup returns only information about the consumer group passed in the API.
 	GetConsumerGroup(ctx context.Context, group string) (*xredis.XInfoGroup, bool, error)
+	// SetID is used to set the position of the group again.
+	SetID(ctx context.Context, group string, pos string) error
 	// Ack is to acknowledge messages once they are read by the consumer group. This is required to be called in case
 	// ReadGroup is used so that messages doesn't end up in pending entries list.
 	Ack(ctx context.Context, group string, ids ...string) error
@@ -91,6 +85,8 @@ type Cache interface {
 	GetStream(ctx context.Context, streamName string) (Stream, error)
 	// ListStreams returns the all the streams with the prefix
 	ListStreams(ctx context.Context, streamNamePrefix string) ([]string, error)
+	// DeleteStream to delete a stream if exists
+	DeleteStream(ctx context.Context, streamName string) error
 }
 
 func NewCache(cfg *config.CacheConfig) Cache {

--- a/store/cache/stream_test.go
+++ b/store/cache/stream_test.go
@@ -40,7 +40,7 @@ func TestStream(t *testing.T) {
 		}()
 
 		rawI := []byte("hello")
-		id, err := stream.Add(ctx, internal.NewStreamData(rawI))
+		id, err := stream.Add(ctx, internal.NewStreamData(nil, rawI))
 		require.NotEmpty(t, id)
 		require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestBenchmarkingStreams(t *testing.T) {
 }
 
 func getEvent() *internal.StreamData {
-	return internal.NewStreamData([]byte(fmt.Sprintf(`{"key": %s}`, RandStringRunes(64))))
+	return internal.NewStreamData(nil, []byte(fmt.Sprintf(`{"key": %s}`, RandStringRunes(64))))
 }
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
This diff is implementing core WebSocket protocol to support real-time event passing using Channels i.e. a functionality where Tigris is responsible for broadcasting events to connected devices/clients at low latency. The events will be stored in the in-memory cache during the lifetime of a channel.

The diff has the following things implemented,

- Websocket protocol to handle events 
  - Disconnect
  - Subscribe
  - Message
  - Heartbeat
  - A session manager to manage device sessions
- A real-time server accepting WebSocket requests.
- Logic to manage the lifecycle of a channel, device, and stream.
- Logic to reload channels during restart, and reconnect devices back to the channel if they join in a short window.
