### PR TITLE
fix: Log error only if during restart index reloading schema fails

### DIFF
--- a/schema/fields.go
+++ b/schema/fields.go
@@ -508,12 +508,18 @@ func (builder *QueryableFieldsBuilder) NewQueryableField(name string, f *Field, 
 			shouldIndex := IndexableField(f.DataType, subType)
 			indexed = &shouldIndex
 		}
+
+		ptrTrue := true
 		if f.DataType == ByteType && indexed == nil {
-			ptrTrue := true
 			indexed = &ptrTrue
 		}
 
 		faceted = f.Faceted
+
+		if sortable == nil  && (f.DataType == Int32Type || f.DataType == Int64Type || f.DataType == DoubleType || f.DataType == DateTimeType) {
+			// enable it by default for numeric fields
+			sortable = &ptrTrue
+		}
 	} else {
 		if indexed == nil {
 			shouldIndex := IndexableField(f.DataType, subType)

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -110,6 +110,10 @@ type IndexSourceValidator struct{}
 
 func (v *IndexSourceValidator) ValidateIndex(existing *SearchIndex, current *SearchFactory) error {
 	if len(existing.Source.Type) > 0 && existing.Source.Type != current.Source.Type {
+		if existing.Source.Type == "user" && current.Source.Type == SearchSourceExternal {
+			return nil
+		}
+
 		return errors.InvalidArgument(
 			"changing index source type is not allowed from: '%s', to: '%s'",
 			existing.Source.Type,

--- a/schema/search.go
+++ b/schema/search.go
@@ -92,7 +92,7 @@ func BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, e
 	} else {
 		source = *schema.Source
 	}
-	if schema.Source.Type != SearchSourceExternal && schema.Source.Type != SearchSourceTigris {
+	if schema.Source.Type != SearchSourceExternal && schema.Source.Type != SearchSourceTigris && schema.Source.Type != "user" {
 		return nil, errors.InvalidArgument("unsupported index source '%s'", schema.Source.Type)
 	}
 	if schema.Source.Type == SearchSourceTigris && len(schema.Source.CollectionName) == 0 {

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -663,7 +663,8 @@ func (tenant *Tenant) reloadSearch(ctx context.Context, tx transaction.Tx, proje
 
 		searchFactory, err := schema.BuildSearch(searchMD.Name, schV.Schema)
 		if err != nil {
-			return nil, err
+			log.Err(err).Msgf("seeing rebuilding failure for search index %s", searchMD.Name)
+			continue
 		}
 
 		var fieldsInSearchStore []tsApi.Field


### PR DESCRIPTION
## Describe your changes
During reload/restart, index building should always succeed if validation has happened during index creation time. This needs to be logged but we need to continue loading other indexes. 

## How best to test these changes

## Issue ticket number and link
