### PR TITLE
fix: Fixed the empty keys response

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -677,6 +677,19 @@ func (x *UpdateUserMetadataRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (x *ListAppKeysResponse) MarshalJSON() ([]byte, error) {
+	if x.AppKeys == nil {
+		x.AppKeys = make([]*AppKey, 0)
+	}
+
+	resp := struct {
+		AppKeys []*AppKey `json:"app_keys"`
+	}{
+		AppKeys: x.AppKeys,
+	}
+	return jsoniter.Marshal(resp)
+}
+
 func (x *GetUserMetadataResponse) MarshalJSON() ([]byte, error) {
 	resp := struct {
 		MetadataKey string              `json:"metadataKey,omitempty"`

--- a/test/v1/server/auth_test.go
+++ b/test/v1/server/auth_test.go
@@ -218,6 +218,23 @@ func TestListAppKeys(t *testing.T) {
 	require.Equal(t, 2, int(appKeysOdd.Length().Raw()))
 }
 
+func TestEmptyListAppKeys(t *testing.T) {
+	e2 := expectLow(t, config.GetBaseURL2())
+	testProject := "TestEmptyListAppKeys"
+	token := readToken(t)
+
+	_ = e2.POST(createProjectUrl(testProject)).WithHeader(Authorization, Bearer+token).Expect()
+
+	appKeys := e2.GET(appKeysOperation(testProject, "get")).
+		WithHeader(Authorization, Bearer+token).
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().Value("app_keys").Array()
+
+	require.Equal(t, 0, int(appKeys.Length().Raw()))
+}
+
 func TestCreateAccessToken(t *testing.T) {
 	e2 := expectLow(t, config.GetBaseURL2())
 	testProject := "auth_test"


### PR DESCRIPTION
## Describe your changes
When there are no keys present for the scope of the call. Tigris returns `{}` empty JSON object. This PR fixes it and returns `app_keys` with `[]` empty array.

## How best to test these changes
Added test for it.

## Issue ticket number and link
