### PR TITLE
fix: Check on index, not on search field type

### DIFF
--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -1222,8 +1222,8 @@ func (runner *SearchQueryRunner) getSearchFields(coll *schema.DefaultCollection)
 			if err != nil {
 				return nil, err
 			}
-			if cf.DataType != schema.StringType {
-				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only string fields can be queried", sf)
+			if !cf.Indexed {
+				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
 			}
 			if cf.InMemoryName() != cf.Name() {
 				searchFields[i] = cf.InMemoryName()


### PR DESCRIPTION
## Describe your changes
When user is passing search fields to query we just need to check if the field is indexed. 

## How best to test these changes

## Issue ticket number and link
