### PR TITLE
fix: remove specific error values from unknown error sources

### DIFF
--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -120,7 +120,7 @@ func (m *Measurement) GetRequestOkTags() map[string]string {
 }
 
 func (m *Measurement) GetRequestErrorTags(err error) map[string]string {
-	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err, "request")), getRequestErrorTagKeys()), config.DefaultConfig.Metrics.Requests.FilteredTags)
+	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getRequestErrorTagKeys()), config.DefaultConfig.Metrics.Requests.FilteredTags)
 }
 
 func (m *Measurement) GetFdbOkTags() map[string]string {
@@ -128,7 +128,7 @@ func (m *Measurement) GetFdbOkTags() map[string]string {
 }
 
 func (m *Measurement) GetFdbErrorTags(err error) map[string]string {
-	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err, "fdb")), getFdbErrorTagKeys()), config.DefaultConfig.Metrics.Fdb.FilteredTags)
+	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getFdbErrorTagKeys()), config.DefaultConfig.Metrics.Fdb.FilteredTags)
 }
 
 func (m *Measurement) GetSearchOkTags() map[string]string {
@@ -136,7 +136,7 @@ func (m *Measurement) GetSearchOkTags() map[string]string {
 }
 
 func (m *Measurement) GetSearchErrorTags(err error) map[string]string {
-	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err, "search")), getSearchErrorTagKeys()), config.DefaultConfig.Metrics.Search.FilteredTags)
+	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getSearchErrorTagKeys()), config.DefaultConfig.Metrics.Search.FilteredTags)
 }
 
 func (m *Measurement) GetSessionOkTags() map[string]string {
@@ -144,7 +144,7 @@ func (m *Measurement) GetSessionOkTags() map[string]string {
 }
 
 func (m *Measurement) GetSessionErrorTags(err error) map[string]string {
-	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err, "session")), getSessionErrorTagKeys()), config.DefaultConfig.Metrics.Session.FilteredTags)
+	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getSessionErrorTagKeys()), config.DefaultConfig.Metrics.Session.FilteredTags)
 }
 
 func (m *Measurement) GetNamespaceSizeTags() map[string]string {
@@ -168,7 +168,7 @@ func (m *Measurement) GetAuthOkTags() map[string]string {
 }
 
 func (m *Measurement) GetAuthErrorTags(err error) map[string]string {
-	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err, "auth")), getAuthErrorTagKeys()), config.DefaultConfig.Metrics.Auth.FilteredTags)
+	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getAuthErrorTagKeys()), config.DefaultConfig.Metrics.Auth.FilteredTags)
 }
 
 func (m *Measurement) SaveMeasurementToContext(ctx context.Context) (context.Context, error) {
@@ -335,7 +335,7 @@ func (m *Measurement) recordHistogramDuration(scope tally.Scope, tags map[string
 	scope.Tagged(tags).Histogram("histogram", tally.DefaultBuckets).RecordDuration(m.stoppedAt.Sub(m.startedAt))
 }
 
-func (m *Measurement) FinishWithError(ctx context.Context, source string, err error) context.Context {
+func (m *Measurement) FinishWithError(ctx context.Context, err error) context.Context {
 	if !m.started {
 		log.Error().Str("service_name", m.serviceName).Str("resource_name", m.resourceName).Msg("Finish tracing called before starting the trace")
 		return ctx
@@ -350,7 +350,7 @@ func (m *Measurement) FinishWithError(ctx context.Context, source string, err er
 	}
 	errCode := status.Code(err)
 	m.datadogSpan.SetTag("grpc.code", errCode.String())
-	errTags := getTagsForError(err, source)
+	errTags := getTagsForError(err)
 	for k, v := range errTags {
 		m.datadogSpan.SetTag(k, v)
 	}

--- a/server/metrics/tags.go
+++ b/server/metrics/tags.go
@@ -35,7 +35,7 @@ func mergeTags(tagSets ...map[string]string) map[string]string {
 		for k, v := range tagSet {
 			if _, ok := res[k]; !ok {
 				res[k] = v
-			} else if res[k] == "unknown" {
+			} else if res[k] == defaults.UnknownValue {
 				res[k] = v
 			}
 		}
@@ -59,8 +59,7 @@ func getTigrisError(err error) (string, bool) {
 	return "", false
 }
 
-func getTagsForError(err error, source string) map[string]string {
-	// The source parameter is only considered when the source cannot be determined from the error itself
+func getTagsForError(err error) map[string]string {
 	value, isFdbError := getFdbError(err)
 	if isFdbError {
 		return map[string]string{
@@ -76,24 +75,11 @@ func getTagsForError(err error, source string) map[string]string {
 			"error_value":  value,
 		}
 	}
-	// Generic errors
-	if err == nil {
-		// Should only happen in test cases, if this is seen in production non-errors are counted as errors
-		return map[string]string{
-			"error_source": source,
-			"error_value":  "none",
-		}
-	}
 
-	genericErrorValue := err.Error()
-	// Don't capture the full stack trace as a tag for a panic, just the error message
-	if strings.HasPrefix(genericErrorValue, "panic") {
-		genericErrorValue = strings.Split(genericErrorValue, "\n")[0]
-	}
-
+	// Only log specific errors in case it's known that there will be only a few possible error values
 	return map[string]string{
-		"error_source": source,
-		"error_value":  genericErrorValue,
+		"error_source": defaults.UnknownValue,
+		"error_value":  defaults.UnknownValue,
 	}
 }
 

--- a/server/metrics/tags_test.go
+++ b/server/metrics/tags_test.go
@@ -47,17 +47,17 @@ func TestTagsHelpers(t *testing.T) {
 
 	t.Run("Test getTagsForError", func(t *testing.T) {
 		assert.Equal(t, map[string]string{
-			"error_source": "test_source",
-			"error_value":  "none",
-		}, getTagsForError(nil, "test_source"))
+			"error_source": "unknown",
+			"error_value":  "unknown",
+		}, getTagsForError(nil))
 
 		// For specific errors, the source is ignored
-		fdbErrTags := getTagsForError(fdb.Error{Code: 1}, "ignored_source")
+		fdbErrTags := getTagsForError(fdb.Error{Code: 1})
 		assert.Equal(t, "fdb", fdbErrTags["error_source"])
 		assert.Equal(t, "1", fdbErrTags["error_value"])
 
 		// For specific errors, the source is ignored
-		tigrisErrTags := getTagsForError(&api.TigrisError{Code: api.Code_NOT_FOUND}, "ignored_source")
+		tigrisErrTags := getTagsForError(&api.TigrisError{Code: api.Code_NOT_FOUND})
 		assert.Equal(t, "tigris_server", tigrisErrTags["error_source"])
 		assert.Equal(t, "NOT_FOUND", tigrisErrTags["error_value"])
 	})

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -111,7 +111,7 @@ func measuredAuthFunction(ctx context.Context, jwtValidator *validator.Validator
 	ctxResult, err = authFunction(ctx, jwtValidator, config, cache)
 	if err != nil {
 		measurement.CountErrorForScope(metrics.AuthErrorCount, measurement.GetAuthErrorTags(err))
-		measurement.FinishWithError(ctxResult, "auth", err)
+		measurement.FinishWithError(ctxResult, err)
 		measurement.RecordDuration(metrics.AuthErrorRespTime, measurement.GetAuthErrorTags(err))
 		return
 	}

--- a/server/middleware/measure.go
+++ b/server/middleware/measure.go
@@ -72,7 +72,7 @@ func measureUnary() func(ctx context.Context, req interface{}, info *grpc.UnaryS
 		if err != nil {
 			// Request had an error
 			measurement.CountErrorForScope(metrics.RequestsErrorCount, measurement.GetRequestErrorTags(err))
-			_ = measurement.FinishWithError(ctx, "request", err)
+			_ = measurement.FinishWithError(ctx, err)
 			measurement.RecordDuration(metrics.RequestsErrorRespTime, measurement.GetRequestErrorTags(err))
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func measureStream() grpc.StreamServerInterceptor {
 		err = handler(srv, wrapped)
 		if err != nil {
 			measurement.CountErrorForScope(metrics.RequestsErrorCount, measurement.GetRequestErrorTags(err))
-			_ = measurement.FinishWithError(wrapped.WrappedContext, "request", err)
+			_ = measurement.FinishWithError(wrapped.WrappedContext, err)
 			measurement.RecordDuration(metrics.RequestsErrorRespTime, measurement.GetRequestErrorTags(err))
 			ulog.E(err)
 			return err

--- a/server/services/v1/database/sessions.go
+++ b/server/services/v1/database/sessions.go
@@ -66,7 +66,7 @@ func (m *SessionManagerWithMetrics) measure(ctx context.Context, name string, f 
 	ctx = measurement.StartTracing(ctx, true)
 	if err := f(ctx); err != nil {
 		measurement.CountErrorForScope(metrics.SessionErrorCount, measurement.GetSessionErrorTags(err))
-		_ = measurement.FinishWithError(ctx, "session", err)
+		_ = measurement.FinishWithError(ctx, err)
 		measurement.RecordDuration(metrics.SessionErrorRespTime, measurement.GetSessionErrorTags(err))
 		return
 	}

--- a/store/kv/kv.go
+++ b/store/kv/kv.go
@@ -109,7 +109,7 @@ func measureLow(ctx context.Context, name string, f func() error) {
 	}
 	// Request had an error
 	measurement.CountErrorForScope(metrics.FdbOkCount, measurement.GetFdbErrorTags(err))
-	_ = measurement.FinishWithError(ctx, "fdb", err)
+	_ = measurement.FinishWithError(ctx, err)
 	measurement.RecordDuration(metrics.FdbErrorRespTime, measurement.GetFdbErrorTags(err))
 }
 

--- a/store/search/ts.go
+++ b/store/search/ts.go
@@ -54,7 +54,7 @@ func (m *storeImplWithMetrics) measure(ctx context.Context, name string, f func(
 	}
 	// Request had error
 	measurement.CountErrorForScope(metrics.SearchErrorCount, measurement.GetSearchErrorTags(err))
-	_ = measurement.FinishWithError(ctx, "search", err)
+	_ = measurement.FinishWithError(ctx, err)
 	measurement.RecordDuration(metrics.SearchErrorRespTime, measurement.GetSearchErrorTags(err))
 }
 


### PR DESCRIPTION
Return unknown error_source and error_value tags for errors that have an unknown source, instead of trying to figure them out from the error itself.