### PR TITLE
refactor: Introduce project abstraction in tenant

### DIFF
--- a/server/metadata/database.go
+++ b/server/metadata/database.go
@@ -14,9 +14,11 @@
 
 package metadata
 
-import "strings"
+import (
+	"strings"
+)
 
-type DatabaseMetadata struct {
+type ProjectMetadata struct {
 	Id             uint32
 	Creator        string
 	CreatedAt      int64
@@ -29,7 +31,7 @@ type CachesMetadata struct {
 	CreatedAt int64
 }
 
-func (dm *DatabaseMetadata) SetDatabaseId(id uint32) {
+func (dm *ProjectMetadata) SetId(id uint32) {
 	dm.Id = id
 }
 
@@ -72,7 +74,7 @@ func (b *DatabaseName) Name() string {
 	return b.Db() + BranchNameSeparator + b.Branch()
 }
 
-// Db is the user facing name of the oprimary database.
+// Db is the user facing name of the primary database.
 func (b *DatabaseName) Db() string {
 	return b.db
 }

--- a/server/metadata/errors.go
+++ b/server/metadata/errors.go
@@ -24,6 +24,7 @@ const (
 	ErrCodeDatabaseBranchExists ErrorCode = 0x02
 	ErrCodeBranchNotFound       ErrorCode = 0x03
 	ErrCodeCannotDeleteBranch   ErrorCode = 0x04
+	ErrCodeProjectNotFound      ErrorCode = 0x05
 )
 
 type Error struct {
@@ -46,18 +47,14 @@ func (e Error) Code() ErrorCode {
 	return e.code
 }
 
-func NewDatabaseNotFoundErr(name string) error {
-	return NewMetadataError(ErrCodeDatabaseNotFound, "database doesn't exist '%s'", name)
-}
-
-func NewDatabaseExistsErr(name string) error {
-	return NewMetadataError(ErrCodeDatabaseExists, "database already exist '%s'", name)
-}
-
 func NewDatabaseBranchExistsErr(name string) error {
 	return NewMetadataError(ErrCodeDatabaseBranchExists, "branch already exist '%s'", name)
 }
 
 func NewBranchNotFoundErr(name string) error {
 	return NewMetadataError(ErrCodeBranchNotFound, "database branch doesn't exist '%s'", name)
+}
+
+func NewProjectNotFoundErr(name string) error {
+	return NewMetadataError(ErrCodeProjectNotFound, "database doesn't exist '%s'", name)
 }

--- a/server/metadata/key_encoder_test.go
+++ b/server/metadata/key_encoder_test.go
@@ -36,6 +36,8 @@ func TestEncodeDecodeKey(t *testing.T) {
 			coll.Id: coll.Name,
 		},
 	}
+	proj := NewProject(db.id, db.Name())
+	proj.database = db
 
 	mgr := &TenantManager{
 		idToTenantMap: map[uint32]string{
@@ -44,11 +46,11 @@ func TestEncodeDecodeKey(t *testing.T) {
 		tenants: map[string]*Tenant{
 			ns.StrId(): {
 				namespace: ns,
-				databases: map[string]*Database{
-					db.Name(): db,
+				projects: map[string]*Project{
+					db.Name(): proj,
 				},
-				idToDatabaseMap: map[uint32]string{
-					db.id: db.Name(),
+				idToDatabaseMap: map[uint32]*Database{
+					db.id: db,
 				},
 			},
 		},

--- a/server/metadata/namespaces_test.go
+++ b/server/metadata/namespaces_test.go
@@ -218,7 +218,7 @@ func TestNamespacesSubspace(t *testing.T) {
 		})
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
 
-		dbMetadata := &DatabaseMetadata{
+		dbMetadata := &ProjectMetadata{
 			Id:        1,
 			Creator:   "google|123",
 			CreatedAt: 1668733841287,
@@ -227,9 +227,9 @@ func TestNamespacesSubspace(t *testing.T) {
 		tm := transaction.NewManager(kvStore)
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.Equal(t, errors.InvalidArgument("invalid dbName, dbName must not be blank"), n.InsertDatabaseMetadata(ctx, tx, 1, "", dbMetadata))
-		require.Equal(t, errors.InvalidArgument("invalid dbMetadata, dbMetadata must not be nil"), n.InsertDatabaseMetadata(ctx, tx, 1, "valid-db-name", nil))
-		require.Equal(t, errors.InvalidArgument("invalid namespace, id must be greater than 0"), n.InsertDatabaseMetadata(ctx, tx, 0, "valid-db-name", dbMetadata))
+		require.Equal(t, errors.InvalidArgument("invalid projName, projName must not be blank"), n.InsertProjectMetadata(ctx, tx, 1, "", dbMetadata))
+		require.Equal(t, errors.InvalidArgument("invalid projMetadata, projMetadata must not be nil"), n.InsertProjectMetadata(ctx, tx, 1, "valid-db-name", nil))
+		require.Equal(t, errors.InvalidArgument("invalid namespace, id must be greater than 0"), n.InsertProjectMetadata(ctx, tx, 0, "valid-db-name", dbMetadata))
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
 	})
 
@@ -242,7 +242,7 @@ func TestNamespacesSubspace(t *testing.T) {
 		})
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
 
-		dbMetadata := &DatabaseMetadata{
+		dbMetadata := &ProjectMetadata{
 			Id:        1,
 			Creator:   "google|123",
 			CreatedAt: 1668733841287,
@@ -251,8 +251,8 @@ func TestNamespacesSubspace(t *testing.T) {
 		tm := transaction.NewManager(kvStore)
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, n.InsertDatabaseMetadata(ctx, tx, 1, "db-name", dbMetadata))
-		value, err := n.GetDatabaseMetadata(ctx, tx, 1, "db-name")
+		require.NoError(t, n.InsertProjectMetadata(ctx, tx, 1, "db-name", dbMetadata))
+		value, err := n.GetProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 		require.Equal(t, dbMetadata, value)
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
@@ -267,7 +267,7 @@ func TestNamespacesSubspace(t *testing.T) {
 		})
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
 
-		dbMetadata := &DatabaseMetadata{
+		dbMetadata := &ProjectMetadata{
 			Id:        1,
 			Creator:   "google|123",
 			CreatedAt: 1668733841287,
@@ -276,15 +276,15 @@ func TestNamespacesSubspace(t *testing.T) {
 		tm := transaction.NewManager(kvStore)
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, n.InsertDatabaseMetadata(ctx, tx, 1, "db-name", dbMetadata))
-		value, err := n.GetDatabaseMetadata(ctx, tx, 1, "db-name")
+		require.NoError(t, n.InsertProjectMetadata(ctx, tx, 1, "db-name", dbMetadata))
+		value, err := n.GetProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 		require.Equal(t, dbMetadata, value)
 
-		err = n.DeleteDatabaseMetadata(ctx, tx, 1, "db-name")
+		err = n.DeleteProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 
-		value, err = n.GetDatabaseMetadata(ctx, tx, 1, "db-name")
+		value, err = n.GetProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 		require.Nil(t, value)
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
@@ -299,7 +299,7 @@ func TestNamespacesSubspace(t *testing.T) {
 		})
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())
 
-		dbMetadata := &DatabaseMetadata{
+		dbMetadata := &ProjectMetadata{
 			Id:        1,
 			Creator:   "google|123",
 			CreatedAt: 1668733841287,
@@ -308,21 +308,21 @@ func TestNamespacesSubspace(t *testing.T) {
 		tm := transaction.NewManager(kvStore)
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, n.InsertDatabaseMetadata(ctx, tx, 1, "db-name", dbMetadata))
-		value, err := n.GetDatabaseMetadata(ctx, tx, 1, "db-name")
+		require.NoError(t, n.InsertProjectMetadata(ctx, tx, 1, "db-name", dbMetadata))
+		value, err := n.GetProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 		require.Equal(t, dbMetadata, value)
 
-		dbMetadata2 := &DatabaseMetadata{
+		dbMetadata2 := &ProjectMetadata{
 			Id:        1,
 			Creator:   "google|456",
 			CreatedAt: 1668733841287,
 		}
 
-		err = n.UpdateDatabaseMetadata(ctx, tx, 1, "db-name", dbMetadata2)
+		err = n.UpdateProjectMetadata(ctx, tx, 1, "db-name", dbMetadata2)
 		require.NoError(t, err)
 
-		value, err = n.GetDatabaseMetadata(ctx, tx, 1, "db-name")
+		value, err = n.GetProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 		require.Equal(t, dbMetadata2, value)
 		_ = kvStore.DropTable(ctx, n.NamespaceSubspaceName())

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -32,9 +32,11 @@ import (
 )
 
 var (
-	kvStore   kv.KeyValueStore
-	tenantDb1 = NewDatabaseName("tenant_db1")
-	tenantDb2 = NewDatabaseName("tenant_db2")
+	kvStore     kv.KeyValueStore
+	tenantProj1 = "tenant_db1"
+	tenantProj2 = "tenant_db2"
+	tenantDb1   = NewDatabaseName("tenant_db1")
+	tenantDb2   = NewDatabaseName("tenant_db2")
 )
 
 func TestTenantManager_CreateOrGetTenant(t *testing.T) {
@@ -49,7 +51,7 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		require.Equal(t, "ns-test1", tenant.namespace.StrId())
 		require.Equal(t, uint32(2), tenant.namespace.Id())
 		require.Equal(t, "ns-test1", m.idToTenantMap[uint32(2)])
-		require.Empty(t, tenant.databases)
+		require.Empty(t, tenant.projects)
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
 
@@ -68,14 +70,14 @@ func TestTenantManager_CreateOrGetTenant(t *testing.T) {
 		require.Equal(t, uint32(2), tenant.namespace.Id())
 		require.Equal(t, "ns-test1", m.idToTenantMap[uint32(2)])
 
-		require.Empty(t, tenant.databases)
+		require.Empty(t, tenant.projects)
 		require.Empty(t, tenant.idToDatabaseMap)
 
 		tenant = m.tenants["ns-test2"]
 		require.Equal(t, "ns-test2", tenant.namespace.StrId())
 		require.Equal(t, uint32(3), tenant.namespace.Id())
 		require.Equal(t, "ns-test2", m.idToTenantMap[uint32(3)])
-		require.Empty(t, tenant.databases)
+		require.Empty(t, tenant.projects)
 
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 	})
@@ -179,9 +181,9 @@ func TestTenantManager_CreateTenant(t *testing.T) {
 	})
 }
 
-func TestTenantManager_CreateDatabases(t *testing.T) {
+func TestTenantManager_CreateProjects(t *testing.T) {
 	tm := transaction.NewManager(kvStore)
-	t.Run("create_databases", func(t *testing.T) {
+	t.Run("create_projects", func(t *testing.T) {
 		m, ctx, cancel := NewTestTenantMgr(kvStore)
 		defer cancel()
 
@@ -195,26 +197,159 @@ func TestTenantManager_CreateDatabases(t *testing.T) {
 
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb1.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb2.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
-		db1, err := tenant.GetDatabase(ctx, tenantDb1)
+		proj1, err := tenant.GetProject(tenantProj1)
 		require.NoError(t, err)
-		require.Equal(t, tenantDb1.Name(), db1.Name())
-		require.Equal(t, tenantDb1.Name(), tenant.idToDatabaseMap[db1.id])
+		require.Equal(t, tenantProj1, proj1.Name())
+		require.Equal(t, proj1.id, proj1.database.id)
+		require.Equal(t, proj1, tenant.projects[tenantProj1])
+		require.Equal(t, tenantProj1, tenant.idToDatabaseMap[proj1.id].Name())
 
-		db2, err := tenant.GetDatabase(ctx, tenantDb2)
+		proj2, err := tenant.GetProject(tenantProj2)
 		require.NoError(t, err)
-		require.Equal(t, tenantDb2.Name(), db2.Name())
+		require.Equal(t, tenantProj2, proj2.Name())
+		require.Equal(t, proj2.id, proj2.database.id)
 		require.NoError(t, tx.Commit(ctx))
-		require.Equal(t, tenantDb2.Name(), tenant.idToDatabaseMap[db2.id])
+
+		require.Equal(t, proj2, tenant.projects[tenantProj2])
+		require.Equal(t, tenantProj2, tenant.idToDatabaseMap[proj2.id].Name())
 
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
 		_ = kvStore.DropTable(ctx, m.mdNameRegistry.EncodingSubspaceName())
 	})
+}
+
+func TestTenantManager_DatabaseBranches(t *testing.T) {
+	tm := transaction.NewManager(kvStore)
+	m, ctx, cancel := NewTestTenantMgr(kvStore)
+	defer cancel()
+
+	_, err := m.CreateOrGetTenant(ctx, &TenantNamespace{"ns-test1", 2, NamespaceMetadata{
+		Id:    2,
+		StrId: "ns-test1",
+		Name:  "ns-test1-displayName",
+	}})
+	require.NoError(t, err)
+	tenant := m.tenants["ns-test1"]
+
+	tx, err := tm.StartTx(ctx)
+	require.NoError(t, err)
+	_, err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
+	require.NoError(t, err)
+	_, err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch1")))
+	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj2, NewDatabaseNameWithBranch(tenantProj2, "branch1")))
+	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch2")))
+	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj2, NewDatabaseNameWithBranch(tenantProj2, "branch2")))
+	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch3")))
+
+	// reload again to get all the branches
+	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+	proj1, err := tenant.GetProject(tenantProj1)
+	require.NoError(t, err)
+	require.Equal(t, proj1.id, proj1.database.id)
+	require.False(t, proj1.database.IsBranch())
+	branch1, err := proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch1"))
+	require.NoError(t, err)
+	require.True(t, branch1.IsBranch())
+	require.Equal(t, tenantProj1+BranchNameSeparator+"branch1", branch1.Name())
+
+	branch2, err := proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch2"))
+	require.NoError(t, err)
+	require.True(t, branch2.IsBranch())
+	require.Equal(t, tenantProj1+BranchNameSeparator+"branch2", branch2.Name())
+
+	branch3, err := proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch3"))
+	require.NoError(t, err)
+	require.True(t, branch3.IsBranch())
+	require.Equal(t, tenantProj1+BranchNameSeparator+"branch3", branch3.Name())
+
+	databases := proj1.GetDatabaseWithBranches()
+	require.Len(t, databases, 4)
+	require.Equal(t, proj1.database, databases[0])
+
+	proj2, err := tenant.GetProject(tenantProj2)
+	require.NoError(t, err)
+
+	branch1, err = proj2.GetDatabase(NewDatabaseNameWithBranch(tenantProj2, "branch1"))
+	require.NoError(t, err)
+	require.True(t, branch1.IsBranch())
+
+	branch2, err = proj2.GetDatabase(NewDatabaseNameWithBranch(tenantProj2, "branch2"))
+	require.NoError(t, err)
+	require.True(t, branch2.IsBranch())
+
+	databases = proj2.GetDatabaseWithBranches()
+	require.Len(t, databases, 3)
+	require.Equal(t, proj2.database, databases[0])
+
+	require.NoError(t, tx.Commit(ctx))
+
+	require.Equal(t, tenantProj1, tenant.idToDatabaseMap[proj1.id].Name())
+	require.Equal(t, tenantProj2, tenant.idToDatabaseMap[proj2.id].Name())
+
+	// delete a branch now
+	tx, err = tm.StartTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tenant.DeleteBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch1")))
+	require.NoError(t, tenant.DeleteBranch(ctx, tx, tenantProj2, NewDatabaseNameWithBranch(tenantProj2, "branch1")))
+	require.NoError(t, tenant.DeleteBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch2")))
+
+	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+	require.NoError(t, tx.Commit(ctx))
+
+	tx, err = tm.StartTx(ctx)
+	require.NoError(t, err)
+
+	proj1, err = tenant.GetProject(tenantProj1)
+	require.NoError(t, err)
+	require.False(t, proj1.database.IsBranch())
+
+	_, err = proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch1"))
+	require.Error(t, NewBranchNotFoundErr("branch1"), err)
+
+	_, err = proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch2"))
+	require.Error(t, NewBranchNotFoundErr("branch2"), err)
+
+	branch3, err = proj1.GetDatabase(NewDatabaseNameWithBranch(tenantProj1, "branch3"))
+	require.NoError(t, err)
+	require.True(t, branch3.IsBranch())
+	require.Equal(t, tenantProj1+BranchNameSeparator+"branch3", branch3.Name())
+
+	databases = proj1.GetDatabaseWithBranches()
+	require.Len(t, databases, 2)
+	require.Equal(t, proj1.database, databases[0])
+	require.Equal(t, branch3, databases[1])
+
+	proj2, err = tenant.GetProject(tenantProj2)
+	require.NoError(t, err)
+
+	_, err = proj2.GetDatabase(NewDatabaseNameWithBranch(tenantProj2, "branch1"))
+	require.Error(t, NewBranchNotFoundErr("branch1"), err)
+
+	branch2, err = proj2.GetDatabase(NewDatabaseNameWithBranch(tenantProj2, "branch2"))
+	require.NoError(t, err)
+	require.True(t, branch2.IsBranch())
+
+	databases = proj2.GetDatabaseWithBranches()
+	require.Len(t, databases, 2)
+	require.Equal(t, proj2.database, databases[0])
+	require.Equal(t, branch2, databases[1])
+
+	require.NoError(t, tx.Commit(ctx))
+
+	_ = kvStore.DropTable(ctx, m.mdNameRegistry.ReservedSubspaceName())
+	_ = kvStore.DropTable(ctx, m.mdNameRegistry.EncodingSubspaceName())
 }
 
 func TestTenantManager_CreateCollections(t *testing.T) {
@@ -229,24 +364,29 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 		tenant := m.tenants["ns-test1"]
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb1.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb2.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
 
-		db1, err := tenant.GetDatabase(ctx, tenantDb1)
+		proj1, err := tenant.GetProject(tenantProj1)
+		require.NoError(t, err)
+		require.Equal(t, tenantProj1, proj1.Name())
+		db1 := proj1.database
 		require.NoError(t, err)
 		require.Equal(t, tenantDb1.Name(), db1.Name())
-		require.Equal(t, tenantDb1.Name(), tenant.idToDatabaseMap[db1.id])
+		require.Equal(t, tenantDb1.Name(), tenant.idToDatabaseMap[db1.id].Name())
 
-		db2, err := tenant.GetDatabase(ctx, tenantDb2)
+		proj2, err := tenant.GetProject(tenantProj2)
 		require.NoError(t, err)
+		require.Equal(t, tenantProj2, proj2.Name())
+		db2 := proj2.database
 		require.Equal(t, tenantDb2.Name(), db2.Name())
-		require.Equal(t, tenantDb2.Name(), tenant.idToDatabaseMap[db2.id])
+		require.Equal(t, tenantDb2.Name(), tenant.idToDatabaseMap[db2.id].Name())
 		require.Equal(t, 2, len(tenant.idToDatabaseMap))
-		require.Equal(t, 2, len(tenant.databases))
+		require.Equal(t, 2, len(tenant.projects))
 
 		jsSchema := []byte(`{
         "title": "test_collection",
@@ -271,8 +411,9 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 
 		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
 
-		db2, err = tenant.GetDatabase(ctx, tenantDb2)
+		proj2, err = tenant.GetProject(tenantProj2)
 		require.NoError(t, err)
+		db2 = proj2.database
 		collection := db2.GetCollection("test_collection")
 		require.Equal(t, "test_collection", collection.Name)
 		require.Equal(t, "test_collection", db2.idToCollectionMap[collection.Id])
@@ -299,18 +440,22 @@ func TestTenantManager_DropCollection(t *testing.T) {
 
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb1.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
 		require.NoError(t, err)
-		_, err = tenant.CreateDatabase(ctx, tx, tenantDb2.Name(), nil)
+		_, err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
 
-		db1, err := tenant.GetDatabase(ctx, tenantDb1)
+		proj1, err := tenant.GetProject(tenantProj1)
+		require.NoError(t, err)
+		db1 := proj1.database
 		require.NoError(t, err)
 		require.Equal(t, tenantDb1.Name(), db1.Name())
 
-		db2, err := tenant.GetDatabase(ctx, tenantDb2)
+		proj2, err := tenant.GetProject(tenantProj2)
+		require.NoError(t, err)
+		db2 := proj2.database
 		require.NoError(t, err)
 		require.Equal(t, tenantDb2.Name(), db2.Name())
 
@@ -371,16 +516,16 @@ func TestTenantManager_DataSize(t *testing.T) {
 	tx, err := tm.StartTx(context.TODO())
 	require.NoError(t, err)
 
-	_, err = tenant.CreateDatabase(ctx, tx, tenantDb1.Name(), nil)
+	_, err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
 	require.NoError(t, err)
-	_, err = tenant.CreateDatabase(ctx, tx, tenantDb2.Name(), nil)
+	_, err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
 	require.NoError(t, err)
 
 	tenant2 := m.tenants["ns-test2"]
 
-	_, err = tenant2.CreateDatabase(ctx, tx, tenantDb1.Name(), nil)
+	_, err = tenant2.CreateProject(ctx, tx, tenantProj1, nil)
 	require.NoError(t, err)
-	_, err = tenant2.CreateDatabase(ctx, tx, tenantDb2.Name(), nil)
+	_, err = tenant2.CreateProject(ctx, tx, tenantProj2, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
@@ -406,10 +551,13 @@ func TestTenantManager_DataSize(t *testing.T) {
 	factory, err := schema.Build("test_collection", jsSchema)
 	require.NoError(t, err)
 
-	db1, err := tenant.GetDatabase(ctx, tenantDb1)
+	proj1, err := tenant.GetProject(tenantProj1)
 	require.NoError(t, err)
-	db2, err := tenant.GetDatabase(ctx, tenantDb2)
+	db1 := proj1.database
+
+	proj2, err := tenant.GetProject(tenantProj2)
 	require.NoError(t, err)
+	db2 := proj2.database
 
 	require.NoError(t, tenant.CreateCollection(ctx, tx, db1, factory))
 	require.NoError(t, err)
@@ -417,14 +565,14 @@ func TestTenantManager_DataSize(t *testing.T) {
 	require.NoError(t, err)
 
 	// create tenant2 dbs and collections
-	db21, err := tenant2.GetDatabase(ctx, tenantDb1)
+	proj21, err := tenant2.GetProject(tenantProj1)
 	require.NoError(t, err)
-	db22, err := tenant2.GetDatabase(ctx, tenantDb2)
+	proj22, err := tenant2.GetProject(tenantProj2)
 	require.NoError(t, err)
 
-	require.NoError(t, tenant2.CreateCollection(ctx, tx, db21, factory))
+	require.NoError(t, tenant2.CreateCollection(ctx, tx, proj21.database, factory))
 	require.NoError(t, err)
-	require.NoError(t, tenant2.CreateCollection(ctx, tx, db22, factory))
+	require.NoError(t, tenant2.CreateCollection(ctx, tx, proj22.database, factory))
 	require.NoError(t, err)
 
 	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
@@ -445,8 +593,8 @@ func TestTenantManager_DataSize(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	coll21 := db21.GetCollection("test_collection")
-	table21, err := m.encoder.EncodeTableName(tenant2.GetNamespace(), db21, coll21)
+	coll21 := proj21.database.GetCollection("test_collection")
+	table21, err := m.encoder.EncodeTableName(tenant2.GetNamespace(), proj21.database, coll21)
 	require.NoError(t, err)
 
 	err = tenant2.kvStore.DropTable(ctx, table21)
@@ -457,8 +605,8 @@ func TestTenantManager_DataSize(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	coll22 := db22.GetCollection("test_collection")
-	table22, err := m.encoder.EncodeTableName(tenant2.GetNamespace(), db22, coll22)
+	coll22 := proj22.database.GetCollection("test_collection")
+	table22, err := m.encoder.EncodeTableName(tenant2.GetNamespace(), proj22.database, coll22)
 	require.NoError(t, err)
 
 	err = tenant2.kvStore.DropTable(ctx, table22)
@@ -492,20 +640,20 @@ func TestTenantManager_DataSize(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2186250), sz) // sum of db21 and db22
 
-	sz, err = tenant2.DatabaseSize(ctx, db21)
+	sz, err = tenant2.DatabaseSize(ctx, proj21.database)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1694750), sz)
 
-	sz, err = tenant2.CollectionSize(ctx, db21, coll21)
+	sz, err = tenant2.CollectionSize(ctx, proj21.database, coll21)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1694750), sz)
 
 	// db22
-	sz, err = tenant2.DatabaseSize(ctx, db22)
+	sz, err = tenant2.DatabaseSize(ctx, proj22.database)
 	require.NoError(t, err)
 	assert.Equal(t, int64(491500), sz)
 
-	sz, err = tenant2.CollectionSize(ctx, db22, coll22)
+	sz, err = tenant2.CollectionSize(ctx, proj22.database, coll22)
 	require.NoError(t, err)
 	assert.Equal(t, int64(491500), sz)
 

--- a/server/quota/quota_test.go
+++ b/server/quota/quota_test.go
@@ -38,7 +38,7 @@ var kvStore kv.KeyValueStore
 
 func TestQuota(t *testing.T) {
 	tenants, ctx, cancel := metadata.NewTestTenantMgr(kvStore)
-	dbName := metadata.NewDatabaseName("tenant_db1")
+	projName := "tenant_proj1"
 	defer cancel()
 
 	txMgr := transaction.NewManager(kvStore)
@@ -52,7 +52,7 @@ func TestQuota(t *testing.T) {
 	tx, err := txMgr.StartTx(context.TODO())
 	require.NoError(t, err)
 
-	_, err = tenant.CreateDatabase(ctx, tx, dbName.Name(), nil)
+	_, err = tenant.CreateProject(ctx, tx, projName, nil)
 	require.NoError(t, err)
 
 	jsSchema := []byte(`{
@@ -71,15 +71,15 @@ func TestQuota(t *testing.T) {
 	err = tenant.Reload(ctx, tx, []byte("aaa"))
 	require.NoError(t, err)
 
-	db1, err := tenant.GetDatabase(ctx, dbName)
+	proj1, err := tenant.GetProject(projName)
 	require.NoError(t, err)
 
-	require.NoError(t, tenant.CreateCollection(ctx, tx, db1, factory))
+	require.NoError(t, tenant.CreateCollection(ctx, tx, proj1.GetMainDatabase(), factory))
 
 	require.NoError(t, tx.Commit(context.TODO()))
 
-	coll1 := db1.GetCollection("test_collection")
-	table, err := metadata.NewEncoder().EncodeTableName(tenant.GetNamespace(), db1, coll1)
+	coll1 := proj1.GetMainDatabase().GetCollection("test_collection")
+	table, err := metadata.NewEncoder().EncodeTableName(tenant.GetNamespace(), proj1.GetMainDatabase(), coll1)
 	require.NoError(t, err)
 
 	err = Init(tenants, &config.Config{

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -391,7 +391,7 @@ func (s *apiService) ListCollections(ctx context.Context, r *api.ListCollections
 
 func (s *apiService) ListProjects(ctx context.Context, r *api.ListProjectsRequest) (*api.ListProjectsResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetProjectQueryRunner(accessToken)
 	runner.SetListProjectsReq(r)
 
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{})
@@ -404,7 +404,7 @@ func (s *apiService) ListProjects(ctx context.Context, r *api.ListProjectsReques
 
 func (s *apiService) CreateProject(ctx context.Context, r *api.CreateProjectRequest) (*api.CreateProjectResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetProjectQueryRunner(accessToken)
 	runner.SetCreateProjectReq(r)
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{
 		MetadataChange:     true,
@@ -422,7 +422,7 @@ func (s *apiService) CreateProject(ctx context.Context, r *api.CreateProjectRequ
 
 func (s *apiService) DeleteProject(ctx context.Context, r *api.DeleteProjectRequest) (*api.DeleteProjectResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetProjectQueryRunner(accessToken)
 	runner.SetDeleteProjectReq(r)
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{
 		MetadataChange:     true,
@@ -460,7 +460,7 @@ func (s *apiService) DescribeCollection(ctx context.Context, r *api.DescribeColl
 
 func (s *apiService) DescribeDatabase(ctx context.Context, r *api.DescribeDatabaseRequest) (*api.DescribeDatabaseResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetProjectQueryRunner(accessToken)
 	runner.SetDescribeDatabaseReq(r)
 
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{})
@@ -473,7 +473,7 @@ func (s *apiService) DescribeDatabase(ctx context.Context, r *api.DescribeDataba
 
 func (s *apiService) CreateBranch(ctx context.Context, r *api.CreateBranchRequest) (*api.CreateBranchResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetBranchQueryRunner(accessToken)
 	runner.SetCreateBranchReq(r)
 
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{
@@ -489,7 +489,7 @@ func (s *apiService) CreateBranch(ctx context.Context, r *api.CreateBranchReques
 
 func (s *apiService) DeleteBranch(ctx context.Context, r *api.DeleteBranchRequest) (*api.DeleteBranchResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
-	runner := s.runnerFactory.GetDatabaseQueryRunner(accessToken)
+	runner := s.runnerFactory.GetBranchQueryRunner(accessToken)
 	runner.SetDeleteBranchReq(r)
 
 	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{

--- a/server/services/v1/cache/errors.go
+++ b/server/services/v1/cache/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package cache
 
 import (
 	apiErrors "github.com/tigrisdata/tigris/errors"
@@ -23,14 +23,7 @@ import (
 func createApiError(err error) error {
 	switch e := err.(type) {
 	case metadata.Error:
-		switch e.Code() {
-		case metadata.ErrCodeDatabaseNotFound, metadata.ErrCodeBranchNotFound:
-			return apiErrors.NotFound(e.Error())
-		case metadata.ErrCodeDatabaseBranchExists, metadata.ErrCodeDatabaseExists:
-			return apiErrors.AlreadyExists(e.Error())
-		case metadata.ErrCodeCannotDeleteBranch:
-			return apiErrors.InvalidArgument(e.Error())
-		case metadata.ErrCodeProjectNotFound:
+		if e.Code() == metadata.ErrCodeProjectNotFound {
 			return apiErrors.NotFound(e.Error())
 		}
 	default:

--- a/server/services/v1/cache/runner.go
+++ b/server/services/v1/cache/runner.go
@@ -342,12 +342,14 @@ func (runner *KeysRunner) Run(ctx context.Context, tenant *metadata.Tenant) (Res
 	}, nil
 }
 
-func getEncodedCacheTableName(ctx context.Context, tenant *metadata.Tenant, project string, cacheName string, encoder metadata.CacheEncoder) (string, error) {
-	db, err := tenant.GetDatabase(ctx, metadata.NewDatabaseNameWithBranch(project, metadata.MainBranch))
+func getEncodedCacheTableName(_ context.Context, tenant *metadata.Tenant, projectName string, cacheName string, encoder metadata.CacheEncoder) (string, error) {
+	project, err := tenant.GetProject(projectName)
 	if err != nil {
-		return "", err
+		return "", createApiError(err)
 	}
-	encodedCacheTableName, err := encoder.EncodeCacheTableName(tenant.GetNamespace().Id(), db.Id(), cacheName)
+
+	// Encode cache table is encoding tenant id, project id(main database id) and cache name.
+	encodedCacheTableName, err := encoder.EncodeCacheTableName(tenant.GetNamespace().Id(), project.Id(), cacheName)
 	if err != nil {
 		return "", err
 	}

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -180,25 +180,23 @@ func (m *managementService) getNameSpaceDetails(ctx context.Context) (nsDetailsR
 			return nil, err
 		}
 
-		for _, dbName := range tenant.ListDatabaseWithBranches(ctx) {
-			db, err := tenant.GetDatabase(ctx, metadata.NewDatabaseName(dbName))
+		for _, projName := range tenant.ListProjects(ctx) {
+			project, err := tenant.GetProject(projName)
 			if err != nil {
-				return nil, err
-			}
-
-			if db == nil {
-				// database was dropped in the meantime
+				// project was dropped in the meantime
 				continue
 			}
 
-			for _, coll := range db.ListCollection() {
-				size, err := tenant.CollectionSize(ctx, db, coll)
-				if err != nil {
-					return nil, err
-				}
-				res[nsName][dbName][coll.Name] = map[string]string{
-					"schema": string(coll.Schema),
-					"size":   strconv.FormatInt(size, 10),
+			for _, db := range project.GetDatabaseWithBranches() {
+				for _, coll := range db.ListCollection() {
+					size, err := tenant.CollectionSize(ctx, db, coll)
+					if err != nil {
+						return nil, err
+					}
+					res[nsName][db.Name()][coll.Name] = map[string]string{
+						"schema": string(coll.Schema),
+						"size":   strconv.FormatInt(size, 10),
+					}
 				}
 			}
 		}

--- a/server/services/v1/realtime/device_session.go
+++ b/server/services/v1/realtime/device_session.go
@@ -43,7 +43,7 @@ type Session struct {
 	chFactory    *ChannelFactory
 	heartbeat    *HeartbeatTable
 	tenant       *metadata.Tenant
-	project      *metadata.Database
+	project      *metadata.Project
 	watchers     map[string]*ChannelWatcher
 }
 
@@ -62,7 +62,7 @@ func (s *Sessions) CreateDeviceSession(ctx context.Context, conn *websocket.Conn
 		return nil, errors.NotFound("tenant '%s' not found", namespaceForThisSession)
 	}
 
-	proj, err := tenant.GetDatabase(ctx, metadata.NewDatabaseName(params.ProjectName))
+	proj, err := tenant.GetProject(params.ProjectName)
 	if err != nil {
 		tx, err := s.txMgr.StartTx(ctx)
 		if err != nil {
@@ -77,8 +77,8 @@ func (s *Sessions) CreateDeviceSession(ctx context.Context, conn *websocket.Conn
 			return nil, err
 		}
 
-		if proj, err = tenant.GetDatabase(ctx, metadata.NewDatabaseName(params.ProjectName)); err != nil {
-			return nil, errors.NotFound("project '%s' not found", params.ProjectName)
+		if proj, err = tenant.GetProject(params.ProjectName); err != nil {
+			return nil, err
 		}
 	}
 

--- a/server/services/v1/realtime/errors.go
+++ b/server/services/v1/realtime/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package realtime
 
 import (
 	apiErrors "github.com/tigrisdata/tigris/errors"
@@ -23,14 +23,7 @@ import (
 func createApiError(err error) error {
 	switch e := err.(type) {
 	case metadata.Error:
-		switch e.Code() {
-		case metadata.ErrCodeDatabaseNotFound, metadata.ErrCodeBranchNotFound:
-			return apiErrors.NotFound(e.Error())
-		case metadata.ErrCodeDatabaseBranchExists, metadata.ErrCodeDatabaseExists:
-			return apiErrors.AlreadyExists(e.Error())
-		case metadata.ErrCodeCannotDeleteBranch:
-			return apiErrors.InvalidArgument(e.Error())
-		case metadata.ErrCodeProjectNotFound:
+		if e.Code() == metadata.ErrCodeProjectNotFound {
 			return apiErrors.NotFound(e.Error())
 		}
 	default:

--- a/server/services/v1/realtime/runner.go
+++ b/server/services/v1/realtime/runner.go
@@ -78,15 +78,12 @@ func newBaseRunner(cache cache.Cache, factory *ChannelFactory) *baseRunner {
 	}
 }
 
-func (runner *baseRunner) getProject(ctx context.Context, tenant *metadata.Tenant, project string) (*metadata.Database, error) {
-	proj, err := tenant.GetDatabase(ctx, metadata.NewDatabaseName(project))
+func (runner *baseRunner) getProject(tenant *metadata.Tenant, project string) (*metadata.Project, error) {
+	proj, err := tenant.GetProject(project)
 	if err != nil {
-		return nil, err
+		return nil, createApiError(err)
 	}
-	if proj == nil {
-		return nil, errors.NotFound("project doesn't exist '%s'", project)
-	}
-	return proj, err
+	return proj, nil
 }
 
 // MessagesRunner is to publish messages to a channel.
@@ -97,7 +94,7 @@ type MessagesRunner struct {
 }
 
 func (runner *MessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (Response, error) {
-	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	project, err := runner.getProject(tenant, runner.req.Project)
 	if err != nil {
 		return Response{}, err
 	}
@@ -144,7 +141,7 @@ type ReadMessagesRunner struct {
 }
 
 func (runner *ReadMessagesRunner) Run(ctx context.Context, tenant *metadata.Tenant) (Response, error) {
-	project, err := runner.getProject(ctx, tenant, runner.req.Project)
+	project, err := runner.getProject(tenant, runner.req.Project)
 	if err != nil {
 		return Response{}, err
 	}
@@ -235,7 +232,7 @@ func (runner *ChannelRunner) SetListSubscriptionsReq(req *api.ListSubscriptionRe
 func (runner *ChannelRunner) Run(ctx context.Context, tenant *metadata.Tenant) (Response, error) {
 	switch {
 	case runner.listSubscriptions != nil:
-		project, err := runner.getProject(ctx, tenant, runner.listSubscriptions.Project)
+		project, err := runner.getProject(tenant, runner.listSubscriptions.Project)
 		if err != nil {
 			return Response{}, err
 		}
@@ -252,7 +249,7 @@ func (runner *ChannelRunner) Run(ctx context.Context, tenant *metadata.Tenant) (
 			},
 		}, nil
 	case runner.channelsReq != nil:
-		project, err := runner.getProject(ctx, tenant, runner.channelsReq.Project)
+		project, err := runner.getProject(tenant, runner.channelsReq.Project)
 		if err != nil {
 			return Response{}, err
 		}
@@ -275,7 +272,7 @@ func (runner *ChannelRunner) Run(ctx context.Context, tenant *metadata.Tenant) (
 			},
 		}, nil
 	default:
-		project, err := runner.getProject(ctx, tenant, runner.channelReq.Project)
+		project, err := runner.getProject(tenant, runner.channelReq.Project)
 		if err != nil {
 			return Response{}, err
 		}


### PR DESCRIPTION
## Describe your changes
This allows wrapping up all the entities that belong to a single project in a single object. This gives the added flexibility of adding Caches/Indexes to this project object. 

## How best to test these changes

## Issue ticket number and link
