### PR TITLE
fix: Change internal fields to _tigris prefix

### DIFF
--- a/schema/collection.go
+++ b/schema/collection.go
@@ -143,7 +143,11 @@ func NewDefaultCollection(id uint32, schVer int, factory *Factory, schemas Versi
 	validator.AdditionalProperties = false
 	disableAdditionalPropertiesAndAllowNullable(validator.Required, validator.Properties)
 
-	queryableFields := BuildQueryableFields(factory.Fields, nil)
+	var fieldsInSearch []tsApi.Field
+	if implicitSearchIndex != nil {
+		fieldsInSearch = implicitSearchIndex.fieldsInSearch
+	}
+	queryableFields := BuildQueryableFields(factory.Fields, fieldsInSearch)
 
 	schemaDeltas, err := buildSchemaDeltas(schemas)
 	if err != nil {

--- a/schema/reserved.go
+++ b/schema/reserved.go
@@ -30,9 +30,9 @@ const (
 )
 
 var ReservedFields = [...]string{
-	CreatedAt:           "created_at",
-	UpdatedAt:           "updated_at",
-	Metadata:            "metadata",
+	CreatedAt:           "_tigris_created_at",
+	UpdatedAt:           "_tigris_updated_at",
+	Metadata:            "_tigris_metadata",
 	IdToSearchKey:       "_tigris_id",
 	DateSearchKeyPrefix: "_tigris_date_",
 	SearchArrNullItem:   "_tigris_null",

--- a/schema/reserved_test.go
+++ b/schema/reserved_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsReservedField(t *testing.T) {
-	require.True(t, IsReservedField("created_at"))
-	require.True(t, IsReservedField("updated_at"))
+	require.True(t, IsReservedField("_tigris_created_at"))
+	require.True(t, IsReservedField("_tigris_updated_at"))
 	require.False(t, IsReservedField("id"))
 }

--- a/schema/search_test.go
+++ b/schema/search_test.go
@@ -110,7 +110,7 @@ func TestSearchIndex_CollectionSchema(t *testing.T) {
 		"id", "_tigris_id", "id_32", "product", "id_uuid", "ts", ToSearchDateKey("ts"), "price", "simple_items", "simple_object.name",
 		"simple_object.phone", "simple_object.address.street", "simple_object.details.nested_id", "simple_object.details.nested_obj.id",
 		"simple_object.details.nested_obj.name", "simple_object.details.nested_array", "simple_object.details.nested_string",
-		"created_at", "updated_at",
+		"_tigris_created_at", "_tigris_updated_at",
 	}
 
 	implicitSearchIndex := NewImplicitSearchIndex("t1", "t1", schFactory.Fields, nil)

--- a/server/services/v1/database/search_indexer_test.go
+++ b/server/services/v1/database/search_indexer_test.go
@@ -76,11 +76,11 @@ func TestPackSearchFields(t *testing.T) {
 			decData, err := util.JSONToMap(res)
 			require.NoError(t, err)
 
-			createdAt, err := decData["created_at"].(json.Number).Int64()
+			createdAt, err := decData[schema.ReservedFields[schema.CreatedAt]].(json.Number).Int64()
 			require.NoError(t, err)
 			require.Equal(t, createdAt, td.CreatedAt.UnixNano())
 
-			updatedAt, err := decData["updated_at"].(json.Number).Int64()
+			updatedAt, err := decData[schema.ReservedFields[schema.UpdatedAt]].(json.Number).Int64()
 			require.NoError(t, err)
 			require.Equal(t, updatedAt, td.UpdatedAt.UnixNano())
 		})
@@ -97,11 +97,11 @@ func TestPackSearchFields(t *testing.T) {
 		decData, err := util.JSONToMap(res)
 		require.NoError(t, err)
 
-		createdAt, err := decData["created_at"].(json.Number).Int64()
+		createdAt, err := decData[schema.ReservedFields[schema.CreatedAt]].(json.Number).Int64()
 		require.NoError(t, err)
 		require.Equal(t, createdAt, td.CreatedAt.UnixNano())
 
-		updatedAt := decData["updated_at"]
+		updatedAt := decData[schema.ReservedFields[schema.UpdatedAt]]
 		require.Nil(t, updatedAt)
 	})
 
@@ -242,27 +242,30 @@ func TestUnpackSearchFields(t *testing.T) {
 	})
 
 	t.Run("created_at metadata gets populated", func(t *testing.T) {
+		createdAt := any(json.Number("1666054267528106000"))
 		doc := map[string]any{
 			"id":         "123",
-			"created_at": json.Number("1666054267528106000"),
+			"created_at": createdAt,
 		}
 		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
+		require.True(t, len(unpacked) == 0)
 		require.NoError(t, err)
 		require.Empty(t, unpacked)
-		expected, _ := doc["created_at"].(json.Number).Int64()
+		expected, _ := createdAt.(json.Number).Int64()
 		require.Equal(t, expected, td.CreatedAt.UnixNano())
 		require.Nil(t, td.UpdatedAt)
 	})
 
 	t.Run("updated_at metadata gets populated", func(t *testing.T) {
+		updatedAt := any(json.Number("1666054267528106000"))
 		doc := map[string]any{
 			"id":         "123",
-			"updated_at": json.Number("1666054267528106000"),
+			"updated_at": updatedAt,
 		}
 		_, td, unpacked, err := UnpackSearchFields(doc, emptyColl)
 		require.NoError(t, err)
 		require.Empty(t, unpacked)
-		expected, _ := doc["updated_at"].(json.Number).Int64()
+		expected, _ := updatedAt.(json.Number).Int64()
 		require.Equal(t, expected, td.UpdatedAt.UnixNano())
 		require.Nil(t, td.CreatedAt)
 	})


### PR DESCRIPTION
## Describe your changes
This change will allow users to have `created_at/updated_at` field in the model. After this is deployed, the internal timestamps will be indexed using `_tigris_` prefix. 

## How best to test these changes

## Issue ticket number and link
