### PR TITLE
chore: remove tigris_cache depends_on

### DIFF
--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -100,7 +100,6 @@ services:
     depends_on:
       - tigris_server
       - tigris_db2
-      - tigris_cache
 
   tigris_realtime:
     container_name: tigris_realtime


### PR DESCRIPTION
## Describe your changes

I incorrectly added a dependency on the `tigris_cache` for the `tigris_server2`. This isn't needed
since the `tigris_server`  has `tigris_cache` as a `depends_on`

## How best to test these changes
`make run` should load up `tigris_cache`

## Issue ticket number and link
clean up from #697 
