### PR TITLE
Bump up ts to 0.24

### DIFF
--- a/scripts/install_local_docker_deps.sh
+++ b/scripts/install_local_docker_deps.sh
@@ -61,7 +61,7 @@ echo "docker:docker@127.0.0.1:4500" >/etc/foundationdb/fdb.cluster
 dpkg --force-confold --configure foundationdb-server
 rm -f "$FDB_PACKAGE_PATH"
 
-TS_RELEASE_VERSION="0.23.1"
+TS_RELEASE_VERSION="0.24.0"
 TS_PACKAGE_NAME="typesense-server-${TS_RELEASE_VERSION}-${ARCH}.deb"
 TS_PACKAGE_PATH="$(mktemp -p /tmp/ -u)/${TS_PACKAGE_NAME}"
 curl --create-dirs -Lo "$TS_PACKAGE_PATH" "https://dl.typesense.org/releases/${TS_RELEASE_VERSION}/${TS_PACKAGE_NAME}"


### PR DESCRIPTION
We also need to define the new typesense image version in `scripts/install_local_docker_deps.sh`



