### PR TITLE
fix: Fixed the error status code in case of auth failure

### DIFF
--- a/server/services/v1/auth/gotrue.go
+++ b/server/services/v1/auth/gotrue.go
@@ -516,7 +516,10 @@ func getAccessTokenUsingClientCredentialsGotrue(ctx context.Context, clientId st
 		return "", 0, err
 	}
 
-	if getTokenRes.StatusCode != http.StatusOK {
+	if getTokenRes.StatusCode == http.StatusBadRequest {
+		log.Error().Int("status", getTokenRes.StatusCode).Msg("Non OK status received to get access token")
+		return "", 0, errors.Unauthenticated("Invalid credentials")
+	} else if getTokenRes.StatusCode != http.StatusOK {
 		log.Error().Int("status", getTokenRes.StatusCode).Msg("Non OK status received to get access token")
 		return "", 0, errors.Internal("Non OK status code received from gotrue")
 	}

--- a/test/v1/server/auth_test.go
+++ b/test/v1/server/auth_test.go
@@ -214,6 +214,18 @@ func TestCreateAccessToken(t *testing.T) {
 	_ = e2.POST(createProjectUrl("new-project")).WithHeader(Authorization, Bearer+accessToken).Expect().Status(http.StatusOK)
 }
 
+func TestCreateAccessTokenUsingInvalidCreds(t *testing.T) {
+	e2 := expectLow(t, config.GetBaseURL2())
+	getAccessTokenResponse := e2.POST(getAuthToken()).
+		WithFormField("client_id", "invalid-id").
+		WithFormField("client_secret", "invalid-password").
+		WithFormField("grant_type", "client_credentials").
+		Expect()
+	getAccessTokenResponse.Status(http.StatusUnauthorized)
+	errorMessage := getAccessTokenResponse.JSON().Object().Value("error").Object().Value("message").String().Raw()
+	require.Equal(t, "Invalid credentials", errorMessage)
+}
+
 func TestAuthFailure(t *testing.T) {
 	e2 := expectLow(t, config.GetBaseURL2())
 	testProject := "auth_test"


### PR DESCRIPTION
## Describe your changes
When auth fails at gotrue with invalid client credentials, with this fix - proper error code and message will be returned back to user.

## How best to test these changes
Added integration test.

## Issue ticket number and link
