### PR TITLE
feat: Adding a few realtime HTTP Middlewares

### DIFF
--- a/api/server/v1/realtime.go
+++ b/api/server/v1/realtime.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+func (x *RealTimeMessage) MarshalJSON() ([]byte, error) {
+	resp := struct {
+		Event     jsoniter.RawMessage `json:"event,omitempty"`
+		EventType EventType           `json:"event_type,omitempty"`
+	}{
+		Event:     x.Event,
+		EventType: x.EventType,
+	}
+	return jsoniter.Marshal(resp)
+}
+
+func (x *AuthEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		if key == "accessToken" {
+			x.AccessToken = value
+		}
+	}
+
+	return nil
+}
+
+func (x *UnsubscribeEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		if key == "channel" {
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		}
+	}
+
+	return nil
+}
+
+func (x *SubscribeEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "channel":
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		case "position":
+			var position string
+			if err := jsoniter.Unmarshal(value, &position); err != nil {
+				return err
+			}
+			x.Position = position
+		}
+	}
+
+	return nil
+}
+
+func (x *MessageEvent) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "id":
+			var id string
+			if err := jsoniter.Unmarshal(value, &id); err != nil {
+				return err
+			}
+			x.Id = id
+		case "channel":
+			var channel string
+			if err := jsoniter.Unmarshal(value, &channel); err != nil {
+				return err
+			}
+			x.Channel = channel
+		case "name":
+			var name string
+			if err := jsoniter.Unmarshal(value, &name); err != nil {
+				return err
+			}
+			x.Name = name
+		case "data":
+			x.Data = value
+		}
+	}
+
+	return nil
+}
+
+func (x *RealTimeMessage) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+	for key, value := range mp {
+		switch key {
+		case "event_type":
+			var eventType EventType
+			if err := jsoniter.Unmarshal(value, &eventType); err != nil {
+				return err
+			}
+			x.EventType = eventType
+		case "event":
+			x.Event = value
+		}
+	}
+
+	return nil
+}
+
+func (x *Message) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+
+	for key, value := range mp {
+		var v interface{}
+
+		switch key {
+		case "id":
+			v = &x.Id
+		case "name":
+			v = &x.Name
+		case "data":
+			// to avoid decoding data
+			x.Data = value
+			continue
+		default:
+			continue
+		}
+		if err := jsoniter.Unmarshal(value, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/server/middleware/http.go
+++ b/server/middleware/http.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/request"
+)
+
+func HTTPAuthMiddleware(config *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			if authFunc := getAuthFunction(config); authFunc != nil {
+				ctx, err := authFunc(r.Context())
+				if err != nil {
+					switch e := err.(type) {
+					case *api.TigrisError:
+						http.Error(w, e.Message, api.ToHTTPCode(e.Code))
+					default:
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+					return
+				}
+
+				r = r.WithContext(ctx)
+			}
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}
+
+func HTTPMetadataExtractorMiddleware(_ *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			reqMetadata := request.NewRequestMetadata(r.Context())
+			r = r.WithContext(reqMetadata.SaveToContext(r.Context()))
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/server/muxer/http.go
+++ b/server/muxer/http.go
@@ -56,6 +56,10 @@ func (s *HTTPServer) SetupMiddlewares(cfg *config.Config) {
 	s.Inproc.WithServerUnaryInterceptor(unary)
 
 	s.Router.Use(cors.AllowAll().Handler)
+	if cfg.Server.Type == config.RealtimeServerType {
+		s.Router.Use(middleware.HTTPMetadataExtractorMiddleware(cfg))
+		s.Router.Use(middleware.HTTPAuthMiddleware(cfg))
+	}
 }
 
 func (s *HTTPServer) Start(mux cmux.CMux) error {

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -65,6 +65,13 @@ func Init(tg metadata.TenantGetter) {
 	tenantGetter = tg
 }
 
+func NewRequestMetadata(ctx context.Context) Metadata {
+	ns, utype, sub := GetMetadataFromHeader(ctx)
+	md := Metadata{IsHuman: utype, Sub: sub}
+	md.SetNamespace(ctx, ns)
+	return md
+}
+
 func NewRequestEndpointMetadata(ctx context.Context, serviceName string, methodInfo grpc.MethodInfo, db string, coll string) Metadata {
 	ns, utype, sub := GetMetadataFromHeader(ctx)
 	md := Metadata{serviceName: serviceName, methodInfo: methodInfo, IsHuman: utype, Sub: sub}


### PR DESCRIPTION
For real-time, we need HTTP Middleware. This diff is adding two:
- Auth: which is the same as the database but making it generic so that can be used for real-time as well
- Metadata: Request metadata that needed to be set in the context