### PR TITLE
fix: Handling of conversion of str to int in case of wrong type

### DIFF
--- a/server/services/v1/database/mutator.go
+++ b/server/services/v1/database/mutator.go
@@ -228,6 +228,7 @@ func (p *baseMutator) traverse(parentMap map[string]any, value any, keys []strin
 			p.mutated = true
 			return nil
 		}
+		return nil
 	}
 
 	switch converted := value.(type) {


### PR DESCRIPTION
Missing a return when the field is an integer and the actual type is not a string. 