### PR TITLE
Separate logs dump on tests failure into own step

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -17,10 +17,26 @@ jobs:
         with:
           submodules: true
 
+      # this is just to separate deps and docker pull logs from the main tests step
+      - name: Warmup tests
+        run: make run
+
       - name: Run tests
-        run: make test || ( docker-compose -f test/docker/docker-compose.yml logs && false )
+        id: tests
+        run: make test
+        continue-on-error: true
         env:
           TEST_PARAM: "-coverprofile=coverage.out -covermode=atomic"
+
+      - name: Server logs
+        if: steps.tests.outcome != 'success'
+        run: docker-compose -f test/docker/docker-compose.yml logs
+
+      - name: Check tests status
+        if: steps.tests.outcome != 'success'
+        run: |
+          echo "^^ Tests failed. Check tests output and logs in the steps above ^^"
+          exit 1
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -18,13 +18,29 @@
 
 set -e
 
+VERSION=1.20
 ARCH=$(dpkg --print-architecture)
+FN="go${VERSION}.linux-${ARCH}.tar.gz"
 
-VERSION=1.19.2
+case "$ARCH" in
+"amd64")
+  SHA256="5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1"
+  ;;
+"arm64")
+  SHA256="17700b6e5108e2a2c3b1a43cd865d3f9c66b7f1c5f0cec26d3672cc131cc0994"
+  ;;
+*)
+  echo "No supported architecture."
+  exit 1
+  ;;
+esac
+
+wget "https://go.dev/dl/$FN"
+echo "$SHA256  $FN" | shasum -a 256 -c
+
 mkdir -p /usr/local
-wget "https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz"
-tar -C /usr/local -xzf "go${VERSION}.linux-${ARCH}.tar.gz"
-rm "go${VERSION}.linux-${ARCH}.tar.gz"
+tar -C /usr/local -xzf "$FN"
+rm "$FN"
 
 export PATH=$PATH:/usr/local/go/bin
 


### PR DESCRIPTION
Separate test action log output into multiple steps,
in order to simplify spotting the failure:

* Warmup tests
  This step hides useless deps installation and docker pull logs

* Run tests
  This step contains useful logs and should be checked on tests failure.

* Server logs
  This step is executed on "Run tests" step failure and can be used
  for deeper debugging of the failure.

* Check tests status
  This step fails the action if "Run tests" is not successful

This diff also updates Go installation scripts to use v1.20

The tigrisdata/tigris-build-base docker image has been updated to
include Go 1.20 too.
