### PR TITLE
fix: Fix error handling, timeouts, not leaking FDB error codes, etc

### DIFF
--- a/schema/fields.go
+++ b/schema/fields.go
@@ -516,7 +516,7 @@ func (builder *QueryableFieldsBuilder) NewQueryableField(name string, f *Field, 
 
 		faceted = f.Faceted
 
-		if sortable == nil  && (f.DataType == Int32Type || f.DataType == Int64Type || f.DataType == DoubleType || f.DataType == DateTimeType) {
+		if sortable == nil && (f.DataType == Int32Type || f.DataType == Int64Type || f.DataType == DoubleType || f.DataType == DateTimeType) {
 			// enable it by default for numeric fields
 			sortable = &ptrTrue
 		}

--- a/server/middleware/timeout.go
+++ b/server/middleware/timeout.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	DefaultTimeout = 2 * time.Second
-	MaximumTimeout = 5 * time.Second
+	DefaultTimeout = 10 * time.Second
+	MaximumTimeout = 30 * time.Second
 )
 
 // timeoutUnaryServerInterceptor returns a new unary server interceptor
@@ -52,7 +52,7 @@ func timeoutUnaryServerInterceptor(timeout time.Duration) grpc.UnaryServerInterc
 				cancel()
 			}
 			if ctx.Err() == context.DeadlineExceeded {
-				err = errors.DeadlineExceeded("context deadline exceeded")
+				err = errors.DeadlineExceeded("the server is taking too long to process the request")
 			}
 		}()
 

--- a/server/services/v1/database/errors.go
+++ b/server/services/v1/database/errors.go
@@ -20,6 +20,7 @@ import (
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	apiErrors "github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/store/kv"
 	"github.com/tigrisdata/tigris/store/search"
 )
 
@@ -47,6 +48,16 @@ func createApiError(err error) error {
 			return apiErrors.InvalidArgument(e.Msg)
 		default:
 			return api.Errorf(api.FromHttpCode(e.HttpCode), e.Msg)
+		}
+	case kv.StoreError:
+		switch e.Code() {
+		case kv.ErrCodeTransactionMaxDuration, kv.ErrCodeTransactionTimedOut:
+			return apiErrors.DeadlineExceeded("the server is taking longer than 5 seconds to process the transaction")
+		case kv.ErrCodeTransactionNotCommitted:
+			return apiErrors.DeadlineExceeded("the transaction may not be committed")
+		case kv.ErrCodeValueSizeExceeded, kv.ErrCodeTransactionSizeExceeded:
+			// ToDo: change it to 413, need to add it in proto
+			return apiErrors.InvalidArgument(e.Msg())
 		}
 	default:
 		return err

--- a/server/services/v1/database/import_runner.go
+++ b/server/services/v1/database/import_runner.go
@@ -149,7 +149,7 @@ func (runner *ImportQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		// Retry insert after updating the schema
 		ts, allKeys, err = runner.insertOrReplace(ctx, tx, tenant, coll, runner.req.GetDocuments(), true)
 		if err == kv.ErrDuplicateKey {
-			return Response{}, ctx, errors.AlreadyExists(err.Error())
+			return Response{}, ctx, errors.AlreadyExists(err.(kv.StoreError).Msg())
 		}
 
 		if err != nil {

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -72,7 +72,7 @@ func (runner *InsertQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	ts, allKeys, err := runner.insertOrReplace(ctx, tx, tenant, coll, runner.req.GetDocuments(), true)
 	if err != nil {
 		if err == kv.ErrDuplicateKey {
-			return Response{}, ctx, errors.AlreadyExists(err.Error())
+			return Response{}, ctx, errors.AlreadyExists(err.(kv.StoreError).Msg())
 		}
 
 		return Response{}, ctx, err

--- a/server/services/v1/search/runner.go
+++ b/server/services/v1/search/runner.go
@@ -635,6 +635,9 @@ func (runner *SearchRunner) getSearchFields(index *schema.SearchIndex) ([]string
 			if !cf.Indexed {
 				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
 			}
+			if cf.Indexed && (cf.DataType == schema.Int32Type || cf.DataType == schema.Int64Type || cf.DataType == schema.DoubleType) {
+				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
+			}
 			if cf.InMemoryName() != cf.Name() {
 				searchFields[i] = cf.InMemoryName()
 			}


### PR DESCRIPTION
## Describe your changes

- Convert storage errors to HTTP errors
- Bump up default timeout to 10 seconds and maximum to 30 seconds
- Search indexes checks if numeric fields are used for full-text search and reject an error.
- Improve context deadline error messages

Fix error handling, timeouts, not leaking FDB error codes, etc

## How best to test these changes

## Issue ticket number and link
