### PR TITLE
fix: Fixed parsing of createdAt field from gotrue response

### DIFF
--- a/test/v1/server/auth_test.go
+++ b/test/v1/server/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/test/config"
@@ -143,6 +144,8 @@ func TestGoTrueAuthProvider(t *testing.T) {
 }
 
 func TestMultipleAppsCreation(t *testing.T) {
+	testStartTime := time.Now()
+
 	e2 := expectLow(t, config.GetBaseURL2())
 	testProject := "auth_test"
 	token := readToken(t)
@@ -171,6 +174,10 @@ func TestMultipleAppsCreation(t *testing.T) {
 		Object().Value("app_keys").Array()
 
 	require.Equal(t, 5, int(appKeys.Length().Raw()))
+	for _, value := range appKeys.Iter() {
+		createdAt := int64(value.Object().Value("created_at").Number().Raw())
+		require.True(t, createdAt >= testStartTime.UnixMilli())
+	}
 }
 
 func TestListAppKeys(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
Gotrue response contains `created_at` in form of string (RFC3339 formatted time) at the top level in user model. This PR fixes parsing of createdAt field into Tigris's response. Also this PR abstracts out the detail in error messages from user.

## How best to test these changes
Modified existing test to inspect `createdAt` field.

## Issue ticket number and link
