### PR TITLE
fix: Allow null when format is int32/int64

### DIFF
--- a/schema/collection.go
+++ b/schema/collection.go
@@ -369,6 +369,10 @@ func init() {
 		return false
 	}
 	jsonschema.Formats[FieldNames[Int32Type]] = func(i interface{}) bool {
+		if i == nil {
+			return true
+		}
+
 		val, err := parseInt(i)
 		if err != nil {
 			return false
@@ -377,6 +381,10 @@ func init() {
 		return !(val < math.MinInt32 || val > math.MaxInt32)
 	}
 	jsonschema.Formats[FieldNames[Int64Type]] = func(i interface{}) bool {
+		if i == nil {
+			return true
+		}
+
 		_, err := parseInt(i)
 		return err == nil
 	}

--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -154,6 +154,10 @@ func TestCollection_SchemaValidate(t *testing.T) {
 			expError: "expected string or null, but got number",
 		},
 		{
+			document: []byte(`{"id": 1, "id_32": null, "id_64": null}`),
+			expError: "",
+		},
+		{
 			document: []byte(`{"id": 1, "product_items": [{"id": 1, "item_name": null}]}`),
 			expError: "",
 		},


### PR DESCRIPTION
## Describe your changes
Allow nulls when format is int32/int64

## How best to test these changes

## Issue ticket number and link
