### PR TITLE
feat: Add group by functionality for search index results

### DIFF
--- a/api/server/v1/search.go
+++ b/api/server/v1/search.go
@@ -57,10 +57,12 @@ func (x *SearchIndexResponse) MarshalJSON() ([]byte, error) {
 		Hits   []*SearchHit            `json:"hits"`
 		Facets map[string]*SearchFacet `json:"facets"`
 		Meta   *SearchMetadata         `json:"meta"`
+		Group  []*GroupedSearchHits    `json:"group"`
 	}{
 		Hits:   x.Hits,
 		Facets: x.Facets,
 		Meta:   x.Meta,
+		Group:  x.Group,
 	}
 
 	if resp.Hits == nil {
@@ -315,6 +317,16 @@ func (x *SearchIndexRequest) UnmarshalJSON(data []byte) error {
 			v = &x.SearchFields
 		case "q":
 			v = &x.Q
+		case "include_fields":
+			v = &x.IncludeFields
+		case "exclude_fields":
+			v = &x.ExcludeFields
+		case "page_size":
+			v = &x.PageSize
+		case "page":
+			v = &x.Page
+		case "collation":
+			v = &x.Collation
 		case "filter":
 			// not decoding it here and let it decode during filter parsing
 			x.Filter = value
@@ -327,16 +339,10 @@ func (x *SearchIndexRequest) UnmarshalJSON(data []byte) error {
 			// delaying the sort deserialization
 			x.Sort = value
 			continue
-		case "include_fields":
-			v = &x.IncludeFields
-		case "exclude_fields":
-			v = &x.ExcludeFields
-		case "page_size":
-			v = &x.PageSize
-		case "page":
-			v = &x.Page
-		case "collation":
-			v = &x.Collation
+		case "group_by":
+			// delaying the sort deserialization
+			x.GroupBy = value
+			continue
 		default:
 			continue
 		}

--- a/query/search/group_by.go
+++ b/query/search/group_by.go
@@ -1,0 +1,37 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+type GroupBy struct {
+	Fields []string
+	Limit  *int64
+}
+
+func UnmarshalGroupBy(input jsoniter.RawMessage) (GroupBy, error) {
+	if len(input) == 0 {
+		return GroupBy{}, nil
+	}
+
+	var g GroupBy
+	if err := jsoniter.Unmarshal(input, &g); err != nil {
+		return GroupBy{}, err
+	}
+
+	return g, nil
+}

--- a/query/search/search.go
+++ b/query/search/search.go
@@ -34,6 +34,7 @@ type Query struct {
 	WrappedF     *filter.WrappedFilter
 	ReadFields   *read.FieldFactory
 	SortOrder    *sort.Ordering
+	GroupBy      GroupBy
 }
 
 func (q *Query) ToSearchFacetSize() int {
@@ -102,6 +103,26 @@ func (q *Query) ToSortFields() string {
 	return sortBy
 }
 
+func (q *Query) ToSearchGroupBy() string {
+	if len(q.GroupBy.Fields) == 0 {
+		return ""
+	}
+
+	var groupBy string
+	for i, f := range q.GroupBy.Fields {
+		if i != 0 {
+			groupBy += ","
+		}
+		groupBy += f
+	}
+
+	return groupBy
+}
+
+func (q *Query) IsGroupByQuery() bool {
+	return len(q.GroupBy.Fields) > 0
+}
+
 type Builder struct {
 	query *Query
 }
@@ -146,6 +167,11 @@ func (b *Builder) ReadFields(f *read.FieldFactory) *Builder {
 
 func (b *Builder) SortOrder(o *sort.Ordering) *Builder {
 	b.query.SortOrder = o
+	return b
+}
+
+func (b *Builder) GroupBy(groupBy GroupBy) *Builder {
+	b.query.GroupBy = groupBy
 	return b
 }
 

--- a/server/search/group.go
+++ b/server/search/group.go
@@ -1,0 +1,60 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import "github.com/tigrisdata/tigris/errors"
+
+type Group struct {
+	Hits []*Hit
+	Keys []string
+}
+
+func NewGroup(keys []string, hits []*Hit) *Group {
+	return &Group{
+		Keys: keys,
+		Hits: hits,
+	}
+}
+
+type Groups struct {
+	index  int
+	groups []*Group
+}
+
+func NewGroups() *Groups {
+	return &Groups{}
+}
+
+func (g *Groups) add(group *Group) {
+	g.groups = append(g.groups, group)
+}
+
+func (g *Groups) Next() (*Group, error) {
+	if g.index < len(g.groups) {
+		group := g.groups[g.index]
+		g.index++
+		return group, nil
+	}
+
+	return nil, errors.Internal("no more hits to iterate")
+}
+
+func (g *Groups) Len() int {
+	return len(g.groups)
+}
+
+func (g *Groups) HasMoreGroups() bool {
+	return g.index < len(g.groups)
+}

--- a/store/search/ts.go
+++ b/store/search/ts.go
@@ -240,6 +240,9 @@ func (s *storeImpl) getBaseSearchParam(query *qsearch.Query, pageNo int) tsApi.M
 	if sortBy := query.ToSortFields(); len(sortBy) > 0 {
 		baseParam.SortBy = &sortBy
 	}
+	if groupBy := query.ToSearchGroupBy(); len(groupBy) > 0 {
+		baseParam.GroupBy = &groupBy
+	}
 
 	return baseParam
 }
@@ -282,7 +285,7 @@ func (s *storeImpl) Search(_ context.Context, table string, query *qsearch.Query
 		return nil, s.convertToInternalError(err)
 	}
 	for _, each := range dest.Results {
-		if each.Hits == nil {
+		if each.Hits == nil && each.GroupedHits == nil {
 			type errResult struct {
 				Code    int    `json:"code"`
 				Message string `json:"error"`


### PR DESCRIPTION
## Describe your changes
This functionality allows grouping of search results. For instance, let's say grouping needs to be done on city field. Then following is the example of the query and response. 

```
{
	"q": "text",
	"group_by": {
		"fields": ["city"]
	},
	"sort": [{
		"created_at": "$asc"
	}]
}
```

Response:
```
{
	"result": {
		"hits": [],
		"facets": {},
		"meta": {},
		"group": [{
			"group_keys": [
				"Anaheim"
			],
			"hits": [{
				"data": {
					"id": "2b1fd919-c752-45f8-bbe5-bb9e2f85af74"
				},
				"metadata": {}
			}]
		}]
	}
}
```

## How best to test these changes

## Issue ticket number and link
https://github.com/tigrisdata/tigris/issues/885