### PR TITLE
fix: Revert empty array response when app keys are empty for list call

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -677,19 +677,6 @@ func (x *UpdateUserMetadataRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (x *ListAppKeysResponse) MarshalJSON() ([]byte, error) {
-	if x.AppKeys == nil {
-		x.AppKeys = make([]*AppKey, 0)
-	}
-
-	resp := struct {
-		AppKeys []*AppKey `json:"app_keys"`
-	}{
-		AppKeys: x.AppKeys,
-	}
-	return jsoniter.Marshal(resp)
-}
-
 func (x *GetUserMetadataResponse) MarshalJSON() ([]byte, error) {
 	resp := struct {
 		MetadataKey string              `json:"metadataKey,omitempty"`

--- a/test/v1/server/auth_test.go
+++ b/test/v1/server/auth_test.go
@@ -236,10 +236,9 @@ func TestEmptyListAppKeys(t *testing.T) {
 		WithHeader(Authorization, Bearer+token).
 		Expect().
 		Status(http.StatusOK).
-		JSON().
-		Object().Value("app_keys").Array()
-
-	require.Equal(t, 0, int(appKeys.Length().Raw()))
+		JSON().Object().Raw()
+	var emptyMap = make(map[string]interface{})
+	require.Equal(t, emptyMap, appKeys)
 }
 
 func TestCreateAccessToken(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
Reverting the change in response behavior: While listing app keys if the response is empty - it will now skip `app_keys` key from returned JSON response. 

## How best to test these changes
updated test to match this behavior

## Issue ticket number and link
