### PR TITLE
fix: encoding information in stream data

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -20,8 +20,9 @@ import (
 )
 
 // NewStreamData returns a stream data for anything that we need to store in streams.
-func NewStreamData(md []byte, data []byte) *StreamData {
+func NewStreamData(enc UserDataEncType, md []byte, data []byte) *StreamData {
 	return &StreamData{
+		Encoding:  int32(enc),
 		Md:        md,
 		RawData:   data,
 		CreatedAt: NewTimestamp(),

--- a/internal/data.go
+++ b/internal/data.go
@@ -44,8 +44,11 @@ const (
 	StreamDataType
 )
 
+type UserDataEncType int8
+
 const (
-	JsonEncoding = iota + 1
+	MsgpackEncoding UserDataEncType = 1
+	JsonEncoding    UserDataEncType = 2
 )
 
 // CreateNewTimestamp is a method used to construct timestamp from unixNano. In search backend we store internal

--- a/internal/data.proto
+++ b/internal/data.proto
@@ -43,7 +43,7 @@ message StreamData {
   string id = 1;
   // ver is the version for the raw bytes, this may be the version of the event
   int32 ver = 2;
-  // encoding represents encoding of the event field.
+  // encoding represents encoding of the raw_data field.
   int32 encoding = 3;
   Timestamp created_at = 4;
   // md is the is the metadata of this stream data.

--- a/server/cdc/listener.go
+++ b/server/cdc/listener.go
@@ -46,7 +46,7 @@ func (p *Publisher) OnCommit(ctx context.Context, tx transaction.Tx, listener kv
 		return err
 	}
 
-	td := internal.NewTableDataWithEncoding(json, internal.JsonEncoding)
+	td := internal.NewTableDataWithEncoding(json, int32(internal.JsonEncoding))
 	enc, err := internal.Encode(td)
 	if err != nil {
 		return err

--- a/server/services/v1/realtime/channel_test.go
+++ b/server/services/v1/realtime/channel_test.go
@@ -42,11 +42,11 @@ func TestChannel(t *testing.T) {
 		defer channel.Close(ctx)
 
 		first := []byte(`{"a": 1}`)
-		id1, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, first))
+		id1, err := channel.PublishMessage(ctx, internal.NewStreamData(internal.MsgpackEncoding, nil, first))
 		require.NoError(t, err)
 
 		second := []byte(`{"b": 2}`)
-		id2, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, second))
+		id2, err := channel.PublishMessage(ctx, internal.NewStreamData(internal.MsgpackEncoding, nil, second))
 		require.NoError(t, err)
 
 		streamMessages, hasData, err := channel.Read(ctx, "0")
@@ -93,7 +93,7 @@ func TestChannel(t *testing.T) {
 
 		var expectedIds []string
 		for i := 0; i < totalEvents; i++ {
-			id, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, dummyWatch.expEvents[i]))
+			id, err := channel.PublishMessage(ctx, internal.NewStreamData(internal.MsgpackEncoding, nil, dummyWatch.expEvents[i]))
 			require.NoError(t, err)
 			expectedIds = append(expectedIds, id)
 		}
@@ -160,7 +160,7 @@ func TestChannel(t *testing.T) {
 		}
 
 		for i := 0; i < totalEvents; i++ {
-			id, err := channel.PublishMessage(ctx, internal.NewStreamData(nil, publishedEvents[i]))
+			id, err := channel.PublishMessage(ctx, internal.NewStreamData(internal.MsgpackEncoding, nil, publishedEvents[i]))
 			require.NoError(t, err)
 			v := idsAtomic.Load().([]string)
 			v[i] = id

--- a/server/services/v1/realtime/device_session.go
+++ b/server/services/v1/realtime/device_session.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog/log"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/lib/uuid"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/request"
@@ -36,7 +37,7 @@ type Session struct {
 	clientId     string
 	socketId     string
 	closed       bool
-	encType      WSEncodingType
+	encType      internal.UserDataEncType
 	conn         *websocket.Conn
 	lastReceived time.Time
 	chFactory    *ChannelFactory
@@ -260,7 +261,7 @@ func (session *Session) handleMessage(ctx context.Context, req *api.RealTimeMess
 			return errors.InternalWS(err.Error())
 		}
 
-		streamData, err := NewMessageData(session.clientId, session.socketId, event.Name, event)
+		streamData, err := NewMessageData(session.encType, session.clientId, session.socketId, event.Name, event)
 		if err != nil {
 			return errors.InternalWS(err.Error())
 		}
@@ -279,7 +280,7 @@ func (session *Session) handleMessage(ctx context.Context, req *api.RealTimeMess
 			return errors.InternalWS(err.Error())
 		}
 
-		streamData, err := NewPresenceData(session.clientId, session.socketId, event.Name, event)
+		streamData, err := NewPresenceData(session.encType, session.clientId, session.socketId, event.Name, event)
 		if err != nil {
 			return errors.InternalWS(err.Error())
 		}
@@ -292,7 +293,7 @@ func (session *Session) handleMessage(ctx context.Context, req *api.RealTimeMess
 	return nil
 }
 
-func SendReply(conn *websocket.Conn, encType WSEncodingType, eventType api.EventType, event proto.Message) {
+func SendReply(conn *websocket.Conn, encType internal.UserDataEncType, eventType api.EventType, event proto.Message) {
 	encEvent, err := EncodeEvent(encType, eventType, event)
 	if err != nil {
 		panic(err)
@@ -310,7 +311,7 @@ func SendReply(conn *websocket.Conn, encType WSEncodingType, eventType api.Event
 
 	msgType := websocket.BinaryMessage
 
-	if encType == JsonEncoding {
+	if encType == internal.JsonEncoding {
 		msgType = websocket.TextMessage
 	}
 

--- a/server/services/v1/realtime/request.go
+++ b/server/services/v1/realtime/request.go
@@ -14,12 +14,7 @@
 
 package realtime
 
-type WSEncodingType int8
-
-const (
-	MsgpackEncoding WSEncodingType = 1
-	JsonEncoding    WSEncodingType = 2
-)
+import "github.com/tigrisdata/tigris/internal"
 
 const (
 	msgPackEncodingStr = "msgpack"
@@ -34,11 +29,11 @@ type ConnectionParams struct {
 	Encoding    string
 }
 
-func (params ConnectionParams) ToEncodingType() WSEncodingType {
+func (params ConnectionParams) ToEncodingType() internal.UserDataEncType {
 	if params.Encoding == jsonEncodingStr {
-		return JsonEncoding
+		return internal.JsonEncoding
 	}
 
 	// default is msgpack
-	return MsgpackEncoding
+	return internal.MsgpackEncoding
 }

--- a/server/services/v1/realtime/types.go
+++ b/server/services/v1/realtime/types.go
@@ -42,24 +42,24 @@ func NewStreamMessageMD(dataType string, clientId string, socketId string, event
 	}
 }
 
-func NewPresenceData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
-	return newStreamData(PresenceChannelData, clientId, socketId, eventName, msg.Data)
+func NewPresenceData(encType internal.UserDataEncType, clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(PresenceChannelData, encType, clientId, socketId, eventName, msg.Data)
 }
 
-func NewMessageData(clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
-	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+func NewMessageData(encType internal.UserDataEncType, clientId string, socketId string, eventName string, msg *api.MessageEvent) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, encType, clientId, socketId, eventName, msg.Data)
 }
 
-func NewEventDataFromMessage(clientId string, socketId string, eventName string, msg *api.Message) (*internal.StreamData, error) {
-	return newStreamData(MessageChannelData, clientId, socketId, eventName, msg.Data)
+func NewEventDataFromMessage(encType internal.UserDataEncType, clientId string, socketId string, eventName string, msg *api.Message) (*internal.StreamData, error) {
+	return newStreamData(MessageChannelData, encType, clientId, socketId, eventName, msg.Data)
 }
 
-func newStreamData(dataType string, clientId string, socketId string, eventName string, rawData []byte) (*internal.StreamData, error) {
+func newStreamData(dataType string, encType internal.UserDataEncType, clientId string, socketId string, eventName string, rawData []byte) (*internal.StreamData, error) {
 	md := NewStreamMessageMD(dataType, clientId, socketId, eventName)
-	enc, err := EncodeStreamMD(md)
+	encMD, err := EncodeStreamMD(md)
 	if err != nil {
 		return nil, err
 	}
 
-	return internal.NewStreamData(enc, rawData), nil
+	return internal.NewStreamData(encType, encMD, rawData), nil
 }

--- a/store/cache/stream_test.go
+++ b/store/cache/stream_test.go
@@ -40,7 +40,7 @@ func TestStream(t *testing.T) {
 		}()
 
 		rawI := []byte("hello")
-		id, err := stream.Add(ctx, internal.NewStreamData(nil, rawI))
+		id, err := stream.Add(ctx, internal.NewStreamData(internal.JsonEncoding, nil, rawI))
 		require.NotEmpty(t, id)
 		require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestBenchmarkingStreams(t *testing.T) {
 }
 
 func getEvent() *internal.StreamData {
-	return internal.NewStreamData(nil, []byte(fmt.Sprintf(`{"key": %s}`, RandStringRunes(64))))
+	return internal.NewStreamData(internal.JsonEncoding, nil, []byte(fmt.Sprintf(`{"key": %s}`, RandStringRunes(64))))
 }
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
## Describe your changes
To store encoding information about how the user data is encoded

## How best to test these changes
Sending requests from websocket and reading channel data through HTTP APIs should work as expected

## Issue ticket number and link
