### PR TITLE
fix: Query using empty string quotes

### DIFF
--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -59,12 +59,8 @@ func (s *Selector) MatchesDoc(doc map[string]interface{}) bool {
 	var val value.Value
 	switch s.Field.DataType {
 	case schema.StringType:
-		if s.Collation == nil || s.Collation.IsCaseSensitive() {
-			val = value.NewStringValue(v.(string), s.Collation)
-		} else {
-			// if it is 'ci' then no need to apply filter as indexing store returns case-sensitive results.
-			return true
-		}
+		// there can be special characters in the string, we need to perform exact match.
+		val = value.NewStringValue(v.(string), s.Collation)
 	case schema.DoubleType:
 		// this method is only used with indexing store and it returns `json.Number` for all numeric types
 		var err error

--- a/value/value.go
+++ b/value/value.go
@@ -48,7 +48,7 @@ type Value interface {
 }
 
 func NewValueUsingCollation(fieldType schema.FieldType, value []byte, collation *Collation) (Value, error) {
-	if fieldType == schema.StringType {
+	if fieldType == schema.StringType && len(value) > 0 {
 		return NewStringValue(string(value), collation), nil
 	}
 


### PR DESCRIPTION
## Describe your changes
This allows querying using empty quotes, plus also adding a check so that querying on special characters also works. 

## How best to test these changes

## Issue ticket number and link
