### PR TITLE
feat: Add KV Atomic Add/Read/ReadRange

### DIFF
--- a/server/transaction/manager.go
+++ b/server/transaction/manager.go
@@ -48,6 +48,9 @@ type BaseTx interface {
 	Get(ctx context.Context, key []byte, isSnapshot bool) (kv.Future, error)
 	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
 	SetVersionstampedKey(ctx context.Context, key []byte, value []byte) error
+	AtomicAdd(ctx context.Context, key keys.Key, value int64) error
+	AtomicRead(ctx context.Context, key keys.Key) (int64, error)
+	AtomicReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key, isSnapshot bool) (kv.AtomicIterator, error)
 }
 
 type Tx interface {
@@ -232,7 +235,7 @@ func (s *TxSession) ReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key,
 		return s.kTx.ReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), nil, isSnapshot)
 	}
 
-	return s.kTx.ReadRange(ctx, lKey.Table(), nil, kv.BuildKey(rKey.IndexParts()...), isSnapshot)
+	return s.kTx.ReadRange(ctx, rKey.Table(), nil, kv.BuildKey(rKey.IndexParts()...), isSnapshot)
 }
 
 func (s *TxSession) SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error {
@@ -255,6 +258,45 @@ func (s *TxSession) SetVersionstampedKey(ctx context.Context, key []byte, value 
 	}
 
 	return s.kTx.SetVersionstampedKey(ctx, key, value)
+}
+
+func (s *TxSession) AtomicAdd(ctx context.Context, key keys.Key, value int64) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return err
+	}
+
+	return s.kTx.AtomicAdd(ctx, key.Table(), kv.BuildKey(key.IndexParts()...), value)
+}
+
+func (s *TxSession) AtomicRead(ctx context.Context, key keys.Key) (int64, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return 0, err
+	}
+
+	return s.kTx.AtomicRead(ctx, key.Table(), kv.BuildKey(key.IndexParts()...))
+}
+
+func (s *TxSession) AtomicReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key, isSnapshot bool) (kv.AtomicIterator, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if err := s.validateSession(); err != nil {
+		return nil, err
+	}
+
+	if rKey != nil && lKey != nil {
+		return s.kTx.AtomicReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), kv.BuildKey(rKey.IndexParts()...), isSnapshot)
+	} else if lKey != nil {
+		return s.kTx.AtomicReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), nil, isSnapshot)
+	}
+
+	return s.kTx.AtomicReadRange(ctx, rKey.Table(), nil, kv.BuildKey(rKey.IndexParts()...), isSnapshot)
 }
 
 func (s *TxSession) Get(ctx context.Context, key []byte, isSnapshot bool) (kv.Future, error) {

--- a/store/kv/base.go
+++ b/store/kv/base.go
@@ -35,6 +35,9 @@ type baseKV interface {
 	UpdateRange(ctx context.Context, table []byte, lKey Key, rKey Key, apply func([]byte) ([]byte, error)) (int32, error)
 	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
 	Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error)
+	AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error
+	AtomicRead(ctx context.Context, table []byte, key Key) (int64, error)
+	AtomicReadRange(ctx context.Context, table []byte, lkey Key, rkey Key, isSnapshot bool) (AtomicIterator, error)
 }
 
 type baseIterator interface {

--- a/store/kv/fdb.go
+++ b/store/kv/fdb.go
@@ -15,7 +15,9 @@
 package kv
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -204,6 +206,32 @@ func (d *fdbkv) SetVersionstampedKey(ctx context.Context, key []byte, value []by
 	return err
 }
 
+func (d *fdbkv) AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error {
+	_, err := d.txWithRetry(ctx, func(tr fdb.Transaction) (interface{}, error) {
+		return nil, (&ftx{d: d, tx: &tr}).AtomicAdd(ctx, table, key, value)
+	})
+	return err
+}
+
+func (d *fdbkv) AtomicRead(ctx context.Context, table []byte, key Key) (int64, error) {
+	val, err := d.txWithRetry(ctx, func(tr fdb.Transaction) (interface{}, error) {
+		return (&ftx{d: d, tx: &tr}).AtomicRead(ctx, table, key)
+	})
+	return val.(int64), err
+}
+
+func (d *fdbkv) AtomicReadRange(ctx context.Context, table []byte, lKey Key, rKey Key, isSnapshot bool) (AtomicIterator, error) {
+	tx, err := d.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	it, err := tx.ReadRange(ctx, table, lKey, rKey, isSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	return &AtomicIteratorImpl{it, nil}, nil
+}
+
 func (d *fdbkv) Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error) {
 	val, err := d.txWithRetry(ctx, func(tr fdb.Transaction) (interface{}, error) {
 		return (&ftx{d: d, tx: &tr}).Get(ctx, key, isSnapshot)
@@ -346,6 +374,18 @@ func (b *fbatch) SetVersionstampedValue(_ context.Context, _ []byte, _ []byte) e
 
 func (b *fbatch) SetVersionstampedKey(_ context.Context, _ []byte, _ []byte) error {
 	return fmt.Errorf("batch doesn't support setting versionstamped key")
+}
+
+func (b *fbatch) AtomicAdd(_ context.Context, _ []byte, _ Key, _ int64) error {
+	return fmt.Errorf("batch doesn't support atomic add")
+}
+
+func (b *fbatch) AtomicRead(_ context.Context, _ []byte, _ Key) (int64, error) {
+	return 0, fmt.Errorf("batch doesn't support atomic read")
+}
+
+func (b *fbatch) AtomicReadRange(_ context.Context, _ []byte, _ Key, _ Key, _ bool) (AtomicIterator, error) {
+	return nil, fmt.Errorf("batch doesn't support atomic read")
 }
 
 func (b *fbatch) Get(_ context.Context, _ []byte, _ bool) (Future, error) {
@@ -558,6 +598,40 @@ func (t *ftx) SetVersionstampedKey(_ context.Context, key []byte, value []byte) 
 	return nil
 }
 
+func (t *ftx) AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error {
+	fdbKey := getFDBKey(table, key)
+
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.LittleEndian, value)
+	if err != nil {
+		return err
+	}
+	encVal := buf.Bytes()
+
+	t.tx.Add(fdbKey, encVal)
+
+	return nil
+}
+
+func (t *ftx) AtomicRead(ctx context.Context, table []byte, key Key) (int64, error) {
+	fdbKey := getFDBKey(table, key)
+	raw, err := t.tx.Get(fdbKey).Get()
+	if err != nil {
+		return 0, err
+	}
+
+	return fdbByteToInt64(&raw)
+}
+
+func (t *ftx) AtomicReadRange(ctx context.Context, table []byte, lkey Key, rkey Key, isSnapshot bool) (AtomicIterator, error) {
+	iter, err := t.ReadRange(ctx, table, lkey, rkey, isSnapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AtomicIteratorImpl{iter, nil}, nil
+}
+
 func (t *ftx) Get(_ context.Context, key []byte, isSnapshot bool) (Future, error) {
 	if isSnapshot {
 		return t.tx.Snapshot().Get(fdb.Key(key)), nil
@@ -706,4 +780,10 @@ func setTxTimeout(tx *fdb.Transaction, ms int64) error {
 	}
 
 	return tx.Options().SetTimeout(ms)
+}
+
+func fdbByteToInt64(value *[]byte) (int64, error) {
+	var numVal int64
+	err := binary.Read(bytes.NewReader(*value), binary.LittleEndian, &numVal)
+	return numVal, err
 }

--- a/store/kv/noop_store.go
+++ b/store/kv/noop_store.go
@@ -25,6 +25,11 @@ type NoopIterator struct{}
 func (n *NoopIterator) Next(value *KeyValue) bool { return false }
 func (n *NoopIterator) Err() error                { return nil }
 
+type NoopFDBTypeIterator struct{}
+
+func (n *NoopFDBTypeIterator) Next(value *FdbBaseKeyValue[int64]) bool { return false }
+func (n *NoopFDBTypeIterator) Err() error                              { return nil }
+
 type NoopTx struct {
 	*NoopKV
 }
@@ -78,6 +83,18 @@ func (n *NoopKV) SetVersionstampedValue(ctx context.Context, key []byte, value [
 
 func (n *NoopKV) SetVersionstampedKey(ctx context.Context, key []byte, value []byte) error {
 	return nil
+}
+
+func (n *NoopKV) AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error {
+	return nil
+}
+
+func (n *NoopKV) AtomicRead(ctx context.Context, table []byte, key Key) (int64, error) {
+	return 0, nil
+}
+
+func (n *NoopKV) AtomicReadRange(ctx context.Context, table []byte, lkey Key, rkey Key, isSnapshot bool) (AtomicIterator, error) {
+	return &NoopFDBTypeIterator{}, nil
 }
 
 func (n *NoopKV) Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error) {


### PR DESCRIPTION
## Describe your changes

Adds api to read, range, and update atomic values in the KV store. Based on the FDB docs, the value is LittleEndian encoded before being written to FDB.

This is the first PR as part of the secondary indexes work. We use the atomic values to keep track of the size of the index and the number of rows.

## How best to test these changes

Tests should pass

## Issue ticket number and link
Closes #789 
