### PR TITLE
fix: support mutating primary keys as part of Update request

### DIFF
--- a/server/services/v1/realtime/pusher.go
+++ b/server/services/v1/realtime/pusher.go
@@ -82,5 +82,4 @@ func (pusher *DevicePusher) sendMessage(msgId string, md *StreamMessageMD, data 
 
 	err = SendReply(pusher.connection, pusher.encType, api.EventType_message, message)
 	log.Err(err).Msgf("failed to push message")
-
 }

--- a/server/services/v1/realtime/serialization.go
+++ b/server/services/v1/realtime/serialization.go
@@ -97,7 +97,6 @@ func EncodeAsMsgPack(data interface{}) ([]byte, error) {
 func JsonByteToMsgPack(data []byte) ([]byte, error) {
 	var obj interface{}
 	err := jsoniter.Unmarshal(data, &obj)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes
This allows modifying primary key values. In case values are modified then we need to remove the old row and add a new row. 

## How best to test these changes

## Issue ticket number and link
