### PR TITLE
chore: lower value on flaky size test

### DIFF
--- a/schema/search_test.go
+++ b/schema/search_test.go
@@ -158,6 +158,5 @@ func TestSearchIndex_Schema(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
-
 	}
 }

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -540,7 +540,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 		assert.NoError(t, err)
 		info, err := indexStore.IndexInfo(ctx, tx)
 		assert.NoError(t, err)
-		assert.Greater(t, info.Size, int64(150000))
+		assert.Greater(t, info.Size, int64(100000))
 		assert.Equal(t, int64(7200), info.Rows)
 		err = tx.Commit(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Describe your changes
This test is quite flaky because size is an estimate. And at the smaller size it isn't that accurate. 
The test just needs to prove that we have some kind of size value. 

## How best to test these changes
Tests should pass

## Issue ticket number and link
