### PR TITLE
Upgrade Typesense to 0.24.0

### DIFF
--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   tigris_search:
     container_name: tigris_search
-    image: typesense/typesense:0.23.1
+    image: typesense/typesense:0.24.0
     environment:
       - TYPESENSE_DATA_DIR=/tmp
       - TYPESENSE_API_KEY=ts_test_key


### PR DESCRIPTION
Upgrading tigris-search typesense image to 0.24.0
`image: typesense/typesense:0.23.1` -> `image: typesense/typesense:0.24.0`

[TIG-1012](https://tigrisdata.atlassian.net/browse/TIG-1012)


[TIG-1012]: https://tigrisdata.atlassian.net/browse/TIG-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ