### PR TITLE
Fix error messages

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -84,7 +84,7 @@ func E(err error) bool {
 		return false
 	}
 
-	log.Error().CallerSkipFrame(2).Err(err).Msg("error")
+	log.Error().CallerSkipFrame(2).Msg(err.Error())
 
 	return true
 }
@@ -102,7 +102,7 @@ func E(err error) bool {
 func CE(format string, args ...interface{}) error {
 	err := fmt.Errorf(format, args...)
 
-	log.Error().CallerSkipFrame(2).Err(err).Msg("error")
+	log.Error().CallerSkipFrame(2).Msg(err.Error())
 
 	return err
 }


### PR DESCRIPTION
Move error details from the attached error field to the log message itself.