### PR TITLE
feat: Bump grpc max receive message limit to 16MB

### DIFF
--- a/server/muxer/grpc.go
+++ b/server/muxer/grpc.go
@@ -23,6 +23,10 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+const (
+	defaultTigrisServerMaxReceiveMessageSize = 1024 * 1024 * 16
+)
+
 type GRPCServer struct {
 	*grpc.Server
 }
@@ -31,7 +35,7 @@ func NewGRPCServer(cfg *config.Config) *GRPCServer {
 	s := &GRPCServer{}
 
 	unary, stream := middleware.Get(cfg)
-	s.Server = grpc.NewServer(grpc.StreamInterceptor(stream), grpc.UnaryInterceptor(unary))
+	s.Server = grpc.NewServer(grpc.StreamInterceptor(stream), grpc.UnaryInterceptor(unary), grpc.MaxRecvMsgSize(defaultTigrisServerMaxReceiveMessageSize))
 	reflection.Register(s)
 	return s
 }


### PR DESCRIPTION
## Describe your changes
Bump grpc max receive message limit to 16MB

## How best to test these changes

## Issue ticket number and link
