### PR TITLE
feat: add human tag to metrics

### DIFF
--- a/server/metrics/fdb.go
+++ b/server/metrics/fdb.go
@@ -36,6 +36,7 @@ func getFdbOkTagKeys() []string {
 		"branch",
 		"collection",
 		"fdb_method",
+		"human",
 	}
 }
 
@@ -52,6 +53,7 @@ func getFdbErrorTagKeys() []string {
 		"fdb_method",
 		"error_source",
 		"error_value",
+		"human",
 	}
 }
 

--- a/server/metrics/network.go
+++ b/server/metrics/network.go
@@ -33,6 +33,7 @@ func getNetworkTagKeys() []string {
 		"project",
 		"branch",
 		"collection",
+		"human",
 	}
 }
 

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -40,6 +40,7 @@ func getRequestOkTagKeys() []string {
 		"write_type",
 		"sort",
 		"sub",
+		"human",
 	}
 }
 
@@ -60,6 +61,7 @@ func getRequestErrorTagKeys() []string {
 		"write_type",
 		"sort",
 		"sub",
+		"human",
 	}
 }
 

--- a/server/metrics/session.go
+++ b/server/metrics/session.go
@@ -36,6 +36,7 @@ func getSessionOkTagKeys() []string {
 		"branch",
 		"collection",
 		"session_method",
+		"human",
 	}
 }
 
@@ -52,6 +53,7 @@ func getSessionErrorTagKeys() []string {
 		"error_source",
 		"error_value",
 		"session_method",
+		"human",
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

Adds the `human` tag to the metrics. It can have, true, false and unknown values. It is true if the tenant is human, false if the tenant is using a machine to machine token.

## How best to test these changes
Fetch the metrics from the server and examine the values of the human tag. Tested manually, metrics test suite is passing. 

## Issue ticket number and link
TIG-1069