### PR TITLE
chore: make fdb hard drop the default

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -201,7 +201,7 @@ var DefaultConfig = Config{
 		Host:         "0.0.0.0",
 		Port:         8081,
 		RealtimePort: 8083,
-		FDBHardDrop:  false,
+		FDBHardDrop:  true,
 	},
 	Auth: AuthConfig{
 		Enabled:          false,


### PR DESCRIPTION
## Describe your changes
The FdbHardDrop configuration option tells if the range should be cleared in FoundationDB after drop database/drop collection. If this is not enabled, drops are soft delete.

## How best to test these changes
During some benchmarks, we saw that hard deletes have little performance impact. 

## Issue ticket number and link
TIG-946
