### PR TITLE
fix: Change size and count in secondary indexes

### DIFF
--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -525,9 +525,9 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 		coll := indexStore.coll
 		_ = kvStore.DropTable(ctx, coll.EncodedTableIndexName)
 
-		for z := 0; z < 100; z++ {
+		for z := 0; z < 30; z++ {
 			tx, err := tm.StartTx(ctx)
-			for i := z * 100; i < 100*z+100; i++ {
+			for i := z * 30; i < 30*z+30; i++ {
 				assert.NoError(t, err)
 				td, pk := createDoc(`{"id":1, "double_f":2,"created":"2023-01-16T12:55:17.304154Z","updated": "2023-01-16T12:55:17.304154Z", "arr":[1,2]}`, []interface{}{i}...)
 				err = indexStore.Index(ctx, tx, td, pk)
@@ -540,8 +540,8 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 		assert.NoError(t, err)
 		info, err := indexStore.IndexInfo(ctx, tx)
 		assert.NoError(t, err)
-		assert.Greater(t, info.Size, int64(3600000))
-		assert.Equal(t, int64(80000), info.Rows)
+		assert.Greater(t, info.Size, int64(150000))
+		assert.Equal(t, int64(7200), info.Rows)
 		err = tx.Commit(ctx)
 		assert.NoError(t, err)
 	})

--- a/store/kv/kv.go
+++ b/store/kv/kv.go
@@ -65,6 +65,7 @@ type Tx interface {
 	Commit(context.Context) error
 	Rollback(context.Context) error
 	IsRetriable() bool
+	RangeSize(ctx context.Context, table []byte, lkey Key, rkey Key) (int64, error)
 }
 
 type KeyValueStore interface {
@@ -469,6 +470,14 @@ func (m *TxImplWithMetrics) AtomicReadRange(ctx context.Context, table []byte, l
 func (m *TxImplWithMetrics) Get(ctx context.Context, key []byte, isSnapshot bool) (val Future, err error) {
 	m.measure(ctx, "Get", func() error {
 		val, err = m.tx.Get(ctx, key, isSnapshot)
+		return err
+	})
+	return
+}
+
+func (m *TxImplWithMetrics) RangeSize(ctx context.Context, table []byte, lkey Key, rkey Key) (size int64, err error) {
+	m.measure(ctx, "RangeSize", func() error {
+		size, err = m.tx.RangeSize(ctx, table, lkey, rkey)
 		return err
 	})
 	return

--- a/store/kv/noop_store.go
+++ b/store/kv/noop_store.go
@@ -100,3 +100,7 @@ func (n *NoopKV) AtomicReadRange(ctx context.Context, table []byte, lkey Key, rk
 func (n *NoopKV) Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error) {
 	return nil, nil
 }
+
+func (n *NoopKV) RangeSize(ctx context.Context, table []byte, lkey Key, rkey Key) (int64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
## Describe your changes

Replace the atomic size with `GetRangeSizeEstimate` and the count is a full table scan. The atomic updates are making the updates a lot slower. Changing that to use the `GetRangeSizeEstimate`. 
I've kept the index count in, this would be very slow in a large index but useful for unit tests and integration tests. I don't think we would expose the index count to the user. 

## How best to test these changes
All tests should pass. 

## Issue ticket number and link
Fixes #874 
