### PR TITLE
fix: Handle floating point greater than 32 bit properly

### DIFF
--- a/api/server/v1/validator.go
+++ b/api/server/v1/validator.go
@@ -18,7 +18,7 @@ import (
 	"regexp"
 )
 
-var validNamePattern = regexp.MustCompile("^[a-zA-Z]+[a-zA-Z0-9_-]+$")
+var validNamePattern = regexp.MustCompile("^[a-zA-Z_]+[a-zA-Z0-9_-]+$")
 
 type Validator interface {
 	Validate() error

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -62,6 +62,10 @@ func TestFieldBuilder_Build(t *testing.T) {
 				builder:  &FieldBuilder{FieldName: "test", Type: "integer", Primary: &boolTrue},
 				expError: nil,
 			},
+			{
+				builder:  &FieldBuilder{FieldName: "_test", Type: "integer"},
+				expError: nil,
+			},
 		}
 		for _, c := range cases {
 			_, err := c.builder.Build(false)

--- a/server/middleware/measure.go
+++ b/server/middleware/measure.go
@@ -145,7 +145,7 @@ func (w *wrappedStream) RecvMsg(m interface{}) error {
 func (w *wrappedStream) SendMsg(m interface{}) error {
 	err := w.ServerStream.SendMsg(m)
 	if err != nil {
-		return errors.Internal("Could not handle stream send message")
+		return errors.Internal("Could not handle stream send message err: %v", err.Error())
 	}
 	if w.measurement == nil {
 		return nil

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -628,5 +628,5 @@ func (runner *StreamingQueryRunner) iterate(coll *schema.DefaultCollection, iter
 		}
 	}
 
-	return row.Key, iterator.Interrupted()
+	return row.Key, createApiError(iterator.Interrupted())
 }

--- a/value/value.go
+++ b/value/value.go
@@ -26,6 +26,12 @@ import (
 	"github.com/tigrisdata/tigris/schema"
 )
 
+const (
+	// SmallestNonZeroNormalFloat32 is the smallest positive non-zero floating number. The go package version
+	// has the denormalized form which is higher than this.
+	SmallestNonZeroNormalFloat32 = 0x1p-126
+)
+
 type Comparable interface {
 	// CompareTo returns a value indicating the relationship between the receiver and the parameter.
 	//


### PR DESCRIPTION
## Describe your changes
1. This is fixing the floating point handling when the value can’t fit in 32-bit. The underlying indexing store is parsing the floating values in float(32bit) which means there are two problems:
  - The smallest floating point normal number needed to be less than ~ 1.1755e-38
  - The number has to be in the range -3.4e38/3.4e38

Outside of this range, an error is returned that was getting swallowed, resulting in empty documents returned for that query. I am fixing that and also handling queries for 64-bit floating-point numbers. 

2. This diff is also allowing collection names to start with `_`


## How best to test these changes

## Issue ticket number and link
