### PR TITLE
fix: Support query for nulls and non-indexed fields

### DIFF
--- a/query/filter/logical.go
+++ b/query/filter/logical.go
@@ -152,6 +152,16 @@ func (a *AndFilter) flattenAnd(soFar string, filters []Filter) []string {
 	return combs
 }
 
+func (a *AndFilter) IsIndexed() bool {
+	for _, f := range a.filter {
+		if !f.IsIndexed() {
+			return false
+		}
+	}
+
+	return true
+}
+
 // OrFilter performs a logical OR operation on an array of two or more expressions. The or filter looks like this,
 // {"$or": [{"f1":1}, {"f2": 3}....]}
 // It can be nested i.e. a top level "$or" can have multiple nested $and/$or.
@@ -215,6 +225,16 @@ func (o *OrFilter) ToSearchFilter() []string {
 		ORs = append(ORs, f.ToSearchFilter()...)
 	}
 	return ORs
+}
+
+func (o *OrFilter) IsIndexed() bool {
+	for _, f := range o.filter {
+		if !f.IsIndexed() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // String a helpful method for logging.

--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -90,6 +90,9 @@ func (s *Selector) Matches(doc []byte) bool {
 	if dtp == jsonparser.NotExist {
 		return false
 	}
+	if dtp == jsonparser.Null {
+		docValue = nil
+	}
 
 	var val value.Value
 	if s.Collation != nil {
@@ -142,6 +145,10 @@ func (s *Selector) ToSearchFilter() []string {
 		}
 	}
 	return []string{fmt.Sprintf(op, s.Field.InMemoryName(), v.AsInterface())}
+}
+
+func (s *Selector) IsIndexed() bool {
+	return !(s.Field.DataType == schema.ByteType || s.Matcher.GetValue().AsInterface() == nil)
 }
 
 // String a helpful method for logging.

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -848,7 +848,8 @@ func (runner *StreamingQueryRunner) buildReaderOptions(collection *schema.Defaul
 		}
 	}
 
-	if filter.None(runner.req.Filter) {
+	if options.filter.None() || !options.filter.IsIndexed() {
+		// trigger full scan in case there is a field in the filter which is not indexed
 		if options.sorting != nil {
 			options.inMemoryStore = true
 		} else {


### PR DESCRIPTION
## Describe your changes
- A filter can be passed to query null values `'{"filter": {"field":null}}'` or empty quoted string `'{"filter": {"str":""}}'`
- Allowing querying for bytes field which is not indexed, this is performed using full table scan. 
- Allow scientific notation in the filter.

## How best to test these changes

## Issue ticket number and link
