### PR TITLE
feat: Backward compatibility rules and checks for search indexes

### DIFF
--- a/schema/migration.go
+++ b/schema/migration.go
@@ -165,7 +165,7 @@ type FieldVersion struct {
 }
 
 // FieldVersions contains all the changes of the field,
-// across all the schema versions
+// across all the schema versions.
 type FieldVersions struct {
 	versions []*FieldVersion
 
@@ -174,7 +174,7 @@ type FieldVersions struct {
 	child map[string]*FieldVersions
 }
 
-// addFieldVersion adds individual field change to the tree
+// addFieldVersion adds individual field change to the tree.
 func addFieldVersion(versions map[string]*FieldVersions, version int, change *VersionDeltaField) {
 	m, i := versions, 0
 

--- a/schema/search.go
+++ b/schema/search.go
@@ -92,6 +92,34 @@ func BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, e
 	} else {
 		source = *schema.Source
 	}
+	if schema.Source.Type != SearchSourceUser && schema.Source.Type != SearchSourceTigris {
+		return nil, errors.InvalidArgument("unsupported index source '%s'", schema.Source.Type)
+	}
+	if schema.Source.Type == SearchSourceTigris && len(schema.Source.CollectionName) == 0 {
+		return nil, errors.InvalidArgument("collection name is required for tigris backed search indexes")
+	}
+	if schema.Source.Type == SearchSourceTigris && len(schema.Source.DatabaseBranch) == 0 {
+		// we set main branch by default if branch is not explicitly provided
+		schema.Source.DatabaseBranch = "main"
+		if searchSchema, err = jsoniter.Marshal(schema); err != nil {
+			return nil, err
+		}
+	}
+
+	found := false
+	for _, f := range fields {
+		if f.FieldName == SearchId {
+			found = true
+			break
+		}
+	}
+	if !found {
+		// add id field if not in the schema
+		fields = append(fields, &Field{
+			FieldName: "id",
+			DataType:  StringType,
+		})
+	}
 
 	factory := &SearchFactory{
 		Name:   index,
@@ -125,7 +153,6 @@ type SearchIndex struct {
 
 func NewSearchIndex(ver int, searchStoreName string, factory *SearchFactory, fieldsInSearch []tsApi.Field) *SearchIndex {
 	queryableFields := BuildQueryableFields(factory.Fields, fieldsInSearch)
-	queryableFields = append(queryableFields, NewQueryableField("id", StringType, UnknownType, nil, nil))
 
 	return &SearchIndex{
 		Version:         ver,

--- a/server/metadata/key_encoder.go
+++ b/server/metadata/key_encoder.go
@@ -26,18 +26,13 @@ import (
 	"github.com/tigrisdata/tigris/schema"
 )
 
-const (
-	searchNameBranchSeparator = "$branch$"
-)
-
 type SearchEncoder interface {
 	// EncodeSearchTableName will encode search index created by the user and return an encoded string that will be use
-	// as an index name in the underlying search store. Source branch is an identifier which will be added to the
-	// index name if it is non-empty.
-	EncodeSearchTableName(tenantId uint32, projId uint32, indexName string, sourceBranch string) string
+	// as an index name in the underlying search store.
+	EncodeSearchTableName(tenantId uint32, projId uint32, indexName string) string
 	// DecodeSearchTableName will decode the information from encoded search index Name. This method returns tenant id,
-	// project id, index name and source branch.
-	DecodeSearchTableName(name string) (uint32, uint32, string, string, bool)
+	// project id, index name.
+	DecodeSearchTableName(name string) (uint32, uint32, string, bool)
 }
 
 type CacheEncoder interface {
@@ -200,29 +195,21 @@ func (d *DictKeyEncoder) DecodeCacheTableName(name string) (uint32, uint32, stri
 }
 
 // EncodeSearchTableName will encode search index created by the user and return an encoded string that will be use
-// as an index name in the underlying search store. Source branch is an identifier which will be added to the
-// index name if it is non-empty.
-func (d *DictKeyEncoder) EncodeSearchTableName(tenantId uint32, projId uint32, indexName string, sourceBranch string) string {
-	if len(sourceBranch) > 0 {
-		return fmt.Sprintf("%d:%d:%s", tenantId, projId, indexName+searchNameBranchSeparator+sourceBranch)
-	}
+// as an index name in the underlying search store.
+func (d *DictKeyEncoder) EncodeSearchTableName(tenantId uint32, projId uint32, indexName string) string {
 	return fmt.Sprintf("%d:%d:%s", tenantId, projId, indexName)
 }
 
 // DecodeSearchTableName will decode the information from encoded search index Name. This method returns tenant id,
-// project id, index name and source branch.
-func (d *DictKeyEncoder) DecodeSearchTableName(name string) (uint32, uint32, string, string, bool) {
+// project id, and index name.
+func (d *DictKeyEncoder) DecodeSearchTableName(name string) (uint32, uint32, string, bool) {
 	allParts := strings.Split(name, ":")
 	if len(allParts) != 3 {
-		return 0, 0, "", "", false
+		return 0, 0, "", false
 	}
 
 	nsId, _ := strconv.ParseInt(allParts[0], 10, 64)
 	pid, _ := strconv.ParseInt(allParts[1], 10, 64)
 
-	searchWithBranch := strings.Split(allParts[2], searchNameBranchSeparator)
-	if len(searchWithBranch) == 2 {
-		return uint32(nsId), uint32(pid), searchWithBranch[0], searchWithBranch[1], true
-	}
-	return uint32(nsId), uint32(pid), allParts[2], "", true
+	return uint32(nsId), uint32(pid), allParts[2], true
 }

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -553,7 +553,7 @@ func TestTenantManager_SearchIndexes(t *testing.T) {
 
 	indexesInSearchStore, err := tenant.searchStore.AllCollections(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, indexesInSearchStore[tenant.Encoder.EncodeSearchTableName(tenant.namespace.Id(), proj1.Id(), factory.Name, "")])
+	require.NotNil(t, indexesInSearchStore[tenant.Encoder.EncodeSearchTableName(tenant.namespace.Id(), proj1.Id(), factory.Name)])
 
 	require.NoError(t, tenant.reload(ctx, tx, nil, indexesInSearchStore))
 

--- a/server/services/v1/search/runner.go
+++ b/server/services/v1/search/runner.go
@@ -558,7 +558,7 @@ func (runner *IndexRunner) Run(ctx context.Context, tx transaction.Tx, tenant *m
 				return Response{}, err
 			}
 
-			var indexInfo = &api.IndexInfo{
+			indexInfo := &api.IndexInfo{
 				Name: index.Name,
 			}
 			if indexInfo.Schema, err = jsoniter.Marshal(us); err != nil {


### PR DESCRIPTION
## Describe your changes
The following are the schema rules that will be applied for index upgrades,
- Adding/Dropping a field is allowed.
- Changing the type of the field is not allowed.
- Changing the index source i.e. if it is backed by Tigris then it is not allowed to change for now.

## How best to test these changes

## Issue ticket number and link
