### PR TITLE
feat: Stream the keys response

### DIFF
--- a/api/server/v1/cache.go
+++ b/api/server/v1/cache.go
@@ -138,6 +138,10 @@ func (x *KeysRequest) UnmarshalJSON(data []byte) error {
 			v = &x.Project
 		case "name":
 			v = &x.Name
+		case "cursor":
+			v = &x.Cursor
+		case "count":
+			v = &x.Count
 		case "pattern":
 			v = &x.Pattern
 		default:
@@ -175,9 +179,11 @@ func (x *GetResponse) MarshalJSON() ([]byte, error) {
 
 func (x *KeysResponse) MarshalJSON() ([]byte, error) {
 	resp := struct {
-		Keys []string `json:"keys,omitempty"`
+		Keys   []string `json:"keys"`
+		Cursor uint64   `json:"cursor"`
 	}{
-		Keys: x.GetKeys(),
+		Keys:   x.GetKeys(),
+		Cursor: x.GetCursor(),
 	}
 	return json.Marshal(resp)
 }

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -224,8 +224,9 @@ var DefaultConfig = Config{
 		WriteEnabled: true,
 	},
 	Cache: CacheConfig{
-		Host: "0.0.0.0",
-		Port: 6379,
+		Host:    "0.0.0.0",
+		Port:    6379,
+		MaxScan: 500,
 	},
 	Tracing: TracingConfig{
 		Enabled: false,
@@ -370,8 +371,9 @@ type SearchConfig struct {
 }
 
 type CacheConfig struct {
-	Host string `mapstructure:"host" json:"host" yaml:"host"`
-	Port int16  `mapstructure:"port" json:"port" yaml:"port"`
+	Host    string `mapstructure:"host" json:"host" yaml:"host"`
+	Port    int16  `mapstructure:"port" json:"port" yaml:"port"`
+	MaxScan int64  `mapstructure:"max_scan" json:"max_scan" yaml:"max_scan"`
 }
 
 type LimitsConfig struct {

--- a/server/services/v1/cache.go
+++ b/server/services/v1/cache.go
@@ -138,15 +138,10 @@ func (c *cacheService) Del(ctx context.Context, req *api.DelRequest) (*api.DelRe
 	}, nil
 }
 
-func (c *cacheService) Keys(ctx context.Context, req *api.KeysRequest) (*api.KeysResponse, error) {
-	accessToken, _ := request.GetAccessToken(ctx)
-	resp, err := c.sessions.Execute(ctx, c.runnerFactory.GetKeysRunner(req, accessToken))
-	if err != nil {
-		return nil, err
-	}
-	return &api.KeysResponse{
-		Keys: resp.Keys,
-	}, nil
+func (c *cacheService) Keys(req *api.KeysRequest, streaming api.Cache_KeysServer) error {
+	accessToken, _ := request.GetAccessToken(streaming.Context())
+	_, err := c.sessions.Execute(streaming.Context(), c.runnerFactory.GetKeysRunner(req, accessToken, streaming))
+	return err
 }
 
 func (c *cacheService) RegisterHTTP(router chi.Router, inproc *inprocgrpc.Channel) error {

--- a/server/services/v1/cache/request.go
+++ b/server/services/v1/cache/request.go
@@ -31,4 +31,10 @@ type Response struct {
 	Keys         []string
 	DeletedCount int64
 	Caches       []*api.CacheMetadata
+	Cursor       uint64
+}
+
+// StreamingKeys is a wrapper interface for passing around for streaming cache keys.
+type StreamingKeys interface {
+	api.Cache_KeysServer
 }

--- a/server/services/v1/cache/runner.go
+++ b/server/services/v1/cache/runner.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/server/types"
 	"github.com/tigrisdata/tigris/store/cache"
+	ulog "github.com/tigrisdata/tigris/util/log"
 )
 
 // Runner is responsible for executing the current query and return the response.
@@ -98,9 +99,10 @@ type DelRunner struct {
 
 type KeysRunner struct {
 	*BaseRunner
-
-	req *api.KeysRequest
+	req       *api.KeysRequest
+	streaming StreamingKeys
 }
+
 type RunnerFactory struct {
 	encoder    metadata.CacheEncoder
 	cacheStore cache.Cache
@@ -163,9 +165,10 @@ func (f *RunnerFactory) GetDelRunner(r *api.DelRequest, accessToken *types.Acces
 	}
 }
 
-func (f *RunnerFactory) GetKeysRunner(r *api.KeysRequest, accessToken *types.AccessToken) *KeysRunner {
+func (f *RunnerFactory) GetKeysRunner(r *api.KeysRequest, accessToken *types.AccessToken, streaming StreamingKeys) *KeysRunner {
 	return &KeysRunner{
 		BaseRunner: NewBaseRunner(f.encoder, accessToken, f.cacheStore),
+		streaming:  streaming,
 		req:        r,
 	}
 }
@@ -325,21 +328,28 @@ func (runner *KeysRunner) Run(ctx context.Context, tenant *metadata.Tenant) (Res
 	if pattern == "" {
 		pattern = "*"
 	}
-	// TODO: add the pagination
-	internalKeys, err := runner.cacheStore.Keys(ctx, tableName, pattern)
-	if err != nil {
-		return Response{}, errors.Internal("Failed to invoke keys, reason %s", err.Error())
-	}
+	cursor := runner.req.GetCursor()
+	var internalKeys []string
+	for {
+		internalKeys, cursor = runner.cacheStore.Scan(ctx, tableName, cursor, runner.req.GetCount(), pattern)
 
-	// transform internal keys to user facing keys
-	userKeys := make([]string, len(internalKeys))
-	for index, internalKey := range internalKeys {
-		userKeys[index] = runner.encoder.DecodeInternalCacheKeyNameToExternal(internalKey)
-	}
+		// transform internal keys to user facing keys
+		userKeys := make([]string, len(internalKeys))
+		for index, internalKey := range internalKeys {
+			userKeys[index] = runner.encoder.DecodeInternalCacheKeyNameToExternal(internalKey)
+		}
 
-	return Response{
-		Keys: userKeys,
-	}, nil
+		if err := runner.streaming.Send(&api.KeysResponse{
+			Keys:   userKeys,
+			Cursor: &cursor,
+		}); ulog.E(err) {
+			return Response{}, err
+		}
+		if cursor == 0 {
+			break
+		}
+	}
+	return Response{}, nil
 }
 
 func getEncodedCacheTableName(_ context.Context, tenant *metadata.Tenant, projectName string, cacheName string, encoder metadata.CacheEncoder) (string, error) {

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -148,6 +148,14 @@ func (c *cache) Keys(ctx context.Context, tableName string, pattern string) ([]s
 	return c.Client.Keys(ctx, encodeToCacheKey(tableName, pattern)).Result()
 }
 
+func (c *cache) Scan(ctx context.Context, tableName string, cursor uint64, count int64, pattern string) ([]string, uint64) {
+	if count > config.DefaultConfig.Cache.MaxScan {
+		count = config.DefaultConfig.Cache.MaxScan
+	}
+	scanCmd := c.Client.Scan(ctx, cursor, encodeToCacheKey(tableName, pattern), count)
+	return scanCmd.Val()
+}
+
 func (c *cache) ListStreams(ctx context.Context, streamNamePrefix string) ([]string, error) {
 	return c.Client.Keys(ctx, streamNamePrefix).Result()
 }

--- a/store/cache/store.go
+++ b/store/cache/store.go
@@ -78,6 +78,7 @@ type Cache interface {
 	// Exists returns if the key exists, for multiple keys it returns the count of the number of keys that exists
 	Exists(ctx context.Context, tableName string, key ...string) (int64, error)
 	Keys(ctx context.Context, tableName string, pattern string) ([]string, error)
+	Scan(ctx context.Context, tableName string, cursor uint64, count int64, pattern string) ([]string, uint64)
 
 	// CreateStream creates and returns a stream object, throws an error if stream already exists
 	CreateStream(ctx context.Context, streamName string) (Stream, error)


### PR DESCRIPTION
## Describe your changes

- Implementation of https://github.com/tigrisdata/tigris-api/pull/193 - keys response for cache api is made streaming.
- Implementation of https://github.com/tigrisdata/tigris-api/pull/194 - removed `kv` from path with the intent to keep all cache related operations in same HTTP path space.

## How best to test these changes
Added unit test, integration test and tested manually.

## Issue ticket number and link
