### PR TITLE
feat: Realtime HTTP APIs

### DIFF
--- a/docker/service-local.sh
+++ b/docker/service-local.sh
@@ -31,6 +31,7 @@ function wait_for_fdb() {
 	done
 }
 
+export TIGRIS_SERVER_TYPE=database
 export TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_dev_key
 export TIGRIS_SERVER_SEARCH_HOST=localhost
 export TIGRIS_SERVER_CDC_ENABLED=true

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -20,10 +20,17 @@ import (
 	"github.com/tigrisdata/tigris/util/log"
 )
 
+const (
+	DatabaseServerType = "database"
+	RealtimeServerType = "realtime"
+)
+
 type ServerConfig struct {
-	Host        string
-	Port        int16
-	FDBHardDrop bool `mapstructure:"fdb_hard_drop" yaml:"fdb_hard_drop" json:"fdb_hard_drop"`
+	Host         string
+	Port         int16
+	Type         string `mapstructure:"type" yaml:"type" json:"type"`
+	FDBHardDrop  bool   `mapstructure:"fdb_hard_drop" yaml:"fdb_hard_drop" json:"fdb_hard_drop"`
+	RealtimePort int16  `mapstructure:"realtime_port" yaml:"realtime_port" json:"realtime_port"`
 }
 
 type Config struct {
@@ -190,9 +197,11 @@ var DefaultConfig = Config{
 		SampleRate: 0.01,
 	},
 	Server: ServerConfig{
-		Host:        "0.0.0.0",
-		Port:        8081,
-		FDBHardDrop: false,
+		Type:         DatabaseServerType,
+		Host:         "0.0.0.0",
+		Port:         8081,
+		RealtimePort: 8083,
+		FDBHardDrop:  false,
 	},
 	Auth: AuthConfig{
 		Enabled:          false,

--- a/server/muxer/http.go
+++ b/server/muxer/http.go
@@ -36,22 +36,30 @@ type HTTPServer struct {
 }
 
 func NewHTTPServer(cfg *config.Config) *HTTPServer {
-	r := chi.NewRouter()
+	server := &HTTPServer{
+		Inproc: &inprocgrpc.Channel{},
+		Router: chi.NewRouter(),
+	}
 
-	r.Use(cors.AllowAll().Handler)
-	r.Mount("/debug", chi_middleware.Profiler())
+	server.SetupMiddlewares(cfg)
 
+	// mount debug handler after adding all middlewares
+	server.Router.Mount("/admin/debug", chi_middleware.Profiler())
+
+	return server
+}
+
+func (s *HTTPServer) SetupMiddlewares(cfg *config.Config) {
 	unary, stream := middleware.Get(cfg)
 
-	inproc := &inprocgrpc.Channel{}
-	inproc.WithServerStreamInterceptor(stream)
-	inproc.WithServerUnaryInterceptor(unary)
+	s.Inproc.WithServerStreamInterceptor(stream)
+	s.Inproc.WithServerUnaryInterceptor(unary)
 
-	return &HTTPServer{Inproc: inproc, Router: r}
+	s.Router.Use(cors.AllowAll().Handler)
 }
 
 func (s *HTTPServer) Start(mux cmux.CMux) error {
-	match := mux.Match(cmux.HTTP1Fast())
+	match := mux.Match(cmux.HTTP1Fast(), cmux.HTTP1HeaderField("Upgrade", "websocket"))
 	go func() {
 		srv := &http.Server{Handler: s.Router, ReadHeaderTimeout: readHeaderTimeout}
 		err := srv.Serve(match)

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -41,8 +41,13 @@ func NewMuxer(cfg *config.Config) *Muxer {
 	return &Muxer{servers: []Server{NewHTTPServer(cfg), NewGRPCServer(cfg)}}
 }
 
-func (m *Muxer) RegisterServices(kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) {
-	services := v1.GetRegisteredServices(kvStore, searchStore, tenantMgr, txMgr)
+func (m *Muxer) RegisterServices(cfg *config.ServerConfig, kvStore kv.KeyValueStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) {
+	var services []v1.Service
+	if cfg.Type == config.RealtimeServerType {
+		services = v1.GetRegisteredServicesRealtime(kvStore, searchStore, tenantMgr, txMgr)
+	} else {
+		services = v1.GetRegisteredServices(kvStore, searchStore, tenantMgr, txMgr)
+	}
 	for _, r := range services {
 		for _, v := range m.servers {
 			if s, ok := v.(*GRPCServer); ok {

--- a/server/services/v1/realtime/runner.go
+++ b/server/services/v1/realtime/runner.go
@@ -1,0 +1,281 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/cache"
+)
+
+// RTMRunner is used to run the realtime HTTP APIs related to channel like accessing a channel, subscribing to a channel, etc.
+type RTMRunner interface {
+	Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error)
+}
+
+type RTMRunnerFactory struct {
+	cache   cache.Cache
+	factory *ChannelFactory
+}
+
+// NewRTMRunnerFactory returns RTMRunnerFactory object.
+func NewRTMRunnerFactory(cache cache.Cache, factory *ChannelFactory) *RTMRunnerFactory {
+	return &RTMRunnerFactory{
+		cache:   cache,
+		factory: factory,
+	}
+}
+
+func (f *RTMRunnerFactory) GetMessagesRunner(r *api.MessagesRequest) *MessagesRunner {
+	return &MessagesRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+		req:        r,
+	}
+}
+
+func (f *RTMRunnerFactory) GetReadMessagesRunner(r *api.ReadMessagesRequest, streaming Streaming) *ReadMessagesRunner {
+	return &ReadMessagesRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+		req:        r,
+		streaming:  streaming,
+	}
+}
+
+func (f *RTMRunnerFactory) GetChannelRunner() *ChannelRunner {
+	return &ChannelRunner{
+		baseRunner: newBaseRunner(f.cache, f.factory),
+	}
+}
+
+type baseRunner struct {
+	cache   cache.Cache
+	factory *ChannelFactory
+}
+
+func newBaseRunner(cache cache.Cache, factory *ChannelFactory) *baseRunner {
+	return &baseRunner{
+		cache:   cache,
+		factory: factory,
+	}
+}
+
+func (runner *baseRunner) getProject(ctx context.Context, tenant *metadata.Tenant, project string) (*metadata.Database, error) {
+	proj, err := tenant.GetDatabase(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		return nil, errors.NotFound("project doesn't exist '%s'", project)
+	}
+	return proj, err
+}
+
+// MessagesRunner is to publish messages to a channel.
+type MessagesRunner struct {
+	*baseRunner
+
+	req *api.MessagesRequest
+}
+
+func (runner *MessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	if err != nil {
+		return nil, err
+	}
+
+	channel, err := runner.factory.GetOrCreateChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.req.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, len(runner.req.Messages))
+	for i, m := range runner.req.Messages {
+		streamData, err := NewEventDataFromMessage("", "", m.Name, m)
+		if err != nil {
+			return nil, err
+		}
+
+		id, err := channel.PublishMessage(ctx, streamData)
+		if err != nil {
+			return nil, err
+		}
+
+		ids[i] = id
+	}
+
+	return &Response{
+		Response: &api.MessagesResponse{
+			Ids: ids,
+		},
+	}, nil
+}
+
+type ReadMessagesRunner struct {
+	*baseRunner
+
+	req       *api.ReadMessagesRequest
+	streaming Streaming
+}
+
+func (runner *ReadMessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	if err != nil {
+		return nil, err
+	}
+
+	channel, err := runner.factory.GetChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.req.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	pos := runner.req.GetStart()
+	if len(pos) == 0 {
+		pos = "$"
+	}
+
+	count := int64(0)
+	for {
+		resp, exists, err := channel.Read(ctx, pos)
+		if !exists {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		var id string
+		for _, m := range resp.Messages {
+			data, err := resp.Decode(m)
+			if err != nil {
+				return nil, err
+			}
+
+			md, err := DecodeStreamMD(data.Md)
+			if err != nil {
+				return nil, err
+			}
+			_ = runner.streaming.Send(&api.ReadMessagesResponse{
+				Message: &api.Message{
+					Id:   &m.ID,
+					Name: md.EventName,
+					Data: data.RawData,
+				},
+			})
+			count++
+			if runner.req.GetLimit() > 0 && count == runner.req.GetLimit() {
+				return nil, nil
+			}
+
+			id = m.ID
+		}
+
+		if len(id) > 0 {
+			split := strings.Split(id, "-")
+			incrId, _ := strconv.ParseInt(strings.Split(id, "-")[1], 10, 64)
+			pos = fmt.Sprintf("%s-%d", split[0], incrId+1)
+		}
+	}
+}
+
+type ChannelRunner struct {
+	*baseRunner
+
+	channelReq        *api.GetRTChannelRequest
+	channelsReq       *api.GetRTChannelsRequest
+	listSubscriptions *api.ListSubscriptionRequest
+}
+
+func (runner *ChannelRunner) SetChannelReq(req *api.GetRTChannelRequest) {
+	runner.channelReq = req
+}
+
+func (runner *ChannelRunner) SetChannelsReq(req *api.GetRTChannelsRequest) {
+	runner.channelsReq = req
+}
+
+func (runner *ChannelRunner) SetListSubscriptionsReq(req *api.ListSubscriptionRequest) {
+	runner.listSubscriptions = req
+}
+
+func (runner *ChannelRunner) Run(ctx context.Context, tenant *metadata.Tenant) (*Response, error) {
+	switch {
+	case runner.listSubscriptions != nil:
+		project, err := runner.getProject(ctx, tenant, runner.listSubscriptions.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channel, err := runner.factory.GetChannel(ctx, tenant.GetNamespace().Id(), project.Id(), runner.listSubscriptions.Channel)
+		if err != nil {
+			return nil, err
+		}
+
+		watchers := channel.ListWatchers()
+		return &Response{
+			Response: &api.ListSubscriptionResponse{
+				Devices: watchers,
+			},
+		}, nil
+	case runner.channelsReq != nil:
+		project, err := runner.getProject(ctx, tenant, runner.channelsReq.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channels, err := runner.factory.ListChannels(ctx, tenant.GetNamespace().Id(), project.Id(), "*")
+		if err != nil {
+			return nil, err
+		}
+
+		var channelsResp []*api.ChannelMetadata
+		for _, c := range channels {
+			channelsResp = append(channelsResp, &api.ChannelMetadata{
+				Channel: c,
+			})
+		}
+
+		return &Response{
+			Response: &api.GetRTChannelsResponse{
+				Channels: channelsResp,
+			},
+		}, nil
+	default:
+		project, err := runner.getProject(ctx, tenant, runner.channelReq.Project)
+		if err != nil {
+			return nil, err
+		}
+
+		channels, err := runner.factory.ListChannels(ctx, tenant.GetNamespace().Id(), project.Id(), runner.channelReq.Channel)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(channels) == 0 {
+			return nil, errors.NotFound("channel '%s' not present ", runner.channelReq.Channel)
+		}
+
+		return &Response{
+			Response: &api.GetRTChannelResponse{
+				Channel: channels[0],
+			},
+		}, nil
+	}
+}

--- a/server/services/v1/realtime/types.go
+++ b/server/services/v1/realtime/types.go
@@ -50,6 +50,10 @@ func NewMessageData(clientId string, socketId string, eventName string, msg *api
 	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
 }
 
+func NewEventDataFromMessage(clientId string, socketId string, eventName string, msg *api.Message) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+}
+
 func newStreamData(dataType string, clientId string, socketId string, eventName string, rawData []byte) (*internal.StreamData, error) {
 	md := NewStreamMessageMD(dataType, clientId, socketId, eventName)
 	enc, err := EncodeStreamMD(md)

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     image: tigris_server
     environment:
       - TIGRIS_ENVIRONMENT=test
+      - TIGRIS_SERVER_SERVER_TYPE=database
       - TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_test_key
       - TIGRIS_SERVER_SEARCH_HOST=tigris_search
       - TIGRIS_SERVER_LOG_FORMAT=console
@@ -81,6 +82,7 @@ services:
     image: tigris_server
     environment:
       - TIGRIS_ENVIRONMENT=test
+      - TIGRIS_SERVER_SERVER_TYPE=database
       - TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_test_key
       - TIGRIS_SERVER_SEARCH_HOST=tigris_search
       - TIGRIS_SERVER_LOG_FORMAT=console
@@ -99,6 +101,27 @@ services:
     depends_on:
       - tigris_server
       - tigris_db2
+
+  tigris_realtime:
+    container_name: tigris_realtime
+    image: tigris_server
+    environment:
+      - TIGRIS_SERVER_SERVER_TYPE=realtime
+      - TIGRIS_ENVIRONMENT=test
+      - TIGRIS_SERVER_LOG_FORMAT=console
+    build:
+      context: ../../
+      dockerfile: docker/Dockerfile
+    volumes:
+      - type: volume
+        source: dbdata
+        target: /etc/foundationdb/
+    ports:
+      - "8083:8083"
+    command: >
+      bash -c '/server/service'
+    depends_on:
+      - tigris_server
 
   tigris_test:
     container_name: tigris_test
@@ -124,6 +147,7 @@ services:
         target: /root/.cache/go-build
     depends_on:
       - tigris_server2
+      - tigris_realtime
 
   tigris_victoriametrics:
     container_name: tigris_victoriametrics


### PR DESCRIPTION
Staging on top of this PR: https://github.com/tigrisdata/tigris/pull/692

This diff implements HTTP APIs for real-time functionality. The HTTP APIs that we would be supporting will be

- GetRTChannel: To get information about the real-time channel
- GetRTChannels: To get information about all the real-time channels
- ReadMessages: To read messages from a position, the default would be read from now().
- Messages: To publish messages to a channel
- ListSubscriptions: A subscription list includes devices that are attached to the channel.

The real-time will be running on its own container using the same binary as the server but the server type will be realtime.