### PR TITLE
fix: Branch names in describe database

### DIFF
--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1173,11 +1173,11 @@ func (tenant *Tenant) ListDatabaseBranches(projName string) []string {
 	}
 
 	branchNames := make([]string, len(project.databaseBranches)+1)
-	branchNames[0] = projName
+	branchNames[0] = project.database.BranchName()
 
 	i := 1
 	for name := range project.databaseBranches {
-		branchNames[i] = name
+		branchNames[i] = project.databaseBranches[name].BranchName()
 		i++
 	}
 	return branchNames

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -256,6 +256,10 @@ func TestTenantManager_DatabaseBranches(t *testing.T) {
 	// reload again to get all the branches
 	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
 
+	// list all branches
+	branches := tenant.ListDatabaseBranches(tenantProj1)
+	require.Equal(t, []string{"main", "branch1", "branch2", "branch3"}, branches)
+
 	proj1, err := tenant.GetProject(tenantProj1)
 	require.NoError(t, err)
 	require.Equal(t, proj1.id, proj1.database.id)


### PR DESCRIPTION
## Describe your changes
- Project names were being returned as it is in database describe response

## How best to test these changes
- Unit tests

## Issue ticket number and link
TIG-976
