### PR TITLE
fix: List app keys by tigris project

### DIFF
--- a/server/services/v1/auth/gotrue.go
+++ b/server/services/v1/auth/gotrue.go
@@ -291,7 +291,7 @@ func (g *gotrue) ListAppKeys(ctx context.Context, req *api.ListAppKeysRequest) (
 	}
 
 	// make external call
-	getUsersUrl := fmt.Sprintf("%s/admin/users?created_by=%s&tigris_namespace=%s&page=1&per_page=5000", g.AuthConfig.Gotrue.URL, currentSub, currentNamespace)
+	getUsersUrl := fmt.Sprintf("%s/admin/users?created_by=%s&tigris_namespace=%s&tigris_project=%s&page=1&per_page=5000", g.AuthConfig.Gotrue.URL, currentSub, currentNamespace, req.GetProject())
 	client := &http.Client{}
 	getUsersReq, err := http.NewRequestWithContext(ctx, http.MethodGet, getUsersUrl, nil)
 	if err != nil {

--- a/test/v1/server/auth_test.go
+++ b/test/v1/server/auth_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/test/config"
 	"gopkg.in/gavv/httpexpect.v1"
@@ -147,8 +146,6 @@ func TestMultipleAppsCreation(t *testing.T) {
 	e2 := expectLow(t, config.GetBaseURL2())
 	testProject := "auth_test"
 	token := readToken(t)
-	log.Info().Msgf("token=%s", token)
-
 	_ = e2.POST(createProjectUrl(testProject)).WithHeader(Authorization, Bearer+token).Expect()
 
 	for i := 0; i < 5; i++ {
@@ -174,6 +171,51 @@ func TestMultipleAppsCreation(t *testing.T) {
 		Object().Value("app_keys").Array()
 
 	require.Equal(t, 5, int(appKeys.Length().Raw()))
+}
+
+func TestListAppKeys(t *testing.T) {
+	e2 := expectLow(t, config.GetBaseURL2())
+	testProject := "auth_test"
+	token := readToken(t)
+
+	_ = e2.POST(createProjectUrl(fmt.Sprintf("%s%d", testProject, 0))).WithHeader(Authorization, Bearer+token).Expect()
+	_ = e2.POST(createProjectUrl(fmt.Sprintf("%s%d", testProject, 1))).WithHeader(Authorization, Bearer+token).Expect()
+
+	for i := 0; i < 5; i++ {
+		var createAppKeyPayload = make(map[string]string)
+		projectForThisKey := fmt.Sprintf("%s%d", testProject, i%2)
+		createAppKeyPayload["name"] = fmt.Sprintf("test_key_%d", i)
+		createAppKeyPayload["description"] = "This key is used for integration test purpose."
+		createAppKeyPayload["project"] = projectForThisKey
+
+		createdAppKey := e2.POST(appKeysOperation(projectForThisKey, "create")).
+			WithHeader(Authorization, Bearer+token).WithJSON(createAppKeyPayload).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object().Value("created_app_key")
+		require.NotNil(t, createdAppKey)
+	}
+
+	appKeysEven := e2.GET(appKeysOperation(testProject+"0", "get")).
+		WithHeader(Authorization, Bearer+token).
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().Value("app_keys").Array()
+
+	// 3 even app keys should be retrieved
+	require.Equal(t, 3, int(appKeysEven.Length().Raw()))
+
+	appKeysOdd := e2.GET(appKeysOperation(testProject+"1", "get")).
+		WithHeader(Authorization, Bearer+token).
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().Value("app_keys").Array()
+
+	// 2 odd app keys should be retrieved
+	require.Equal(t, 2, int(appKeysOdd.Length().Raw()))
 }
 
 func TestCreateAccessToken(t *testing.T) {
@@ -209,8 +251,6 @@ func TestCreateAccessToken(t *testing.T) {
 	require.NotNil(t, getAccessTokenResponse.JSON().Object().Value("expires_in"))
 
 	// use access token
-	log.Info().Str("token", accessToken).Msg(createProjectUrl("new-project"))
-
 	_ = e2.POST(createProjectUrl("new-project")).WithHeader(Authorization, Bearer+accessToken).Expect().Status(http.StatusOK)
 }
 

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -4269,7 +4269,8 @@ func TestImport(t *testing.T) {
 					JSON().
 					Object().
 					ValueEqual("collection", c.coll).Raw()
-
+				// set size of the collection in description 0 for test
+				sch["size"] = 0.0
 				b, err := jsoniter.Marshal(sch)
 				require.NoError(t, err)
 				require.JSONEq(t, c.exp, string(b))


### PR DESCRIPTION
## Describe your changes
This PR sends a filter to gotrue asking to filter app keys on a project. This fixes the issue where all the app keys created by a users in a given namespaces are listed (ignoring project).

## How best to test these changes
Added integration test.

## Issue ticket number and link
