### PR TITLE
Fix handling non existing metadata

### DIFF
--- a/server/metadata/namespace.go
+++ b/server/metadata/namespace.go
@@ -16,7 +16,6 @@ package metadata
 
 import (
 	"context"
-
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/keys"
 	"github.com/tigrisdata/tigris/server/defaults"
@@ -144,6 +143,12 @@ func (n *NamespaceSubspace) GetProjectMetadata(ctx context.Context, tx transacti
 		n.getProjKey(namespaceId, projName),
 		&projMetadata,
 	); err != nil {
+		// TODO: This is not needed if the cluster created after writing of this comment
+		// Project metadata inserted during project creation and should always exist.
+		if err == errors.ErrNotFound {
+			return &ProjectMetadata{}, nil
+		}
+
 		return nil, err
 	}
 

--- a/server/metadata/namespace_test.go
+++ b/server/metadata/namespace_test.go
@@ -63,6 +63,18 @@ func TestNamespacesSubspace(t *testing.T) {
 		require.Equal(t, errors.InvalidArgument("invalid metadataKey. "+namespaceKey+" is reserved"), n.InsertNamespaceMetadata(ctx, tx, 1, namespaceKey, testNSPayload))
 	})
 
+	t.Run("get_error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		n, tx, cleanup := initNSTest(t)
+		defer cleanup()
+
+		r, err := n.GetNamespaceMetadata(ctx, tx, 1, "meta-key-non-existing")
+		require.Equal(t, errors.ErrNotFound, err)
+		require.Nil(t, r)
+	})
+
 	t.Run("put_get_1", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -184,6 +196,18 @@ func TestNamespacesSubspace(t *testing.T) {
 		require.Equal(t, errors.InvalidArgument("invalid namespace, id must be greater than 0"), n.InsertProjectMetadata(ctx, tx, 0, "valid-db-name", dbMetadata))
 	})
 
+	t.Run("database_metadata_get_error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		n, tx, cleanup := initNSTest(t)
+		defer cleanup()
+
+		r, err := n.GetProjectMetadata(ctx, tx, 1, "meta-key-non-existing")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+	})
+
 	t.Run("database_metadata_put_get_1", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -224,8 +248,9 @@ func TestNamespacesSubspace(t *testing.T) {
 		err = n.DeleteProjectMetadata(ctx, tx, 1, "db-name")
 		require.NoError(t, err)
 
-		_, err = n.GetProjectMetadata(ctx, tx, 1, "db-name")
-		require.Equal(t, errors.ErrNotFound, err)
+		r, err := n.GetProjectMetadata(ctx, tx, 1, "db-name")
+		require.NoError(t, err)
+		require.NotNil(t, r)
 	})
 
 	t.Run("database_metadata_put_get_update_get", func(t *testing.T) {

--- a/server/metadata/user_test.go
+++ b/server/metadata/user_test.go
@@ -57,6 +57,15 @@ func TestUserSubspace(t *testing.T) {
 				testUserPayload))
 	})
 
+	t.Run("get_error", func(t *testing.T) {
+		tx, cleanup := initTx(t, ctx, tm)
+		defer cleanup()
+
+		r, err := u.GetUserMetadata(ctx, tx, 1, User, "uuu", "meta-key-non-existing")
+		require.Equal(t, errors.ErrNotFound, err)
+		require.Nil(t, r)
+	})
+
 	t.Run("put_get_1", func(t *testing.T) {
 		tx, cleanup := initTx(t, ctx, tm)
 		defer cleanup()

--- a/server/services/v1/auth/auth0.go
+++ b/server/services/v1/auth/auth0.go
@@ -385,7 +385,7 @@ func getAccessTokenUsingClientCredentials(ctx context.Context, req *api.GetAcces
 
 	metadataKey := createAccessTokenMetadataKey(req.GetClientSecret())
 	cachedToken, err := a.userStore.GetUserMetadata(ctx, tx, defaultNamespaceId, metadata.Application, req.GetClientId(), metadataKey)
-	if err != nil {
+	if err != nil && err != errors.ErrNotFound {
 		return nil, tokenError("Failed to get access token: reason = could not process cache", err)
 	}
 

--- a/server/services/v1/namespace_metadata_provider.go
+++ b/server/services/v1/namespace_metadata_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/transaction"
+	ulog "github.com/tigrisdata/tigris/util/log"
 )
 
 type NamespaceMetadataProvider interface {
@@ -44,9 +45,12 @@ func (a *DefaultNamespaceMetadataProvider) GetNamespaceMetadata(ctx context.Cont
 
 	val, err := a.namespaceStore.GetNamespaceMetadata(ctx, tx, namespaceId, req.GetMetadataKey())
 	if err != nil {
-		if err = tx.Rollback(ctx); err != nil {
-			log.Error().Err(err).Msg("Failed to rollback transaction.")
+		ulog.E(tx.Rollback(ctx))
+
+		if err == errors.ErrNotFound {
+			return nil, errors.NotFound("namespace metadata not found")
 		}
+
 		return nil, errors.Internal("Failed to read namespace metadata.")
 	}
 


### PR DESCRIPTION
* New project should always have corresponding metadata. This fixes the project which were created before metadata were introduced. (Are there such projects?)

* Handle ErrNotFound instead of relying on `nil, nil` in access token metadata processing.

* Return specific error to outside API callers.

