### PR TITLE
fix: bump up default max candidates limit to 100

### DIFF
--- a/store/search/ts.go
+++ b/store/search/ts.go
@@ -31,6 +31,10 @@ import (
 	tsApi "github.com/typesense/typesense-go/typesense/api"
 )
 
+var (
+	maxCandidates = 100
+)
+
 type IndexResp struct {
 	Code     int
 	Document string
@@ -262,7 +266,9 @@ func (s *storeImpl) Search(_ context.Context, table string, query *qsearch.Query
 		})
 	}
 
-	res, err := s.client.MultiSearch.PerformWithContentType(&tsApi.MultiSearchParams{}, tsApi.MultiSearchSearchesParameter{
+	res, err := s.client.MultiSearch.PerformWithContentType(&tsApi.MultiSearchParams{
+		MaxCandidates: &maxCandidates,
+	}, tsApi.MultiSearchSearchesParameter{
 		Searches: params,
 	}, StreamContentType)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes
Allow returning more results if the prefix matches more number of documents.

## How best to test these changes

## Issue ticket number and link
