### PR TITLE
fix: typesense failed to start in single image container sporadically

### DIFF
--- a/docker/service-local.sh
+++ b/docker/service-local.sh
@@ -7,13 +7,31 @@ function start_typesense() {
 function wait_for_typesense() {
 	echo "Waiting for typesense to start"
 	IS_LEADER=1
+	echo "Waiting for typesense to become leader"
   while [ ${IS_LEADER} -ne 0 ]
   do
 		curl -H "X-TYPESENSE-API-KEY: ${TIGRIS_SERVER_SEARCH_AUTH_KEY}" localhost:8108/status | grep LEADER
 		IS_LEADER=$?
+		if [ ${IS_LEADER} -ne 0 ]
+		then
+			echo "Typesense is not leader yet, waiting"
+		fi
 		sleep 2
 	done
 
+	echo "Waiting for typesense to respond to list collections"
+	LIST_COLLECTIONS_RESP=1
+	while [ ${LIST_COLLECTIONS_RESP} -ne 0 ]
+	do
+		# Try to do list collections and see the response code, this can take time
+		curl -H "X-TYPESENSE-API-KEY: ${TIGRIS_SERVER_SEARCH_AUTH_KEY}" -I -X GETlocalhost:8108/collections | grep "200 OK"
+		LIST_COLLECTIONS_RESP=$?
+		if [ ${LIST_COLLECTIONS_RESP} -ne 0 ]
+		then
+			echo "Typesense could not list collections yet, waiting"
+		fi
+		sleep 2
+	done
 }
 
 function start_fdb() {


### PR DESCRIPTION
On ferretdb's CI typesense fails to start sporadically. The reason is it receives a request before it's ready to serve requests. This means that tigris server will fail to initialize.