### PR TITLE
feat: Add search field match information in response

### DIFF
--- a/api/server/v1/error.go
+++ b/api/server/v1/error.go
@@ -173,6 +173,8 @@ func FromHttpCode(httpCode int) Code {
 		return Code_INTERNAL
 	case 503:
 		return Code_UNAVAILABLE
+	case 413:
+		return Code_CONTENT_TOO_LARGE
 	default:
 		return Code_UNKNOWN
 	}
@@ -222,6 +224,8 @@ func ToHTTPCode(code Code) int {
 		return 409
 	case Code_BAD_GATEWAY:
 		return 502
+	case Code_CONTENT_TOO_LARGE:
+		return 413
 	}
 
 	return 500

--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -884,13 +884,15 @@ func (x *SearchHit) MarshalJSON() ([]byte, error) {
 
 func (x *SearchMetadata) MarshalJSON() ([]byte, error) {
 	resp := struct {
-		Found      int64 `json:"found"`
-		TotalPages int32 `json:"total_pages"`
-		Page       *Page `json:"page"`
+		Found         int64    `json:"found"`
+		TotalPages    int32    `json:"total_pages"`
+		Page          *Page    `json:"page"`
+		MatchedFields []string `json:"matched_fields"`
 	}{
-		Found:      x.Found,
-		TotalPages: x.TotalPages,
-		Page:       x.Page,
+		Found:         x.Found,
+		TotalPages:    x.TotalPages,
+		Page:          x.Page,
+		MatchedFields: x.MatchedFields,
 	}
 	return jsoniter.Marshal(resp)
 }

--- a/api/server/v1/marshaler_test.go
+++ b/api/server/v1/marshaler_test.go
@@ -76,6 +76,6 @@ func TestJSONEncoding(t *testing.T) {
 		}
 		r, err := jsoniter.Marshal(resp)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"hits":[{"metadata":{}}],"facets":{"myField":{"counts":[{"count":32,"value":"adidas"}],"stats":{"avg":40,"count":50}}},"meta":{"found":1234,"total_pages":0,"page":{"current":2,"size":10}}}`, string(r))
+		require.JSONEq(t, `{"hits":[{"metadata":{}}],"facets":{"myField":{"counts":[{"count":32,"value":"adidas"}],"stats":{"avg":40,"count":50}}},"meta":{"found":1234, "matched_fields":null, "total_pages":0,"page":{"current":2,"size":10}}}`, string(r))
 	})
 }

--- a/api/server/v1/search.go
+++ b/api/server/v1/search.go
@@ -24,6 +24,7 @@ import (
 type DocMetadata struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	Match     *Match     `json:"match,omitempty"`
 }
 
 func (x *IndexDoc) MarshalJSON() ([]byte, error) {
@@ -56,6 +57,7 @@ func CreateMDFromDocMeta(x *DocMeta) *DocMetadata {
 		tm := x.UpdatedAt.AsTime()
 		md.UpdatedAt = &tm
 	}
+	md.Match = x.Match
 
 	return &md
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -63,6 +63,12 @@ func DeadlineExceeded(format string, args ...any) error {
 		format, args...)
 }
 
+// ContentTooLarge constructs content too large error (HTTP: 413).
+func ContentTooLarge(format string, args ...any) error {
+	return api.Errorf(api.Code_CONTENT_TOO_LARGE,
+		format, args...)
+}
+
 // Unimplemented constructs not implemented error (HTTP: 501).
 func Unimplemented(format string, args ...any) error {
 	return api.Errorf(api.Code_UNIMPLEMENTED,

--- a/server/services/v1/database/errors.go
+++ b/server/services/v1/database/errors.go
@@ -57,7 +57,7 @@ func createApiError(err error) error {
 			return apiErrors.DeadlineExceeded("the transaction may not be committed")
 		case kv.ErrCodeValueSizeExceeded, kv.ErrCodeTransactionSizeExceeded:
 			// ToDo: change it to 413, need to add it in proto
-			return apiErrors.InvalidArgument(e.Msg())
+			return apiErrors.ContentTooLarge(e.Msg())
 		}
 	default:
 		return err


### PR DESCRIPTION
## Describe your changes

- Returning a matched fields information for search response i.e. how many fields matched the search
- Individual document matched results now also return which for which field search matched that document
- Fixing search metadata errors and wrapping up in the HTTP errors. 

## How best to test these changes

## Issue ticket number and link
