### PR TITLE
fix: Switched to RawStdEncoding base64 decoding

### DIFF
--- a/server/request/request.go
+++ b/server/request/request.go
@@ -332,12 +332,15 @@ func getMetadataFromToken(token string) (string, bool, string) {
 		return defaults.UnknownValue, false, ""
 	}
 
-	decodedToken, err := base64.StdEncoding.DecodeString(tokenParts[1])
+	var decodedToken []byte
+	decodedToken, err := base64.RawStdEncoding.DecodeString(tokenParts[1])
 	if err != nil {
+		stdDecoded, err := base64.StdEncoding.DecodeString(tokenParts[1])
 		if err != nil {
 			log.Error().Err(err).Msg("Could not base64 decode token")
 			return defaults.UnknownValue, false, ""
 		}
+		decodedToken = stdDecoded
 	}
 
 	namespaceCode, err := jsonparser.GetString(decodedToken, JWTTigrisClaimSpace, NamespaceCode)


### PR DESCRIPTION
## Describe your changes
JWT's payload part is base64 encoded. Decoding the payload after validation fails to decode with just RawStdEncoding's decode - This PR attempts to  fallback to StdEncoding decoding if the RawStdEncoding's decoder fails.

## How best to test these changes

## Issue ticket number and link
