### PR TITLE
fixes for secondary indexes and integration tests

### DIFF
--- a/internal/data.go
+++ b/internal/data.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	UserTableKeyPrefix      = []byte("data")
-	SecondaryTableKeyPrefix = []byte("sidx")
+	SecondaryTableKeyPrefix = []byte("idx")
 	PartitionKeyPrefix      = []byte("part")
 	CacheKeyPrefix          = "cache"
 )

--- a/internal/data.go
+++ b/internal/data.go
@@ -25,9 +25,10 @@ import (
 )
 
 var (
-	UserTableKeyPrefix = []byte("data")
-	PartitionKeyPrefix = []byte("part")
-	CacheKeyPrefix     = "cache"
+	UserTableKeyPrefix      = []byte("data")
+	SecondaryTableKeyPrefix = []byte("sidx")
+	PartitionKeyPrefix      = []byte("part")
+	CacheKeyPrefix          = "cache"
 )
 
 var bh codec.BincHandle

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -43,6 +43,8 @@ type DefaultCollection struct {
 	Name string
 	// EncodedName is the encoded name of the collection.
 	EncodedName []byte
+	// EncodedSecondaryName is the encoded name of the collection's Secondary Index.
+	EncodedSecondaryName []byte
 	// Fields are derived from the user schema.
 	Fields []*Field
 	// Indexes is a wrapper on the indexes part of this collection.

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -43,8 +43,8 @@ type DefaultCollection struct {
 	Name string
 	// EncodedName is the encoded name of the collection.
 	EncodedName []byte
-	// EncodedSecondaryName is the encoded name of the collection's Secondary Index.
-	EncodedSecondaryName []byte
+	// EncodedTableIndexName is the encoded name of the collection's Secondary Index.
+	EncodedTableIndexName []byte
 	// Fields are derived from the user schema.
 	Fields []*Field
 	// Indexes is a wrapper on the indexes part of this collection.

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -39,7 +39,7 @@ type Config struct {
 	Auth           AuthConfig           `yaml:"auth" json:"auth"`
 	Cdc            CdcConfig            `yaml:"cdc" json:"cdc"`
 	Search         SearchConfig         `yaml:"search" json:"search"`
-	SecondaryIndex SecondaryIndexConfig `yaml:"secondary_index" json:"secondary_index"`
+	SecondaryIndex SecondaryIndexConfig `mapstructure:"secondary_index" yaml:"secondary_index" json:"secondary_index"`
 	Cache          CacheConfig          `yaml:"cache" json:"cache"`
 	Tracing        TracingConfig        `yaml:"tracing" json:"tracing"`
 	Metrics        MetricsConfig        `yaml:"metrics" json:"metrics"`

--- a/server/metadata/key_encoder.go
+++ b/server/metadata/key_encoder.go
@@ -47,6 +47,8 @@ type Encoder interface {
 
 	// EncodeTableName returns encoded bytes which are formed by combining namespace, database, and collection.
 	EncodeTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error)
+	// EncodeSecondaryIndexTableName returns encoded bytes for the table name of a collections secondary index.
+	EncodeSecondaryIndexTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error)
 	EncodePartitionTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error)
 	// EncodeIndexName returns encoded bytes for the index name
 	EncodeIndexName(idx *schema.Index) []byte
@@ -81,6 +83,10 @@ type DictKeyEncoder struct{}
 // If both database and collections are omitted then result name includes all databases in the namespace.
 func (d *DictKeyEncoder) EncodeTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error) {
 	return d.encodedTableName(ns, db, coll, internal.UserTableKeyPrefix), nil
+}
+
+func (d *DictKeyEncoder) EncodeSecondaryIndexTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error) {
+	return d.encodedTableName(ns, db, coll, internal.SecondaryTableKeyPrefix), nil
 }
 
 func (d *DictKeyEncoder) EncodePartitionTableName(ns Namespace, db *Database, coll *schema.DefaultCollection) ([]byte, error) {

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -639,6 +639,12 @@ func (tenant *Tenant) reloadDatabase(ctx context.Context, tx transaction.Tx, dbN
 		}
 		collection.EncodedName = encName
 
+		encIdxName, err := tenant.Encoder.EncodeSecondaryIndexTableName(tenant.namespace, database, collection)
+		if err != nil {
+			return nil, err
+		}
+		collection.EncodedSecondaryName = encIdxName
+
 		database.collections[coll] = newCollectionHolder(meta.ID, coll, collection, idxMeta)
 		database.idToCollectionMap[meta.ID] = coll
 	}
@@ -1221,6 +1227,12 @@ func (tenant *Tenant) createCollection(ctx context.Context, tx transaction.Tx, d
 
 	collection.EncodedName = encName
 
+	encIdxName, err := tenant.Encoder.EncodeSecondaryIndexTableName(tenant.namespace, database, collection)
+	if err != nil {
+		return err
+	}
+	collection.EncodedSecondaryName = encIdxName
+
 	database.collections[schFactory.Name] = newCollectionHolder(collMeta.ID, schFactory.Name, collection, idxMeta)
 	if config.DefaultConfig.Search.WriteEnabled {
 		// only creating implicit index here
@@ -1301,6 +1313,12 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 	}
 
 	collection.EncodedName = encName
+
+	encIdxName, err := tenant.Encoder.EncodeSecondaryIndexTableName(tenant.namespace, database, collection)
+	if err != nil {
+		return err
+	}
+	collection.EncodedSecondaryName = encIdxName
 
 	// recreating collection holder is fine because we are working on databaseClone and also has a lock on the tenant
 	database.collections[schFactory.Name] = newCollectionHolder(c.id, schFactory.Name, collection, c.idxMeta)
@@ -1635,6 +1653,7 @@ func (c *collectionHolder) clone() *collectionHolder {
 
 	copyC.collection.SchemaDeltas = c.collection.SchemaDeltas
 	copyC.collection.EncodedName = c.collection.EncodedName
+	copyC.collection.EncodedSecondaryName = c.collection.EncodedSecondaryName
 
 	copyC.idxMeta = make(map[string]*IndexMetadata)
 	for k, v := range c.idxMeta {

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -643,7 +643,7 @@ func (tenant *Tenant) reloadDatabase(ctx context.Context, tx transaction.Tx, dbN
 		if err != nil {
 			return nil, err
 		}
-		collection.EncodedSecondaryName = encIdxName
+		collection.EncodedTableIndexName = encIdxName
 
 		database.collections[coll] = newCollectionHolder(meta.ID, coll, collection, idxMeta)
 		database.idToCollectionMap[meta.ID] = coll
@@ -1231,7 +1231,7 @@ func (tenant *Tenant) createCollection(ctx context.Context, tx transaction.Tx, d
 	if err != nil {
 		return err
 	}
-	collection.EncodedSecondaryName = encIdxName
+	collection.EncodedTableIndexName = encIdxName
 
 	database.collections[schFactory.Name] = newCollectionHolder(collMeta.ID, schFactory.Name, collection, idxMeta)
 	if config.DefaultConfig.Search.WriteEnabled {
@@ -1318,7 +1318,7 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 	if err != nil {
 		return err
 	}
-	collection.EncodedSecondaryName = encIdxName
+	collection.EncodedTableIndexName = encIdxName
 
 	// recreating collection holder is fine because we are working on databaseClone and also has a lock on the tenant
 	database.collections[schFactory.Name] = newCollectionHolder(c.id, schFactory.Name, collection, c.idxMeta)
@@ -1653,7 +1653,7 @@ func (c *collectionHolder) clone() *collectionHolder {
 
 	copyC.collection.SchemaDeltas = c.collection.SchemaDeltas
 	copyC.collection.EncodedName = c.collection.EncodedName
-	copyC.collection.EncodedSecondaryName = c.collection.EncodedSecondaryName
+	copyC.collection.EncodedTableIndexName = c.collection.EncodedTableIndexName
 
 	copyC.idxMeta = make(map[string]*IndexMetadata)
 	for k, v := range c.idxMeta {

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -273,8 +273,8 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 				}
 			}
 		} else if config.DefaultConfig.SecondaryIndex.WriteEnabled {
-			if err := indexer.Update(ctx, tx, newData, row.Data, key.IndexParts()); ulog.E(err) {
-				return Response{}, nil, err
+			if err = indexer.Update(ctx, tx, newData, row.Data, key.IndexParts()); ulog.E(err) {
+				return Response{}, ctx, err
 			}
 		}
 		if err = tx.Replace(ctx, newKey, newData, isUpdate); ulog.E(err) {
@@ -525,7 +525,6 @@ func (runner *StreamingQueryRunner) Run(ctx context.Context, tx transaction.Tx, 
 	}
 
 	ctx = runner.instrumentRunner(ctx, options)
-
 	if options.inMemoryStore {
 		if err = runner.iterateOnIndexingStore(ctx, coll, options); err != nil {
 			return Response{}, ctx, err

--- a/server/services/v1/database/search_indexer.go
+++ b/server/services/v1/database/search_indexer.go
@@ -97,10 +97,6 @@ func (i *SearchIndexer) OnPostCommit(ctx context.Context, tenant *metadata.Tenan
 				return err
 			}
 
-			if tableData == nil {
-				continue
-			}
-
 			searchData, err := PackSearchFields(ctx, tableData, collection, searchKey)
 			if err != nil {
 				return err

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -90,11 +90,11 @@ type IndexerUpdateSet struct {
 }
 
 func genRowCountKey(coll *schema.DefaultCollection, fieldPath string) keys.Key {
-	return keys.NewKey(coll.EncodedSecondaryName, coll.Indexes.SecondaryIndex.Name, InfoSubspace, CountSubSpace, fieldPath)
+	return keys.NewKey(coll.EncodedTableIndexName, coll.Indexes.SecondaryIndex.Name, InfoSubspace, CountSubSpace, fieldPath)
 }
 
 func genRowSizeKey(coll *schema.DefaultCollection, fieldPath string) keys.Key {
-	return keys.NewKey(coll.EncodedSecondaryName, coll.Indexes.SecondaryIndex.Name, InfoSubspace, SizeSubSpace, fieldPath)
+	return keys.NewKey(coll.EncodedTableIndexName, coll.Indexes.SecondaryIndex.Name, InfoSubspace, SizeSubSpace, fieldPath)
 }
 
 type SecondaryIndexer struct {
@@ -111,8 +111,8 @@ func NewSecondaryIndexer(coll *schema.DefaultCollection) *SecondaryIndexer {
 
 // For testing only, it reads the full index.
 func (q *SecondaryIndexer) scanIndex(ctx context.Context, tx transaction.Tx) (kv.Iterator, error) {
-	start := keys.NewKey(q.coll.EncodedSecondaryName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
-	end := keys.NewKey(q.coll.EncodedSecondaryName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
+	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
+	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
 	return tx.ReadRange(ctx, start, end, false)
 }
 
@@ -146,8 +146,8 @@ func (q *SecondaryIndexer) IndexInfo(ctx context.Context, tx transaction.Tx) (*S
 }
 
 func (q *SecondaryIndexer) aggregateInfo(ctx context.Context, tx transaction.Tx, subSpace string) (int64, error) {
-	lkey := keys.NewKey(q.coll.EncodedSecondaryName, q.coll.Indexes.SecondaryIndex.Name, InfoSubspace, subSpace, "")
-	rkey := keys.NewKey(q.coll.EncodedSecondaryName, q.coll.Indexes.SecondaryIndex.Name, InfoSubspace, subSpace, 0xFF)
+	lkey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, InfoSubspace, subSpace, "")
+	rkey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, InfoSubspace, subSpace, 0xFF)
 	iter, err := tx.AtomicReadRange(ctx, lkey, rkey, false)
 	if err != nil {
 		return 0, err
@@ -195,7 +195,7 @@ func (q *SecondaryIndexer) Index(ctx context.Context, tx transaction.Tx, td *int
 }
 
 func (q *SecondaryIndexer) Update(ctx context.Context, tx transaction.Tx, newTd *internal.TableData, oldTd *internal.TableData, primaryKey []interface{}) error {
-	if len(q.coll.EncodedSecondaryName) == 0 {
+	if len(q.coll.EncodedTableIndexName) == 0 {
 		return fmt.Errorf("Could not index collection %s, encoded table not set", q.coll.Name)
 	}
 	updateSet, err := q.buildAddAndRemoveKVs(newTd, oldTd, primaryKey)
@@ -353,7 +353,7 @@ func (q *SecondaryIndexer) buildTSRows(tableData *internal.TableData) ([]IndexRo
 
 func (q *SecondaryIndexer) buildIndexKey(row IndexRow, primaryKey []interface{}) keys.Key {
 	version := getFieldVersion(row.name, q.coll)
-	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedSecondaryName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
+	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
 }
 
 func (q *SecondaryIndexer) createKeysAndIndexInfo(primaryKey []interface{}, rows []IndexRow) ([]keys.Key, map[string]int64, map[string]int64) {

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -131,6 +131,54 @@ func TestIndexingCreateSimpleKVsforDoc(t *testing.T) {
 	})
 }
 
+func TestIndexingMissing(t *testing.T) {
+	reqSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer"
+			},
+			"double_f": {
+				"type": "number"
+			},
+			"a_string": {
+				"type": "string"
+			},
+			"updated": {
+				"type": "string",
+				"format": "date-time"
+			},
+			"arr": {
+				"type": "array",
+				"items": {
+					"type": "integer"
+				}
+			},
+			"arr2": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"nested": { "type": "boolean" }
+					}
+				}
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	indexStore := setupTest(t, reqSchema)
+	td, primaryKey := createDoc(`{"id":1`)
+	updateSet, err := indexStore.buildAddAndRemoveKVs(td, nil, primaryKey)
+	assert.NoError(t, err)
+	expected := [][]interface{}{
+		{"skey", KVSubspace, "_tigris_created_at", 1, td.CreatedAt.ToRFC3339(), 0, 1},
+		{"skey", KVSubspace, "_tigris_updated_at", 1, td.UpdatedAt.ToRFC3339(), 0, 1},
+		{"skey", KVSubspace, "id", 1, int64(1), 0, 1},
+	}
+	assertKVs(t, expected, updateSet.addKeys, updateSet.addCounts)
+}
+
 func TestIndexingNull(t *testing.T) {
 	reqSchema := []byte(`{
 		"title": "t1",
@@ -467,13 +515,15 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	assert.NoError(t, kvStore.DropTable(ctx, []byte("t1")))
 	assert.NoError(t, kvStore.CreateTable(ctx, []byte("t1")))
+	assert.NoError(t, kvStore.DropTable(ctx, []byte("sidx1")))
+	assert.NoError(t, kvStore.CreateTable(ctx, []byte("sidx1")))
 	indexStore := setupTest(t, reqSchema)
 
 	tm := transaction.NewManager(kvStore)
 
 	t.Run("insert", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedName)
+		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
 		tx, err := tm.StartTx(ctx)
 		assert.NoError(t, err)
 
@@ -508,7 +558,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	t.Run("update", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedName)
+		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
 		td, pk := createDoc(`{"id":1, "double_f":2,"created":"2023-01-16T12:55:17.304154Z","updated": "2023-01-16T12:55:17.304154Z", "arr":[1,2]}`)
 
 		tx, err := tm.StartTx(ctx)
@@ -564,7 +614,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedName)
+		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
 		tx, err := tm.StartTx(ctx)
 		assert.NoError(t, err)
 
@@ -622,6 +672,7 @@ func setupTest(t *testing.T, reqSchema []byte) *SecondaryIndexer {
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	assert.NoError(t, err)
 	coll.EncodedName = []byte("t1")
+	coll.EncodedSecondaryName = []byte("sidx1")
 	return NewSecondaryIndexer(coll)
 }
 

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -523,7 +523,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	t.Run("insert", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
+		_ = kvStore.DropTable(ctx, coll.EncodedTableIndexName)
 		tx, err := tm.StartTx(ctx)
 		assert.NoError(t, err)
 
@@ -558,7 +558,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	t.Run("update", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
+		_ = kvStore.DropTable(ctx, coll.EncodedTableIndexName)
 		td, pk := createDoc(`{"id":1, "double_f":2,"created":"2023-01-16T12:55:17.304154Z","updated": "2023-01-16T12:55:17.304154Z", "arr":[1,2]}`)
 
 		tx, err := tm.StartTx(ctx)
@@ -614,7 +614,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		coll := indexStore.coll
-		_ = kvStore.DropTable(ctx, coll.EncodedSecondaryName)
+		_ = kvStore.DropTable(ctx, coll.EncodedTableIndexName)
 		tx, err := tm.StartTx(ctx)
 		assert.NoError(t, err)
 
@@ -672,7 +672,7 @@ func setupTest(t *testing.T, reqSchema []byte) *SecondaryIndexer {
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	assert.NoError(t, err)
 	coll.EncodedName = []byte("t1")
-	coll.EncodedSecondaryName = []byte("sidx1")
+	coll.EncodedTableIndexName = []byte("sidx1")
 	return NewSecondaryIndexer(coll)
 }
 

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - TIGRIS_SERVER_SEARCH_AUTH_KEY=ts_test_key
       - TIGRIS_SERVER_SEARCH_HOST=tigris_search
       - TIGRIS_SERVER_TRACING_ENABLED=true
+      - TIGRIS_SERVER_SECONDARY_INDEX_WRITE_ENABLED=true
       - GOCOVERDIR=/tmp/tigris_coverdata
     build:
       context: ../../
@@ -91,6 +92,7 @@ services:
       - TIGRIS_SERVER_SEARCH_HOST=tigris_search
       - TIGRIS_SERVER_LOG_FORMAT=console
       - TIGRIS_SERVER_CDC_ENABLED=true
+      - TIGRIS_SERVER_SECONDARY_INDEX_WRITE_ENABLED=true
     build:
       context: ../../
       dockerfile: docker/Dockerfile

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -37,7 +37,6 @@ import (
 func TestInsert_Bad_NotFoundRequest(t *testing.T) {
 	db, coll := setupTests(t)
 	defer cleanupTests(t, db)
-
 	cases := []struct {
 		databaseName   string
 		collectionName string
@@ -1823,7 +1822,6 @@ func TestUpdate_Limit(t *testing.T) {
 func TestUpdate_UsingCollation(t *testing.T) {
 	db, coll := setupTests(t)
 	defer cleanupTests(t, db)
-
 	inputDocument := []Doc{
 		{
 			"pkey_int":     110,
@@ -1882,7 +1880,6 @@ func TestUpdate_UsingCollation(t *testing.T) {
 		Object().
 		ValueEqual("status", "updated").
 		ValueEqual("modified_count", 2)
-
 	outDocument := []Doc{
 		{
 			"pkey_int":     110,
@@ -1917,7 +1914,6 @@ func TestUpdate_UsingCollation(t *testing.T) {
 func TestUpdate_OnAnyField(t *testing.T) {
 	db, coll := setupTests(t)
 	defer cleanupTests(t, db)
-
 	inputDocument := []Doc{
 		{
 			"pkey_int":           110,
@@ -4345,7 +4341,7 @@ func readByFilter(t *testing.T, db string, collection string, filter Map, fields
 	if len(order) > 0 {
 		payload["sort"] = order
 	}
-	if options!= nil {
+	if options != nil {
 		payload["options"] = options
 	}
 


### PR DESCRIPTION
## Describe your changes

chore: Enable secondary index writes for tests

fix: Ignore missing fields for arrrays fields

fix: Refactor the way the iterator was chosen for reading the docs.
There was a subtle bug because the variables were declared at the top.

fix: Add a separate table for secondary indexes so that it doesn't
interfere with scanning the primary key index and none of the index
writes get sent to the search indexer

## How best to test these changes

All tests should pass


## Issue ticket number and link
