### PR TITLE
fix: local image failing to start sporadically

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -43,16 +43,7 @@ COPY --from=build /usr/lib/libfdb_c.so /usr/lib/libfdb_c.so
 COPY --from=build /usr/bin/fdbcli /usr/bin/fdbcli
 
 RUN chown -R tigris:tigris /server /etc/tigrisdata/tigris
-
-#RUN echo "docker:docker@127.0.0.1:4500" >/etc/foundationdb/fdb.cluster
-RUN echo "#!/bin/bash\n \
-	/usr/bin/typesense-server --config=/etc/typesense/typesense-server.ini & \n \
-	fdbserver --listen-address 127.0.0.1:4500 --public-address 127.0.0.1:4500 --datadir /var/lib/foundationdb/data --logdir /var/lib/foundationdb/logs --locality-zoneid tigris --locality-machineid tigris & \n\
-	export TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_dev_key \n \
-	export TIGRIS_SERVER_SEARCH_HOST=localhost \n \
-	export TIGRIS_SERVER_CDC_ENABLED=true \n \
-	fdbcli --exec 'configure new single memory' \n \
-	/server/service\n" >/server/service.sh
+COPY docker/service-local.sh /server/service.sh
 
 EXPOSE 8081
 

--- a/docker/service-local.sh
+++ b/docker/service-local.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+function start_typesense() {
+	/usr/bin/typesense-server --config=/etc/typesense/typesense-server.ini &
+}
+
+function wait_for_typesense() {
+	echo "Waiting for typesense to start"
+	IS_LEADER=1
+  while [ ${IS_LEADER} -ne 0 ]
+  do
+		curl -H "X-TYPESENSE-API-KEY: ${TIGRIS_SERVER_SEARCH_AUTH_KEY}" localhost:8108/status | grep LEADER
+		IS_LEADER=$?
+		sleep 2
+	done
+
+}
+
+function start_fdb() {
+	fdbserver --listen-address 127.0.0.1:4500 --public-address 127.0.0.1:4500 --datadir /var/lib/foundationdb/data --logdir /var/lib/foundationdb/logs --locality-zoneid tigris --locality-machineid tigris &
+	fdbcli --exec 'configure new single memory'
+}
+
+function wait_for_fdb() {
+	echo "Waiting for foundationdb to start"
+	OUTPUT="something_else"
+	while [ "x${OUTPUT}" != "xThe database is available." ]
+	do
+		OUTPUT=$(fdbcli --exec 'status minimal')
+		sleep 2
+	done
+}
+
+export TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_dev_key
+export TIGRIS_SERVER_SEARCH_HOST=localhost
+export TIGRIS_SERVER_CDC_ENABLED=true
+start_fdb
+wait_for_fdb
+start_typesense
+wait_for_typesense
+/server/service


### PR DESCRIPTION
The tigris-local image is failing to start sporadically. The reason for that is tigris starts in the container before typesense is ready, and it can't connect to it. 

With this change, we will wait for foundationdb and typesense to be ready before starting the tigris server.