### PR TITLE
feat: Configure which fields to add to index

### DIFF
--- a/config/server.dev.yaml
+++ b/config/server.dev.yaml
@@ -30,3 +30,8 @@ log:
 
 foundationdb:
   cluster_file: "./test/config/fdb.cluster"
+
+secondary_index:
+  read_enabled: true
+  write_enabled: true
+  mutate_enabled: true

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -52,9 +52,9 @@ type Filter interface {
 	// MatchesDoc similar to Matches but used when document is already parsed
 	MatchesDoc(doc map[string]interface{}) bool
 	ToSearchFilter() []string
-	// IsIndexed to let caller knows if there is any non-indexed field in the query. This
+	// IsSearchIndexed to let caller knows if there is any fields in the query not indexed in search. This
 	// will trigger full scan.
-	IsIndexed() bool
+	IsSearchIndexed() bool
 }
 
 type EmptyFilter struct{}
@@ -62,7 +62,7 @@ type EmptyFilter struct{}
 func (f *EmptyFilter) Matches(_ []byte) bool                    { return true }
 func (f *EmptyFilter) MatchesDoc(_ map[string]interface{}) bool { return true }
 func (f *EmptyFilter) ToSearchFilter() []string                 { return nil }
-func (f *EmptyFilter) IsIndexed() bool                          { return false }
+func (f *EmptyFilter) IsSearchIndexed() bool                    { return false }
 
 type WrappedFilter struct {
 	Filter
@@ -101,8 +101,8 @@ func (w *WrappedFilter) SearchFilter() []string {
 	return w.searchFilter
 }
 
-func (w *WrappedFilter) IsIndexed() bool {
-	return w.Filter.IsIndexed()
+func (w *WrappedFilter) IsSearchIndexed() bool {
+	return w.Filter.IsSearchIndexed()
 }
 
 func None(reqFilter []byte) bool {

--- a/query/filter/logical.go
+++ b/query/filter/logical.go
@@ -152,9 +152,9 @@ func (a *AndFilter) flattenAnd(soFar string, filters []Filter) []string {
 	return combs
 }
 
-func (a *AndFilter) IsIndexed() bool {
+func (a *AndFilter) IsSearchIndexed() bool {
 	for _, f := range a.filter {
-		if !f.IsIndexed() {
+		if !f.IsSearchIndexed() {
 			return false
 		}
 	}
@@ -227,9 +227,9 @@ func (o *OrFilter) ToSearchFilter() []string {
 	return ORs
 }
 
-func (o *OrFilter) IsIndexed() bool {
+func (o *OrFilter) IsSearchIndexed() bool {
 	for _, f := range o.filter {
-		if !f.IsIndexed() {
+		if !f.IsSearchIndexed() {
 			return false
 		}
 	}

--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -144,7 +144,7 @@ func (s *Selector) ToSearchFilter() []string {
 	return []string{fmt.Sprintf(op, s.Field.InMemoryName(), v.AsInterface())}
 }
 
-func (s *Selector) IsIndexed() bool {
+func (s *Selector) IsSearchIndexed() bool {
 	switch {
 	case s.Field.DataType == schema.DoubleType:
 		v, ok := s.Matcher.GetValue().(*value.DoubleValue)

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -213,6 +213,16 @@ func (d *DefaultCollection) GetQueryableFields() []*QueryableField {
 	return d.QueryableFields
 }
 
+func (d *DefaultCollection) GetIndexedFields() []*QueryableField {
+	var indexed []*QueryableField
+	for _, q := range d.QueryableFields {
+		if q.Indexed {
+			indexed = append(indexed, q)
+		}
+	}
+	return indexed
+}
+
 func (d *DefaultCollection) GetQueryableField(name string) (*QueryableField, error) {
 	for _, qf := range d.QueryableFields {
 		if qf.Name() == name {

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -26,7 +26,7 @@ var (
 )
 
 var validators = []Validator{
-	&IndexSchemaValidator{},
+	&PrimaryIndexSchemaValidator{},
 	&FieldSchemaValidator{},
 }
 
@@ -43,9 +43,9 @@ type SearchIndexValidator interface {
 	ValidateIndex(existing *SearchIndex, current *SearchFactory) error
 }
 
-type IndexSchemaValidator struct{}
+type PrimaryIndexSchemaValidator struct{}
 
-func (v *IndexSchemaValidator) Validate(existing *DefaultCollection, current *Factory) error {
+func (v *PrimaryIndexSchemaValidator) Validate(existing *DefaultCollection, current *Factory) error {
 	return existing.Indexes.PrimaryKey.IsCompatible(current.Indexes.PrimaryKey)
 }
 

--- a/schema/rules_test.go
+++ b/schema/rules_test.go
@@ -160,7 +160,7 @@ func TestApplySchemaRulesIncompatible(t *testing.T) {
 	}
 }
 
-func TestApplyIndexSchemaRules(t *testing.T) {
+func TestApplySearchIndexSchemaRules(t *testing.T) {
 	cases := []struct {
 		existing []byte
 		incoming []byte

--- a/schema/search.go
+++ b/schema/search.go
@@ -202,7 +202,7 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 			Name:     s.Name(),
 			Type:     s.SearchType,
 			Facet:    &s.Faceted,
-			Index:    &s.Indexed,
+			Index:    &s.SearchIndexed,
 			Sort:     &s.Sortable,
 			Optional: &ptrTrue,
 		})
@@ -212,7 +212,7 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 				Name:     s.InMemoryName(),
 				Type:     s.SearchType,
 				Facet:    &s.Faceted,
-				Index:    &s.Indexed,
+				Index:    &s.SearchIndexed,
 				Sort:     &s.Sortable,
 				Optional: &ptrTrue,
 			})
@@ -264,7 +264,7 @@ func GetSearchDeltaFields(forSearchIndex bool, existingFields []*QueryableField,
 			Name:     f.FieldName,
 			Type:     f.SearchType,
 			Facet:    &f.Faceted,
-			Index:    &f.Indexed,
+			Index:    &f.SearchIndexed,
 			Optional: &ptrTrue,
 		}
 

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -225,7 +225,7 @@ func (runner *BaseQueryRunner) buildSecondaryIndexKeysUsingFilter(coll *schema.D
 		return nil, errors.InvalidArgument("secondary indexes do not support case insensitive collation")
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.QueryableFields)
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func (runner *BaseQueryRunner) getSecondaryWriterIterator(ctx context.Context, t
 		return nil, err
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.QueryableFields)
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -422,7 +422,7 @@ func (runner *StreamingQueryRunner) buildReaderOptions(collection *schema.Defaul
 		}
 	}
 
-	if options.filter.None() || !options.filter.IsIndexed() {
+	if options.filter.None() || !options.filter.IsSearchIndexed() {
 		// trigger full scan in case there is a field in the filter which is not indexed
 		if options.sorting != nil {
 			options.inMemoryStore = true

--- a/server/services/v1/database/search_runner.go
+++ b/server/services/v1/database/search_runner.go
@@ -202,7 +202,7 @@ func (runner *SearchQueryRunner) getSearchFields(coll *schema.DefaultCollection)
 			if err != nil {
 				return nil, err
 			}
-			if !cf.Indexed {
+			if !cf.SearchIndexed {
 				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
 			}
 			if cf.InMemoryName() != cf.Name() {

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -699,7 +699,10 @@ func setupTest(t *testing.T, reqSchema []byte) *SecondaryIndexer {
 	assert.NoError(t, err)
 	coll.EncodedName = []byte("t1")
 	coll.EncodedTableIndexName = []byte("sidx1")
-	return NewSecondaryIndexer(coll)
+	indexer := NewSecondaryIndexer(coll)
+	indexer.indexAll = true
+
+	return indexer
 }
 
 func assertKVs(t *testing.T, expected [][]interface{}, indexKeys []keys.Key, counts map[string]int64) {

--- a/server/services/v1/search/runner.go
+++ b/server/services/v1/search/runner.go
@@ -664,10 +664,10 @@ func (runner *SearchRunner) getSearchFields(index *schema.SearchIndex) ([]string
 			if err != nil {
 				return nil, err
 			}
-			if !cf.Indexed {
+			if !cf.SearchIndexed {
 				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
 			}
-			if cf.Indexed && (cf.DataType == schema.Int32Type || cf.DataType == schema.Int64Type || cf.DataType == schema.DoubleType) {
+			if cf.SearchIndexed && (cf.DataType == schema.Int32Type || cf.DataType == schema.Int64Type || cf.DataType == schema.DoubleType) {
 				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
 			}
 			if cf.InMemoryName() != cf.Name() {

--- a/test/v1/server/integration_test.go
+++ b/test/v1/server/integration_test.go
@@ -48,11 +48,13 @@ var testCreateSchema = Map{
 			"int_value": Map{
 				"description": "simple int field",
 				"type":        "integer",
+				"index":       true,
 			},
 			"string_value": Map{
 				"description": "simple string field",
 				"type":        "string",
 				"maxLength":   128,
+				"index":       true,
 			},
 			"added_string_value": Map{
 				"description": "simple string field",
@@ -61,10 +63,12 @@ var testCreateSchema = Map{
 			"bool_value": Map{
 				"description": "simple boolean field",
 				"type":        "boolean",
+				"index":       true,
 			},
 			"double_value": Map{
 				"description": "simple double field",
 				"type":        "number",
+				"index":       true,
 			},
 			"added_value_double": Map{
 				"description": "simple double field",
@@ -79,11 +83,13 @@ var testCreateSchema = Map{
 				"description": "uuid field",
 				"type":        "string",
 				"format":      "uuid",
+				"index":       true,
 			},
 			"date_time_value": Map{
 				"description": "date time field",
 				"type":        "string",
 				"format":      "date-time",
+				"index":       true,
 			},
 			"simple_array_value": Map{
 				"description": "array field",


### PR DESCRIPTION
## Describe your changes
Secondary indexes are now configurable via the schema. Adding `index: true` to a top level field will add that field to the secondary index. The schema rules have been updated to make sure that only top level fields can be indexed.

## How best to test these changes
All tests should pass. I've updated some of the update and delete test's so that the queries will use the secondary index

## Issue ticket number and link
Fixes #875 
