### PR TITLE
Fix maxLength tags separator in Golang generated schema

### DIFF
--- a/schema/lang/go_test.go
+++ b/schema/lang/go_test.go
@@ -63,6 +63,7 @@ type Product struct {
 	DefValStrQ string ` + "`" + `json:"def_val_str_q" tigris:"default:'st\\'r1'"` + "`" + `
 	DefValUuid uuid.UUID ` + "`" + `json:"def_val_uuid" tigris:"default:'uuid()'"` + "`" + `
 	MaxLenStr string ` + "`" + `json:"max_len_str" tigris:"maxLength:11"` + "`" + `
+	MaxLenStrReq string ` + "`" + `json:"max_len_str_req" tigris:"maxLength:11,required"` + "`" + `
 	NameGen int32 ` + "`" + `json:"name_gen" tigris:"autoGenerate"` + "`" + `
 	NameGenKey int32 ` + "`" + `json:"name_gen_key" tigris:"primaryKey:4,autoGenerate"` + "`" + `
 	NameKey int32 ` + "`" + `json:"name_key" tigris:"primaryKey:3"` + "`" + `

--- a/schema/lang/java_test.go
+++ b/schema/lang/java_test.go
@@ -225,6 +225,7 @@ public class Product implements TigrisCollectionType {
     private String def_val_str_q;
     private UUID def_val_uuid;
     private String max_len_str;
+    private String max_len_str_req;
     @TigrisPrimaryKey(autoGenerate = true)
     private int name_gen;
     @TigrisPrimaryKey(order = 4, autoGenerate = true)
@@ -323,6 +324,14 @@ public class Product implements TigrisCollectionType {
         this.max_len_str = maxLenStr;
     }
 
+    public String getMax_len_str_req() {
+        return max_len_str_req;
+    }
+
+    public void setMax_len_str_req(String maxLenStrReq) {
+        this.max_len_str_req = maxLenStrReq;
+    }
+
     public int getName_gen() {
         return name_gen;
     }
@@ -385,6 +394,7 @@ public class Product implements TigrisCollectionType {
         String defValStrQ,
         UUID defValUuid,
         String maxLenStr,
+        String maxLenStrReq,
         int nameGen,
         int nameGenKey,
         int nameKey,
@@ -403,6 +413,7 @@ public class Product implements TigrisCollectionType {
         this.def_val_str_q = defValStrQ;
         this.def_val_uuid = defValUuid;
         this.max_len_str = maxLenStr;
+        this.max_len_str_req = maxLenStrReq;
         this.name_gen = nameGen;
         this.name_gen_key = nameGenKey;
         this.name_key = nameKey;
@@ -433,6 +444,7 @@ public class Product implements TigrisCollectionType {
             def_val_str_q == other.def_val_str_q &&
             def_val_uuid == other.def_val_uuid &&
             max_len_str == other.max_len_str &&
+            max_len_str_req == other.max_len_str_req &&
             name_gen == other.name_gen &&
             name_gen_key == other.name_gen_key &&
             name_key == other.name_key &&
@@ -455,6 +467,7 @@ public class Product implements TigrisCollectionType {
             def_val_str_q,
             def_val_uuid,
             max_len_str,
+            max_len_str_req,
             name_gen,
             name_gen_key,
             name_key,

--- a/schema/lang/schema.go
+++ b/schema/lang/schema.go
@@ -246,6 +246,7 @@ func genSchema(w io.Writer, name string, desc string, field map[string]*Field,
 			return ErrEmptyObjectName
 		}
 
+		// TODO: We assume required array is sorted, need fix to not depend on it.
 		req := false
 		if reqPtr < len(required) {
 			if required[reqPtr] == n {

--- a/schema/lang/schema_test.go
+++ b/schema/lang/schema_test.go
@@ -41,7 +41,7 @@ var (
         "title": "products",
         "primary_key": ["Key", "KeyGenIdx", "name_key", "name_gen_key"],
         "description": "type description",
-        "required": ["req_field", "time_f"],
+        "required": ["max_len_str_req", "req_field", "time_f"],
         "properties": {
           "Gen": { "type": "integer", "format": "int32", "autoGenerate": true },
           "Key": { "type": "integer", "format": "int32"},
@@ -58,6 +58,7 @@ var (
           "def_val_uuid": { "type": "string", "format": "uuid", "default": "uuid()" },
           "def_val_cuid": { "type": "string", "default": "cuid()" },
           "max_len_str": { "type": "string", "maxLength" : 11 },
+          "max_len_str_req": { "type": "string", "maxLength" : 11 },
           "req_field": { "type": "integer", "format": "int32"},
           "time_f": { "type": "string", "format": "date-time", "default": "now()", "updatedAt": true, "createdAt": true }
 		}}`

--- a/schema/lang/typescript_test.go
+++ b/schema/lang/typescript_test.go
@@ -108,6 +108,9 @@ export class Product {
   @Field({ maxLength: 11 })
   max_len_str: string;
 
+  @Field({ maxLength: 11 })
+  max_len_str_req: string;
+
   @Field(TigrisDataTypes.INT32, { autoGenerate: true })
   name_gen?: number;
 

--- a/templates/schema/go/object.gotmpl
+++ b/templates/schema/go/object.gotmpl
@@ -25,9 +25,9 @@ type {{ .Name }} struct {
          {{- if $def}}{{if $m}},{{end}}default:{{$def}}{{- $m = true}}{{end -}}
          {{- if $v.AutoGenerate}}{{if $m}},{{end}}autoGenerate{{- $m = true }}{{end -}}
          {{- if $v.UpdatedAt}}{{if $m}},{{end}}updatedAt{{- $m = true }}{{end -}}
-         {{- if $v.CreatedAt}}{{if $m}},{{end}}createdAt{{- end}}
-         {{- if $v.MaxLength}}{{if $m}},{{end}}maxLength:{{$v.MaxLength}}{{- end -}}
-         {{- if $v.Required}}{{if $m}},{{end}}required{{- end -}}
+         {{- if $v.CreatedAt}}{{if $m}},{{end}}createdAt{{- $m = true }}{{- end}}
+         {{- if $v.MaxLength}}{{if $m}},{{end}}maxLength:{{$v.MaxLength}}{{- $m = true }}{{- end -}}
+         {{- if $v.Required}}{{if $m}},{{end}}required{{- $m = true }}{{- end -}}
                     "{{end}}`
     {{- end -}}
 {{- end}}


### PR DESCRIPTION
Broken:
```
createdAtmaxLength:100
```
Fixed:
```
createdAt,maxLength:100
```
