### PR TITLE
Push tigris-debug to Quay.io as well

### DIFF
--- a/.github/workflows/publish-debug-image.yaml
+++ b/.github/workflows/publish-debug-image.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   DOCKER_REPOSITORY: "tigrisdata/tigris-debug"
+  QUAY_REPOSITORY: "quay.io/tigrisdata/tigris-debug"
 
 jobs:
   build-and-push-debug-image:
@@ -33,6 +34,13 @@ jobs:
           username: ${{ secrets.GH_DOCKER_ACCESS_USER }}
           password: ${{ secrets.GH_DOCKER_ACCESS_TOKEN }}
 
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_REGISTRY_PASSWORD }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -40,6 +48,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ env.DOCKER_REPOSITORY }}
+            ${{ env.QUAY_REPOSITORY }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch

--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   DOCKER_REPOSITORY: "tigrisdata/tigris"
-  QUAY_IMAGE: "quay.io/tigrisdata/tigris"
+  QUAY_REPOSITORY: "quay.io/tigrisdata/tigris"
 
 jobs:
   build-and-push-image:
@@ -54,7 +54,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ env.DOCKER_REPOSITORY }}
-            ${{ env.QUAY_IMAGE }}
+            ${{ env.QUAY_REPOSITORY }}
           # generate Docker tags based on the following events/attributes
           # we generate the latest tag off the beta branch
           tags: |


### PR DESCRIPTION
## Describe your changes
Modified the build to push debug `tigris-debug` image to Quay.io in addition to DockerHub, as we intend to serve all deployments from Quay.io

## How best to test these changes
Added `debug image` label to run the `push-debug-image` job.
<img width="1697" alt="image" src="https://user-images.githubusercontent.com/70140951/223228675-d54f27e0-8cd4-460b-986f-4d1cf54a5302.png">


