### PR TITLE
feat: Enabling full text search on database collection through schema

### DIFF
--- a/query/filter/logical_test.go
+++ b/query/filter/logical_test.go
@@ -24,18 +24,18 @@ import (
 func TestLogicalToSearch(t *testing.T) {
 	factory := Factory{
 		fields: []*schema.QueryableField{
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f1", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f2", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f3", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f4", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f5", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f6", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("a", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("b", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("c", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("d", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("e", &schema.Field{DataType: schema.Int64Type}, nil),
-			schema.NewQueryableFieldsBuilder(false).NewQueryableField("f", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f1", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f2", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f3", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f4", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f5", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f6", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("a", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("b", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("c", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("d", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("e", &schema.Field{DataType: schema.Int64Type}, nil),
+			schema.NewQueryableFieldsBuilder().NewQueryableField("f", &schema.Field{DataType: schema.Int64Type}, nil),
 		},
 	}
 

--- a/query/search/search_test.go
+++ b/query/search/search_test.go
@@ -27,9 +27,9 @@ import (
 func TestSearchBuilder(t *testing.T) {
 	js := []byte(`{"a": 4, "$and": [{"int_value":1}, {"string_value1": "shoe"}]}`)
 	f := filter.NewFactory([]*schema.QueryableField{
-		schema.NewQueryableFieldsBuilder(false).NewQueryableField("a", &schema.Field{DataType: schema.Int64Type}, nil),
-		schema.NewQueryableFieldsBuilder(false).NewQueryableField("int_value", &schema.Field{DataType: schema.Int64Type}, nil),
-		schema.NewQueryableFieldsBuilder(false).NewQueryableField("string_value1", &schema.Field{DataType: schema.StringType}, nil),
+		schema.NewQueryableFieldsBuilder().NewQueryableField("a", &schema.Field{DataType: schema.Int64Type}, nil),
+		schema.NewQueryableFieldsBuilder().NewQueryableField("int_value", &schema.Field{DataType: schema.Int64Type}, nil),
+		schema.NewQueryableFieldsBuilder().NewQueryableField("string_value1", &schema.Field{DataType: schema.StringType}, nil),
 	}, nil)
 	wrappedF, err := f.WrappedFilter(js)
 	require.NoError(t, err)

--- a/query/update/operator_test.go
+++ b/query/update/operator_test.go
@@ -484,7 +484,7 @@ func testCollection(t *testing.T) *schema.DefaultCollection {
 	"primary_key": ["id"]
 }`)
 
-	schFactory, err := schema.Build("test_update", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("test_update", reqSchema)
 	require.NoError(t, err)
 
 	c, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
@@ -539,7 +539,7 @@ func testCollection2(t *testing.T) *schema.DefaultCollection {
 	"primary_key": ["id", "a", "c"]
 }`)
 
-	schFactory, err := schema.Build("test_update", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("test_update", reqSchema)
 	require.NoError(t, err)
 
 	c, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -70,7 +70,7 @@ type DefaultCollection struct {
 	QueryableFields []*QueryableField
 	// CollectionType is the type of the collection. Only two types of collections are supported "messages" and "documents"
 	CollectionType CollectionType
-	// Track all the int64 paths in the collection. For example, if top level object has a int64 field then key would be
+	// Track all the int64 paths in the collection. For example, if top level object has an int64 field then key would be
 	// obj.fieldName so that caller can easily navigate to this field.
 	int64FieldsPath map[string]struct{}
 	// This is the existing fields in search
@@ -145,11 +145,11 @@ func NewDefaultCollection(id uint32, schVer int, factory *Factory, schemas Versi
 	validator.AdditionalProperties = false
 	disableAdditionalPropertiesAndAllowNullable(validator.Required, validator.Properties)
 
-	var fieldsInSearch []tsApi.Field
+	var prevVersionInSearch []tsApi.Field
 	if implicitSearchIndex != nil {
-		fieldsInSearch = implicitSearchIndex.fieldsInSearch
+		prevVersionInSearch = implicitSearchIndex.prevVersionInSearch
 	}
-	queryableFields := NewQueryableFieldsBuilder(false).BuildQueryableFields(factory.Fields, fieldsInSearch)
+	queryableFields := NewQueryableFieldsBuilder().BuildQueryableFields(factory.Fields, prevVersionInSearch)
 
 	schemaDeltas, err := buildSchemaDeltas(schemas)
 	if err != nil {

--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -223,7 +223,7 @@ func TestCollection_SchemaValidate(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		schFactory, err := Build("t1", reqSchema)
+		schFactory, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 		require.NoError(t, err)
 
 		coll, err := NewDefaultCollection(1, 1, schFactory, nil, nil)
@@ -286,7 +286,7 @@ func TestCollection_AdditionalProperties(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		schFactory, err := Build("t1", reqSchema)
+		schFactory, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 		require.NoError(t, err)
 
 		coll, err := NewDefaultCollection(1, 1, schFactory, nil, nil)
@@ -324,7 +324,7 @@ func TestCollection_Object(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		schFactory, err := Build("t1", reqSchema)
+		schFactory, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 		require.NoError(t, err)
 
 		coll, err := NewDefaultCollection(1, 1, schFactory, nil, nil)
@@ -384,7 +384,7 @@ func TestCollection_Int64(t *testing.T) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := Build("t1", reqSchema)
+	schFactory, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(t, err)
 	coll, err := NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)

--- a/schema/factory_builder.go
+++ b/schema/factory_builder.go
@@ -1,0 +1,148 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"bytes"
+
+	"github.com/buger/jsonparser"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/lib/container"
+)
+
+type FactoryBuilder struct {
+	forSearch     bool
+	onUserRequest bool
+}
+
+func NewFactoryBuilder(onUserRequest bool) *FactoryBuilder {
+	return &FactoryBuilder{
+		onUserRequest: onUserRequest,
+	}
+}
+
+func (fb *FactoryBuilder) setBuilderForSearch() {
+	fb.forSearch = true
+}
+
+func (fb *FactoryBuilder) deserializeArray(items *FieldBuilder, current *[]*Field) error {
+	for ; items.Items != nil; items = items.Items {
+		it, err := items.Build(fb.forSearch)
+		if err != nil {
+			return err
+		}
+
+		*current = []*Field{it}
+		current = &it.Fields
+	}
+
+	// object array type
+	if len(items.Properties) > 0 {
+		if items.Type != jsonSpecObject {
+			return errors.InvalidArgument("properties only allowed for object type")
+		}
+
+		nestedFields, err := fb.deserializeProperties(items.Properties, nil)
+		if err != nil {
+			return err
+		}
+
+		*current = []*Field{{DataType: ObjectType, Fields: nestedFields}}
+	} else {
+		// primitive array type
+		it, err := items.Build(fb.forSearch)
+		if err != nil {
+			return err
+		}
+
+		*current = []*Field{it}
+	}
+
+	return nil
+}
+
+func (fb *FactoryBuilder) deserializeProperties(properties jsoniter.RawMessage, primaryKeysSet *container.HashSet) ([]*Field, error) {
+	var fields []*Field
+
+	err := jsonparser.ObjectEach(properties, func(key []byte, v []byte, dataType jsonparser.ValueType, offset int) error {
+		var err error
+		var builder FieldBuilder
+
+		if fb.onUserRequest {
+			// only validate during incoming request i.e. no need to validate during reloading of schemas.
+			if err = ValidateSupportedProperties(v); err != nil {
+				// builder validates against the supported schema attributes on properties
+				return err
+			}
+		}
+
+		// set field name and try to unmarshal the value into field builder
+		builder.FieldName = string(key)
+
+		dec := jsoniter.NewDecoder(bytes.NewReader(v))
+		dec.UseNumber()
+		if err = dec.Decode(&builder); err != nil {
+			return errors.Internal(err.Error())
+		}
+
+		if builder.Type == jsonSpecArray {
+			if builder.Items == nil {
+				return errors.InvalidArgument("missing items for array field")
+			}
+
+			if err = fb.deserializeArray(builder.Items, &builder.Fields); err != nil {
+				return err
+			}
+		}
+
+		// for objects, properties are part of the field definitions in that case deserialize those
+		// nested fields
+		if len(builder.Properties) > 0 {
+			if builder.Type != jsonSpecObject {
+				return errors.InvalidArgument("properties only allowed for object type")
+			}
+
+			if builder.Fields, err = fb.deserializeProperties(builder.Properties, nil); err != nil {
+				return err
+			}
+		}
+
+		if primaryKeysSet != nil && primaryKeysSet.Contains(builder.FieldName) {
+			boolTrue := true
+			builder.Primary = &boolTrue
+		}
+
+		if fb.onUserRequest {
+			if err = ValidateFieldBuilder(builder); err != nil {
+				return err
+			}
+		}
+
+		f, err := builder.Build(fb.forSearch)
+		if err != nil {
+			return err
+		}
+
+		fields = append(fields, f)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -19,10 +19,10 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/lib/container"
 	"github.com/tigrisdata/tigris/server/config"
-	tsApi "github.com/typesense/typesense-go/typesense/api"
 )
 
 type FieldType int
@@ -65,9 +65,8 @@ var FieldNames = [...]string{
 }
 
 var (
-	MsgFieldNameAsLanguageKeyword = "Invalid collection field name, It contains language keyword for fieldName = '%s'"
-	MsgFieldNameInvalidPattern    = "Invalid collection field name, field name can only contain [a-zA-Z0-9_$] and it can only start with [a-zA-Z_$] for fieldName = '%s'"
-	ValidFieldNamePattern         = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
+	MsgFieldNameInvalidPattern = "Invalid collection field name, field name can only contain [a-zA-Z0-9_$] and it can only start with [a-zA-Z_$] for fieldName = '%s'"
+	ValidFieldNamePattern      = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
 )
 
 const (
@@ -161,7 +160,7 @@ func IsPrimitiveType(fieldType FieldType) bool {
 	return false
 }
 
-func IndexableField(fieldType FieldType) bool {
+func SupportedIndexableType(fieldType FieldType) bool {
 	switch fieldType {
 	case BoolType, Int32Type, Int64Type, UUIDType, StringType, DateTimeType, DoubleType:
 		return true
@@ -170,7 +169,7 @@ func IndexableField(fieldType FieldType) bool {
 	}
 }
 
-func SearchIndexableField(fieldType FieldType, subType FieldType) bool {
+func SupportedSearchIndexableType(fieldType FieldType, subType FieldType) bool {
 	switch fieldType {
 	case BoolType, Int32Type, Int64Type, UUIDType, StringType, DateTimeType, DoubleType:
 		return true
@@ -181,16 +180,29 @@ func SearchIndexableField(fieldType FieldType, subType FieldType) bool {
 	}
 }
 
-func FacetableField(fieldType FieldType) bool {
+func SupportedFacetableType(fieldType FieldType, subType FieldType) bool {
 	switch fieldType {
 	case Int32Type, Int64Type, StringType, DoubleType:
+		return true
+	case ArrayType:
+		return subType == Int32Type || subType == Int64Type || subType == StringType || subType == DoubleType
+	default:
+		return false
+	}
+}
+
+// DefaultFacetableType are the types for which faceting is automatically enabled for database collections.
+func DefaultFacetableType(fieldType FieldType) bool {
+	switch fieldType {
+	case Int32Type, Int64Type, DoubleType:
 		return true
 	default:
 		return false
 	}
 }
 
-func DefaultSortableField(fieldType FieldType) bool {
+// DefaultSortableType are the types for which sorting is automatically enabled.
+func DefaultSortableType(fieldType FieldType) bool {
 	switch fieldType {
 	case Int32Type, Int64Type, DoubleType, DateTimeType, BoolType:
 		return true
@@ -325,110 +337,45 @@ type FieldBuilder struct {
 	Fields      []*Field
 }
 
-func (f *FieldBuilder) Validate(v []byte) error {
-	var fieldProperties map[string]jsoniter.RawMessage
-	if err := jsoniter.Unmarshal(v, &fieldProperties); err != nil {
-		return err
-	}
-
-	for key := range fieldProperties {
-		if !SupportedFieldProperties.Contains(key) {
-			return errors.InvalidArgument("unsupported property found '%s'", key)
-		}
-	}
-
-	return nil
-}
-
-func (f *FieldBuilder) Build(isArrayElement bool) (*Field, error) {
-	if IsReservedField(f.FieldName) {
-		return nil, errors.InvalidArgument("following reserved fields are not allowed %q", ReservedFields)
-	}
-
-	// for array elements, items will have field name empty so skip the test for that.
-	// make sure they start with [a-z], [A-Z], $, _ and can only contain [a-z], [A-Z], $, _, [0-9]
-	if !isArrayElement && !ValidFieldNamePattern.MatchString(f.FieldName) {
-		return nil, errors.InvalidArgument(MsgFieldNameInvalidPattern, f.FieldName)
-	}
-
+func (f *FieldBuilder) Build(forSearchIndex bool) (*Field, error) {
 	fieldType := ToFieldType(f.Type, f.Encoding, f.Format)
-	if fieldType == UnknownType {
-		if len(f.Encoding) > 0 {
-			return nil, errors.InvalidArgument("unsupported encoding '%s'", f.Encoding)
+	if forSearchIndex {
+		// for search indexes, any field in schema is search indexable if it is not set explicitly.
+		// Similarly, we also tag it with sort if it is numeric.
+		if len(f.FieldName) > 0 && fieldType != ObjectType {
+			ptrTrue := true
+			if f.SearchIndex == nil {
+				f.SearchIndex = &ptrTrue
+			}
+			if f.Sorted == nil && DefaultSortableType(fieldType) {
+				// enable it by default for numeric fields
+				f.Sorted = &ptrTrue
+			}
 		}
-		if len(f.Format) > 0 {
-			return nil, errors.InvalidArgument("unsupported format '%s'", f.Format)
-		}
-
-		return nil, errors.InvalidArgument("unsupported type detected '%s'", f.Type)
-	}
-	if f.Primary != nil && *f.Primary {
-		// validate the primary key types
-		if !IsValidKeyType(fieldType) {
-			return nil, errors.InvalidArgument("unsupported primary key type detected '%s'", f.Type)
-		}
-	}
-
-	if f.Primary == nil && f.Auto != nil && *f.Auto {
-		return nil, errors.InvalidArgument("only primary fields can be set as auto-generated '%s'", f.FieldName)
 	}
 
 	field := &Field{
 		FieldName:       f.FieldName,
 		MaxLength:       f.MaxLength,
 		DataType:        fieldType,
-		PrimaryKeyField: f.Primary,
 		Fields:          f.Fields,
-		AutoGenerated:   f.Auto,
 		Sorted:          f.Sorted,
 		Indexed:         f.Index,
 		Faceted:         f.Facet,
 		SearchIndexed:   f.SearchIndex,
-	}
-
-	if err := f.ValidateIndexOnField(field); err != nil {
-		return nil, err
+		PrimaryKeyField: f.Primary,
+		AutoGenerated:   f.Auto,
 	}
 
 	if f.CreatedAt != nil || f.UpdatedAt != nil || f.Default != nil {
 		var err error
 		if field.Defaulter, err = newDefaulter(f.CreatedAt, f.UpdatedAt, field.FieldName, field.DataType, f.Default); err != nil {
-			return nil, err
+			// just log, as this should not happen and during incoming request the field builder should have already caught this.
+			log.Err(err).Msgf("defaulter creation failed for field '%s'", field.FieldName)
 		}
 	}
 
 	return field, nil
-}
-
-func (f *FieldBuilder) ValidateIndexOnField(field *Field) error {
-	if err := checkFieldIndex(field, false); err != nil {
-		return err
-	}
-
-	for _, sub := range field.Fields {
-		if err := checkFieldIndex(sub, true); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func checkFieldIndex(field *Field, isSubField bool) error {
-	indexed := false
-	if field.Indexed != nil {
-		indexed = *field.Indexed
-	}
-	if indexed && isSubField && len(field.Name()) > 0 {
-		return errors.InvalidArgument("Cannot index nested field '%s'", field.Name())
-	}
-
-	if indexed && isSubField {
-		return errors.InvalidArgument("Cannot index nested field in array")
-	}
-	if indexed && !field.IsIndexable() {
-		return errors.InvalidArgument("'%s' has been configured to be indexed but it is not a supported indexable type. Only top level non-byte fields can be indexed.", field.Name())
-	}
-	return nil
 }
 
 type Field struct {
@@ -469,6 +416,18 @@ func (f *Field) IsSorted() bool {
 	return f.Sorted != nil && *f.Sorted
 }
 
+func (f *Field) IsIndexed() bool {
+	return f.Indexed != nil && *f.Indexed
+}
+
+func (f *Field) IsSearchIndexed() bool {
+	return f.SearchIndexed != nil && *f.SearchIndexed
+}
+
+func (f *Field) IsFaceted() bool {
+	return f.Faceted != nil && *f.Faceted
+}
+
 func (f *Field) IsCompatible(f1 *Field) error {
 	if f.DataType != f1.DataType && !config.DefaultConfig.Schema.AllowIncompatible {
 		return errors.InvalidArgument("data type mismatch for field %q", f.FieldName)
@@ -502,216 +461,9 @@ func (f *Field) GetDefaulter() *FieldDefaulter {
 }
 
 func (f *Field) IsIndexable() bool {
-	if f.Indexed != nil && *f.Indexed && IndexableField(f.DataType) {
+	if f.Indexed != nil && *f.Indexed && SupportedIndexableType(f.DataType) {
 		return true
 	}
 
 	return false
-}
-
-type QueryableField struct {
-	FieldName     string
-	Indexed       bool // Secondary Index
-	InMemoryAlias string
-	Faceted       bool
-	SearchIndexed bool
-	Sortable      bool
-	DataType      FieldType
-	SubType       FieldType
-	SearchType    string
-	packThis      bool
-}
-
-func (builder *QueryableFieldsBuilder) NewQueryableField(name string, f *Field, fieldsInSearch []tsApi.Field) *QueryableField {
-	var (
-		searchType    string
-		searchIndexed *bool
-		faceted       *bool
-		sortable      = f.Sorted
-	)
-
-	subType := UnknownType
-	if f.DataType == ArrayType && len(f.Fields) > 0 {
-		subType = f.Fields[0].DataType
-	}
-
-	packThis := false
-	if f.DataType == ArrayType {
-		for _, fieldInSearch := range fieldsInSearch {
-			if fieldInSearch.Name == name {
-				searchType = fieldInSearch.Type
-				if searchType == FieldNames[StringType] {
-					packThis = true
-				}
-
-				searchIndexed = fieldInSearch.Index
-				faceted = fieldInSearch.Facet
-				sortable = fieldInSearch.Sort
-			}
-		}
-	}
-
-	if len(searchType) == 0 {
-		searchType = toSearchFieldType(f.DataType, subType)
-	}
-
-	if builder.ForSearchIndex {
-		searchIndexed = f.SearchIndexed
-		if searchIndexed == nil {
-			shouldIndex := SearchIndexableField(f.DataType, subType)
-			searchIndexed = &shouldIndex
-		}
-
-		ptrTrue := true
-		if f.DataType == ByteType && searchIndexed == nil {
-			searchIndexed = &ptrTrue
-		}
-
-		faceted = f.Faceted
-
-		if sortable == nil && (f.DataType == Int32Type || f.DataType == Int64Type || f.DataType == DoubleType || f.DataType == DateTimeType) {
-			// enable it by default for numeric fields
-			sortable = &ptrTrue
-		}
-	} else {
-		if searchIndexed == nil {
-			shouldIndex := SearchIndexableField(f.DataType, subType)
-			searchIndexed = &shouldIndex
-		}
-		if faceted == nil {
-			shouldFacet := FacetableField(f.DataType)
-			faceted = &shouldFacet
-		}
-		if sortable == nil {
-			shouldSort := DefaultSortableField(f.DataType)
-			sortable = &shouldSort
-		}
-	}
-
-	q := &QueryableField{
-		FieldName:  name,
-		SearchType: searchType,
-		DataType:   f.DataType,
-		SubType:    subType,
-		packThis:   packThis,
-		Indexed:    f.IsIndexable(),
-	}
-
-	if searchIndexed != nil && *searchIndexed {
-		q.SearchIndexed = true
-	}
-	if sortable != nil && *sortable {
-		q.Sortable = true
-	}
-	if faceted != nil && *faceted {
-		q.Faceted = true
-	}
-
-	if IsSearchID(name) {
-		q.InMemoryAlias = ReservedFields[IdToSearchKey]
-	} else {
-		q.InMemoryAlias = name
-	}
-	return q
-}
-
-// InMemoryName returns key name that is used to index this field in the indexing store. For example, an "id" key is indexed with
-// "_tigris_id" name.
-func (q *QueryableField) InMemoryName() string {
-	return q.InMemoryAlias
-}
-
-// Name returns the name of this field as defined in the schema.
-func (q *QueryableField) Name() string {
-	return q.FieldName
-}
-
-// Type returns the data type of this field.
-func (q *QueryableField) Type() FieldType {
-	return q.DataType
-}
-
-// ShouldPack returns true if we need to pack this field before sending to indexing store.
-func (q *QueryableField) ShouldPack() bool {
-	if q.packThis {
-		return true
-	}
-
-	if q.DataType == ArrayType && (q.SubType == ArrayType || q.SubType == ObjectType || q.SubType == UnknownType) {
-		return true
-	}
-	return !q.IsReserved() && q.DataType == DateTimeType
-}
-
-// IsReserved returns true if the queryable field is internal field.
-func (q *QueryableField) IsReserved() bool {
-	return IsReservedField(q.Name())
-}
-
-func (q *QueryableField) KeyPath() []string {
-	return strings.Split(q.FieldName, ".")
-}
-
-type QueryableFieldsBuilder struct {
-	ForSearchIndex bool
-}
-
-func NewQueryableFieldsBuilder(forSearchIndex bool) *QueryableFieldsBuilder {
-	return &QueryableFieldsBuilder{
-		ForSearchIndex: forSearchIndex,
-	}
-}
-
-func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fieldsInSearch []tsApi.Field) []*QueryableField {
-	var queryableFields []*QueryableField
-
-	for _, f := range fields {
-		if f.DataType == ObjectType {
-			queryableFields = append(queryableFields, builder.buildQueryableForObject(f.FieldName, f.Fields, fieldsInSearch)...)
-		} else {
-			queryableFields = append(queryableFields, builder.buildQueryableField("", f, fieldsInSearch))
-		}
-	}
-
-	ptrTrue := true
-	// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
-	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[CreatedAt], &Field{
-		FieldName:     ReservedFields[CreatedAt],
-		DataType:      DateTimeType,
-		Sorted:        &ptrTrue,
-		SearchIndexed: &ptrTrue,
-		Indexed:       &ptrTrue,
-	}, fieldsInSearch))
-
-	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
-		FieldName:     ReservedFields[UpdatedAt],
-		DataType:      DateTimeType,
-		Sorted:        &ptrTrue,
-		SearchIndexed: &ptrTrue,
-		Indexed:       &ptrTrue,
-	}, fieldsInSearch))
-
-	return queryableFields
-}
-
-func (builder *QueryableFieldsBuilder) buildQueryableForObject(parent string, fields []*Field, fieldsInSearch []tsApi.Field) []*QueryableField {
-	var queryable []*QueryableField
-	for _, nested := range fields {
-		if nested.DataType != ObjectType {
-			queryable = append(queryable, builder.buildQueryableField(parent, nested, fieldsInSearch))
-		} else {
-			queryable = append(queryable, builder.buildQueryableForObject(parent+ObjFlattenDelimiter+nested.FieldName, nested.Fields, fieldsInSearch)...)
-		}
-	}
-
-	return queryable
-}
-
-func (builder *QueryableFieldsBuilder) buildQueryableField(parent string, f *Field, fieldsInSearch []tsApi.Field) *QueryableField {
-	name := f.FieldName
-	if len(parent) > 0 {
-		name = parent + ObjFlattenDelimiter + f.FieldName
-	}
-
-	return builder.NewQueryableField(name, f, fieldsInSearch)
 }

--- a/schema/migration.go
+++ b/schema/migration.go
@@ -119,11 +119,12 @@ func buildSchemaDelta(schema1 Version, schema2 Version) (*VersionDelta, error) {
 		err           error
 	)
 
-	if first, err = Build("", schema1.Schema); err != nil {
+	fb := NewFactoryBuilder(false)
+	if first, err = fb.Build("", schema1.Schema); err != nil {
 		return nil, err
 	}
 
-	if second, err = Build("", schema2.Schema); err != nil {
+	if second, err = fb.Build("", schema2.Schema); err != nil {
 		return nil, err
 	}
 

--- a/schema/queryable.go
+++ b/schema/queryable.go
@@ -1,0 +1,193 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"strings"
+
+	tsApi "github.com/typesense/typesense-go/typesense/api"
+)
+
+type QueryableField struct {
+	FieldName     string
+	Indexed       bool // Secondary Index
+	InMemoryAlias string
+	Faceted       bool
+	SearchIndexed bool
+	Sortable      bool
+	DataType      FieldType
+	SubType       FieldType
+	SearchType    string
+	packThis      bool
+}
+
+// InMemoryName returns key name that is used to index this field in the indexing store. For example, an "id" key is indexed with
+// "_tigris_id" name.
+func (q *QueryableField) InMemoryName() string {
+	return q.InMemoryAlias
+}
+
+// Name returns the name of this field as defined in the schema.
+func (q *QueryableField) Name() string {
+	return q.FieldName
+}
+
+// Type returns the data type of this field.
+func (q *QueryableField) Type() FieldType {
+	return q.DataType
+}
+
+// ShouldPack returns true if we need to pack this field before sending to indexing store.
+func (q *QueryableField) ShouldPack() bool {
+	if q.packThis {
+		return true
+	}
+
+	if q.DataType == ArrayType && (q.SubType == ArrayType || q.SubType == ObjectType || q.SubType == UnknownType) {
+		return true
+	}
+	return !q.IsReserved() && q.DataType == DateTimeType
+}
+
+// IsReserved returns true if the queryable field is internal field.
+func (q *QueryableField) IsReserved() bool {
+	return IsReservedField(q.Name())
+}
+
+func (q *QueryableField) KeyPath() []string {
+	return strings.Split(q.FieldName, ".")
+}
+
+type QueryableFieldsBuilder struct{}
+
+func NewQueryableFieldsBuilder() *QueryableFieldsBuilder {
+	return &QueryableFieldsBuilder{}
+}
+
+func (builder *QueryableFieldsBuilder) NewQueryableField(name string, f *Field, fieldsInSearch []tsApi.Field) *QueryableField {
+	var (
+		searchType    string
+		faceted       = f.Faceted
+		sortable      = f.Sorted
+		searchIndexed = f.SearchIndexed
+	)
+
+	subType := UnknownType
+	if f.DataType == ArrayType && len(f.Fields) > 0 {
+		subType = f.Fields[0].DataType
+	}
+
+	packThis := false
+	if f.DataType == ArrayType {
+		for _, fieldInSearch := range fieldsInSearch {
+			if fieldInSearch.Name == name {
+				searchType = fieldInSearch.Type
+				if searchType == FieldNames[StringType] {
+					packThis = true
+
+					// honor whatever we have in search for this case, these are very old collection when we were
+					// packing arrays. Probably not been in use.
+					searchIndexed = fieldInSearch.Index
+					faceted = fieldInSearch.Facet
+					sortable = fieldInSearch.Sort
+				}
+			}
+		}
+	}
+
+	if len(searchType) == 0 {
+		searchType = toSearchFieldType(f.DataType, subType)
+	}
+
+	q := &QueryableField{
+		FieldName:  name,
+		SearchType: searchType,
+		DataType:   f.DataType,
+		SubType:    subType,
+		packThis:   packThis,
+		Indexed:    f.IsIndexable(),
+	}
+
+	if searchIndexed != nil && *searchIndexed {
+		q.SearchIndexed = true
+	}
+	if sortable != nil && *sortable {
+		q.Sortable = true
+	}
+	if faceted != nil && *faceted {
+		q.Faceted = true
+	}
+
+	if IsSearchID(name) {
+		q.InMemoryAlias = ReservedFields[IdToSearchKey]
+	} else {
+		q.InMemoryAlias = name
+	}
+	return q
+}
+
+func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fieldsInSearch []tsApi.Field) []*QueryableField {
+	var queryableFields []*QueryableField
+
+	for _, f := range fields {
+		if f.DataType == ObjectType {
+			queryableFields = append(queryableFields, builder.buildQueryableForObject(f.FieldName, f.Fields, fieldsInSearch)...)
+		} else {
+			queryableFields = append(queryableFields, builder.buildQueryableField("", f, fieldsInSearch))
+		}
+	}
+
+	ptrTrue := true
+	// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
+	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[CreatedAt], &Field{
+		FieldName:     ReservedFields[CreatedAt],
+		DataType:      DateTimeType,
+		Sorted:        &ptrTrue,
+		SearchIndexed: &ptrTrue,
+		Indexed:       &ptrTrue,
+	}, fieldsInSearch))
+
+	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
+		FieldName:     ReservedFields[UpdatedAt],
+		DataType:      DateTimeType,
+		Sorted:        &ptrTrue,
+		SearchIndexed: &ptrTrue,
+		Indexed:       &ptrTrue,
+	}, fieldsInSearch))
+
+	return queryableFields
+}
+
+func (builder *QueryableFieldsBuilder) buildQueryableForObject(parent string, fields []*Field, fieldsInSearch []tsApi.Field) []*QueryableField {
+	var queryable []*QueryableField
+	for _, nested := range fields {
+		if nested.DataType != ObjectType {
+			queryable = append(queryable, builder.buildQueryableField(parent, nested, fieldsInSearch))
+		} else {
+			queryable = append(queryable, builder.buildQueryableForObject(parent+ObjFlattenDelimiter+nested.FieldName, nested.Fields, fieldsInSearch)...)
+		}
+	}
+
+	return queryable
+}
+
+func (builder *QueryableFieldsBuilder) buildQueryableField(parent string, f *Field, fieldsInSearch []tsApi.Field) *QueryableField {
+	name := f.FieldName
+	if len(parent) > 0 {
+		name = parent + ObjFlattenDelimiter + f.FieldName
+	}
+
+	return builder.NewQueryableField(name, f, fieldsInSearch)
+}

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/config"
 )
@@ -35,10 +36,18 @@ var searchIndexValidators = []SearchIndexValidator{
 	&IndexSourceValidator{},
 }
 
+// Validator is a backward compatibility validator i.e. when an update request for a collection is received then a set
+// of validators are run to ensure that collection is safe to upgrade from state A to B.
+//
+// Note: Validators have no role during initial collection creation as there is no backward compatibility check at that
+// point.
 type Validator interface {
 	Validate(existing *DefaultCollection, current *Factory) error
 }
 
+// SearchIndexValidator is a backward compatibility validator i.e. when an update request for a search
+// index is received then a set of validators are run to ensure that search index is safe to upgrade from
+// state A to B.
 type SearchIndexValidator interface {
 	ValidateIndex(existing *SearchIndex, current *SearchFactory) error
 }
@@ -142,14 +151,14 @@ func (v *IndexSourceValidator) ValidateIndex(existing *SearchIndex, current *Sea
 	return nil
 }
 
-// ApplySchemaRules is to validate incoming collection request against the existing present collection. It performs
+// ApplyBackwardCompatibilityRules is to validate incoming collection request against the existing present collection. It performs
 // following validations,
 //   - Primary Key Changed, or order of fields part of the primary key is changed
 //   - Collection name change
 //   - A validation on field property is also applied like for instance if existing field has some property, but it is
 //     removed in the new schema
 //   - Any index exist on the collection will also have same checks like type, etc
-func ApplySchemaRules(existing *DefaultCollection, current *Factory) error {
+func ApplyBackwardCompatibilityRules(existing *DefaultCollection, current *Factory) error {
 	if existing.Name != current.Name {
 		return ErrCollectionNameMismatch
 	}
@@ -163,12 +172,12 @@ func ApplySchemaRules(existing *DefaultCollection, current *Factory) error {
 	return nil
 }
 
-// ApplySearchIndexSchemaRules is to validate incoming index schema against the existing index version. It performs
+// ApplySearchIndexBackwardCompatibilityRules is to validate incoming index schema against the existing index version. It performs
 // following validations,
 //   - Collection name change.
 //   - A validation on field like changing the type is not allowed.
 //   - A validation on index source, it is defined during index creation and should not change afterwards.
-func ApplySearchIndexSchemaRules(existing *SearchIndex, current *SearchFactory) error {
+func ApplySearchIndexBackwardCompatibilityRules(existing *SearchIndex, current *SearchFactory) error {
 	if existing.Name != current.Name {
 		return ErrIndexNameMismatch
 	}
@@ -176,6 +185,181 @@ func ApplySearchIndexSchemaRules(existing *SearchIndex, current *SearchFactory) 
 	for _, v := range searchIndexValidators {
 		if err := v.ValidateIndex(existing, current); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateFieldBuilder is to validate before building a field. This is done because there are some validation that
+// can't be caught in the "ValidateFieldAttributes" like the values for default fields. Anything that needs to be
+// validated on builder and can't be done on field has to be done here. Similar to ValidateFieldAttributes, this is
+// also only done during incoming requests and ignored during reloading of schemas.
+func ValidateFieldBuilder(f FieldBuilder) error {
+	fieldType := ToFieldType(f.Type, f.Encoding, f.Format)
+	if fieldType == UnknownType {
+		if len(f.Encoding) > 0 {
+			return errors.InvalidArgument("unsupported encoding '%s'", f.Encoding)
+		}
+		if len(f.Format) > 0 {
+			return errors.InvalidArgument("unsupported format '%s'", f.Format)
+		}
+
+		return errors.InvalidArgument("unsupported type detected '%s'", f.Type)
+	}
+
+	if f.CreatedAt != nil || f.UpdatedAt != nil || f.Default != nil {
+		if _, err := newDefaulter(f.CreatedAt, f.UpdatedAt, f.FieldName, fieldType, f.Default); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateFieldAttributes is validated when a schema request is received. Each builder(collection/search) calls this
+// method to validate if field is properly formed. This is done outside the fieldBuilder to avoid doing validation
+// during reloading of schemas. This method recursively checks each field that whether the attributes are properly set
+// or not.
+func ValidateFieldAttributes(isSearch bool, field *Field) error {
+	if IsReservedField(field.FieldName) {
+		return errors.InvalidArgument("following reserved fields are not allowed %q", ReservedFields)
+	}
+
+	if isSearch {
+		if field.IsPrimaryKey() {
+			return errors.InvalidArgument("setting primary key is not supported on search index '%s'", field.Name())
+		}
+
+		if field.FieldName == SearchId {
+			if field.DataType != StringType {
+				return errors.InvalidArgument("Only string type is supported as 'id' field")
+			}
+		}
+	} else {
+		if field.IsPrimaryKey() {
+			// validate the primary key types
+			if !IsValidKeyType(field.DataType) {
+				return errors.InvalidArgument("unsupported primary key type detected '%s'", FieldNames[field.DataType])
+			}
+		}
+		if !field.IsPrimaryKey() && field.AutoGenerated != nil && *field.AutoGenerated {
+			return errors.InvalidArgument("only primary fields can be set as auto-generated '%s'", field.FieldName)
+		}
+	}
+
+	if field.DataType == ObjectType {
+		if hasIndexingAttributes(field) {
+			if field.IsIndexed() {
+				return errors.InvalidArgument("Cannot enable index on object '%s' or object fields", field.Name())
+			} else {
+				return errors.InvalidArgument("Cannot have search attributes on object '%s', set it on object fields", field.Name())
+			}
+		}
+		return validateObjectFields(field, false)
+	}
+
+	return validateFields(field, false)
+}
+
+func validateObjectFields(f *Field, notSupported bool) error {
+	for _, nested := range f.Fields {
+		if nested.DataType == ObjectType {
+			if hasIndexingAttributes(nested) {
+				if nested.IsIndexed() {
+					return errors.InvalidArgument("Cannot enable index on object '%s' or object fields", nested.Name())
+				} else {
+					return errors.InvalidArgument("Cannot have search attributes on object '%s', set it on object fields", nested.Name())
+				}
+			}
+
+			if err := validateObjectFields(nested, notSupported); err != nil {
+				return err
+			}
+		} else {
+			if nested.IsIndexed() {
+				return errors.InvalidArgument("Cannot enable index on nested field '%s'", nested.Name())
+			}
+			if err := validateFields(nested, notSupported); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateFields(f *Field, notSupported bool) error {
+	if f.DataType == ArrayType {
+		if f.Fields[0].DataType != ObjectType {
+			return validateFieldAttribute(f, notSupported)
+		}
+
+		if hasIndexingAttributes(f) || hasIndexingAttributes(f.Fields[0]) {
+			return errors.InvalidArgument("Cannot enable index or search on an array of objects '%s'", f.FieldName)
+		}
+
+		// for arrays, we are validating that there are no attribute set on any nested objects
+		return validateObjectFields(f.Fields[0], true)
+	}
+
+	return validateFieldAttribute(f, notSupported)
+}
+
+func validateFieldAttribute(f *Field, notSupported bool) error {
+	// for array elements, items will have field name empty so skip the test for that.
+	// make sure they start with [a-z], [A-Z], $, _ and can only contain [a-z], [A-Z], $, _, [0-9]
+	if len(f.FieldName) > 0 && !ValidFieldNamePattern.MatchString(f.FieldName) {
+		return errors.InvalidArgument(MsgFieldNameInvalidPattern, f.FieldName)
+	}
+
+	if notSupported && hasIndexingAttributes(f) {
+		return errors.InvalidArgument("Cannot enable index or search on an array of objects")
+	}
+
+	subType := UnknownType
+	if f.DataType == ArrayType {
+		if hasIndexingAttributes(f.Fields[0]) {
+			return errors.InvalidArgument("Attributes for primitive arrays needs to be set on array level '%s'", f.FieldName)
+		}
+
+		subType = f.Fields[0].DataType
+	}
+
+	if f.IsIndexed() && !f.IsIndexable() {
+		return errors.InvalidArgument("Cannot enable index on field '%s' of type '%s'. Only top level non-byte fields can be indexed.", f.FieldName, FieldNames[f.DataType])
+	}
+	if f.IsSearchIndexed() && !SupportedSearchIndexableType(f.DataType, subType) {
+		return errors.InvalidArgument("Cannot enable search index on field '%s' of type '%s'", f.FieldName, FieldNames[f.DataType])
+	}
+	if !f.IsSearchIndexed() && (f.IsFaceted() || f.IsSorted()) {
+		return errors.InvalidArgument("Enable search index first to use faceting or sorting on field '%s' of type '%s'", f.FieldName, FieldNames[f.DataType])
+	}
+	if f.IsFaceted() && !SupportedFacetableType(f.DataType, subType) {
+		return errors.InvalidArgument("Cannot enable faceting on field '%s'", f.FieldName)
+	}
+	if f.IsSorted() && !IsPrimitiveType(f.DataType) {
+		return errors.InvalidArgument("Cannot enable sorting on field '%s' of type '%s'", f.FieldName, FieldNames[f.DataType])
+	}
+
+	return nil
+}
+
+func hasIndexingAttributes(f *Field) bool {
+	return f.IsIndexed() || f.IsSearchIndexed() || f.IsFaceted() || f.IsSorted()
+}
+
+// ValidateSupportedProperties to validate what all JSON tagging is allowed on a field. We can extend this to also
+// validate based on whether the schema is for search or for collection.
+func ValidateSupportedProperties(v []byte) error {
+	var fieldProperties map[string]jsoniter.RawMessage
+	if err := jsoniter.Unmarshal(v, &fieldProperties); err != nil {
+		return err
+	}
+
+	for key := range fieldProperties {
+		if !SupportedFieldProperties.Contains(key) {
+			return errors.InvalidArgument("unsupported property found '%s'", key)
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -15,7 +15,6 @@
 package schema
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -171,7 +170,7 @@ func GetCollectionType(_ jsoniter.RawMessage) (CollectionType, error) {
 }
 
 // Build is used to deserialize the user json schema into a schema factory.
-func Build(collection string, reqSchema jsoniter.RawMessage) (*Factory, error) {
+func (fb *FactoryBuilder) Build(collection string, reqSchema jsoniter.RawMessage) (*Factory, error) {
 	cType, err := GetCollectionType(reqSchema)
 	if err != nil {
 		return nil, api.Errorf(api.Code_INTERNAL, err.Error()).WithDetails(&api.ErrorDetails{
@@ -205,7 +204,7 @@ func Build(collection string, reqSchema jsoniter.RawMessage) (*Factory, error) {
 	}
 
 	primaryKeysSet := container.NewHashSet(schema.PrimaryKeys...)
-	fields, err := deserializeProperties(schema.Properties, &primaryKeysSet)
+	fields, err := fb.deserializeProperties(schema.Properties, &primaryKeysSet)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +224,7 @@ func Build(collection string, reqSchema jsoniter.RawMessage) (*Factory, error) {
 		}
 	}
 
-	return &Factory{
+	factory := &Factory{
 		Fields: fields,
 		Indexes: &Indexes{
 			PrimaryKey: &Index{
@@ -242,7 +241,25 @@ func Build(collection string, reqSchema jsoniter.RawMessage) (*Factory, error) {
 		CollectionType:  cType,
 		IndexingVersion: schema.IndexingVersion,
 		Version:         schema.Version,
-	}, nil
+	}
+
+	if fb.onUserRequest {
+		if err = fb.validateSchema(factory); err != nil {
+			return nil, err
+		}
+	}
+
+	return factory, nil
+}
+
+func (fb *FactoryBuilder) validateSchema(factory *Factory) error {
+	for _, f := range factory.Fields {
+		if err := ValidateFieldAttributes(false, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func setPrimaryKey(reqSchema jsoniter.RawMessage, format string, ifMissing bool) (jsoniter.RawMessage, error) {
@@ -273,106 +290,6 @@ func setPrimaryKey(reqSchema jsoniter.RawMessage, format string, ifMissing bool)
 	}
 
 	return jsoniter.Marshal(schema)
-}
-
-func deserializeArray(items *FieldBuilder, current *[]*Field) error {
-	for ; items.Items != nil; items = items.Items {
-		it, err := items.Build(true)
-		if err != nil {
-			return err
-		}
-
-		*current = []*Field{it}
-		current = &it.Fields
-	}
-
-	// object array type
-	if len(items.Properties) > 0 {
-		if items.Type != jsonSpecObject {
-			return errors.InvalidArgument("properties only allowed for object type")
-		}
-
-		nestedFields, err := deserializeProperties(items.Properties, nil)
-		if err != nil {
-			return err
-		}
-
-		*current = []*Field{{DataType: ObjectType, Fields: nestedFields}}
-	} else {
-		// primitive array type
-		it, err := items.Build(true)
-		if err != nil {
-			return err
-		}
-
-		*current = []*Field{it}
-	}
-
-	return nil
-}
-
-func deserializeProperties(properties jsoniter.RawMessage, primaryKeysSet *container.HashSet) ([]*Field, error) {
-	var fields []*Field
-
-	err := jsonparser.ObjectEach(properties, func(key []byte, v []byte, dataType jsonparser.ValueType, offset int) error {
-		var err error
-		var builder FieldBuilder
-
-		if err = builder.Validate(v); err != nil {
-			// builder validates against the supported schema attributes on properties
-			return err
-		}
-
-		// set field name and try to unmarshal the value into field builder
-		builder.FieldName = string(key)
-
-		dec := jsoniter.NewDecoder(bytes.NewReader(v))
-		dec.UseNumber()
-		if err = dec.Decode(&builder); err != nil {
-			return errors.Internal(err.Error())
-		}
-
-		if builder.Type == jsonSpecArray {
-			if builder.Items == nil {
-				return errors.InvalidArgument("missing items for array field")
-			}
-
-			if err = deserializeArray(builder.Items, &builder.Fields); err != nil {
-				return err
-			}
-		}
-
-		// for objects, properties are part of the field definitions in that case deserialize those
-		// nested fields
-		if len(builder.Properties) > 0 {
-			if builder.Type != jsonSpecObject {
-				return errors.InvalidArgument("properties only allowed for object type")
-			}
-
-			if builder.Fields, err = deserializeProperties(builder.Properties, nil); err != nil {
-				return err
-			}
-		}
-
-		if primaryKeysSet != nil && primaryKeysSet.Contains(builder.FieldName) {
-			boolTrue := true
-			builder.Primary = &boolTrue
-		}
-
-		f, err := builder.Build(false)
-		if err != nil {
-			return err
-		}
-
-		fields = append(fields, f)
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return fields, nil
 }
 
 // Generate schema in the requested format.

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -25,7 +25,7 @@ import (
 func TestCreateCollectionFromSchema(t *testing.T) {
 	t.Run("test_create_success", func(t *testing.T) {
 		reqSchema := []byte(`{"title":"t1", "description":"This document records the details of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
-		schF, err := Build("t1", reqSchema)
+		schF, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 		require.NoError(t, err)
 
 		c, err := NewDefaultCollection(1, 1, schF, nil, nil)
@@ -37,7 +37,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	})
 	t.Run("test_create_failure", func(t *testing.T) {
 		reqSchema := []byte(`{"title":"Record of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
-		_, err := Build("t1", reqSchema)
+		_, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 		require.Equal(t, "collection name is not same as schema name 't1' 'Record of an order'", err.(*api.TigrisError).Error())
 	})
 	t.Run("test_supported_types", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1", "K2"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1", "K2", "K3", "K4", "K5"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -127,13 +127,13 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 				"type": "number"
 			},
 			"K2": {
-				"type": "int"
+				"type": "integer"
 			}
 		},
 		"primary_key": ["K1"]
 	}`)
-		_, err := Build("t1", schema)
-		require.Equal(t, "unsupported primary key type detected 'number'", err.(*api.TigrisError).Error())
+		_, err := NewFactoryBuilder(true).Build("t1", schema)
+		require.Equal(t, "unsupported primary key type detected 'double'", err.(*api.TigrisError).Error())
 	})
 
 	t.Run("test_complex_types", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["id"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 
 		coll, err := NewDefaultCollection(1, 1, sch, nil, nil)
@@ -331,7 +331,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["id"]
 }`)
-		_, err := Build("t1", schema)
+		_, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.Equal(t, errors.InvalidArgument("missing items for array field"), err)
 	})
 
@@ -356,7 +356,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["id"]
 }`)
-		_, err := Build("t1", schema)
+		_, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.Equal(t, "properties only allowed for object type", err.Error())
 	})
 
@@ -373,7 +373,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["id"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -403,7 +403,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1", "K2"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1"]
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -468,7 +468,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1"]
 }`)
-		_, err := Build("t1", schema)
+		_, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.Equal(t, "now() is only supported for date-time type", err.Error())
 
 		schema = []byte(`{
@@ -484,7 +484,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 	},
 	"primary_key": ["K1"]
 }`)
-		_, err = Build("t1", schema)
+		_, err = NewFactoryBuilder(true).Build("t1", schema)
 		require.Equal(t, "'random()' function is not supported", err.Error())
 	})
 	t.Run("test_no-primary-key-default-id", func(t *testing.T) {
@@ -500,7 +500,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		}
 	}
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
@@ -532,7 +532,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		}
 	}
 }`)
-		sch, err := Build("t1", schema)
+		sch, err := NewFactoryBuilder(true).Build("t1", schema)
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)

--- a/schema/search.go
+++ b/schema/search.go
@@ -60,29 +60,9 @@ type SearchFactory struct {
 	Source SearchSource
 }
 
-func ValidateSearchSchema(factory *SearchFactory) error {
-	if factory.Source.Type != SearchSourceExternal {
-		return errors.InvalidArgument("unsupported index source '%s'", factory.Source.Type)
-	}
+func (fb *FactoryBuilder) BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, error) {
+	fb.setBuilderForSearch()
 
-	for _, f := range factory.Fields {
-		if f.Faceted != nil && *f.Faceted && !FacetableField(f.DataType) {
-			return errors.InvalidArgument("facet is not allowed for field type '%s'", FieldNames[f.DataType])
-		}
-
-		if f.Sorted != nil && *f.Sorted {
-			switch f.DataType {
-			case Int32Type, Int64Type, DoubleType, DateTimeType, BoolType, StringType:
-			default:
-				return errors.InvalidArgument("sort is not allowed for field type '%s'", FieldNames[f.DataType])
-			}
-		}
-	}
-
-	return nil
-}
-
-func BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, error) {
 	searchSchema := make([]byte, len(reqSchema))
 	copy(searchSchema, reqSchema)
 
@@ -96,7 +76,7 @@ func BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, e
 	if len(schema.Properties) == 0 {
 		return nil, errors.InvalidArgument("missing properties field in schema")
 	}
-	fields, err := deserializeProperties(schema.Properties, nil)
+	fields, err := fb.deserializeProperties(schema.Properties, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +124,41 @@ func BuildSearch(index string, reqSchema jsoniter.RawMessage) (*SearchFactory, e
 		Source: source,
 	}
 
+	idFound := false
+	for _, f := range factory.Fields {
+		if f.FieldName == SearchId {
+			idFound = true
+			break
+		}
+	}
+	if !idFound {
+		factory.Fields = append(factory.Fields, &Field{
+			FieldName: SearchId,
+			DataType:  StringType,
+		})
+	}
+
+	if fb.onUserRequest {
+		if err = fb.validateSearchSchema(factory); err != nil {
+			return nil, err
+		}
+	}
+
 	return factory, nil
+}
+
+func (fb *FactoryBuilder) validateSearchSchema(factory *SearchFactory) error {
+	if factory.Source.Type != SearchSourceExternal {
+		return errors.InvalidArgument("unsupported index source '%s'", factory.Source.Type)
+	}
+
+	for _, f := range factory.Fields {
+		if err := ValidateFieldAttributes(true, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // SearchIndex is to manage search index created by the user.
@@ -168,17 +182,19 @@ type SearchIndex struct {
 }
 
 func NewSearchIndex(ver int, searchStoreName string, factory *SearchFactory, fieldsInSearch []tsApi.Field) *SearchIndex {
-	queryableFields := NewQueryableFieldsBuilder(true).BuildQueryableFields(factory.Fields, fieldsInSearch)
+	queryableFields := NewQueryableFieldsBuilder().BuildQueryableFields(factory.Fields, fieldsInSearch)
 
-	return &SearchIndex{
+	index := &SearchIndex{
 		Version:         ver,
 		Name:            factory.Name,
 		Fields:          factory.Fields,
 		Schema:          factory.Schema,
 		QueryableFields: queryableFields,
-		StoreSchema:     buildSearchSchema(searchStoreName, queryableFields),
 		Source:          factory.Source,
 	}
+	index.buildSearchSchema(searchStoreName)
+
+	return index
 }
 
 func (s *SearchIndex) StoreIndexName() string {
@@ -194,10 +210,10 @@ func (s *SearchIndex) GetQueryableField(name string) (*QueryableField, error) {
 	return nil, errors.InvalidArgument("Field `%s` is not present in collection", name)
 }
 
-func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.CollectionSchema {
+func (s *SearchIndex) buildSearchSchema(name string) {
 	ptrTrue, ptrFalse := true, false
-	tsFields := make([]tsApi.Field, 0, len(queryableFields))
-	for _, s := range queryableFields {
+	tsFields := make([]tsApi.Field, 0, len(s.QueryableFields))
+	for _, s := range s.QueryableFields {
 		tsFields = append(tsFields, tsApi.Field{
 			Name:     s.Name(),
 			Type:     s.SearchType,
@@ -206,6 +222,7 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 			Sort:     &s.Sortable,
 			Optional: &ptrTrue,
 		})
+
 		if s.InMemoryName() != s.Name() {
 			// we are storing this field differently in in-memory store
 			tsFields = append(tsFields, tsApi.Field{
@@ -217,6 +234,7 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 				Optional: &ptrTrue,
 			})
 		}
+
 		// Save original date as string to disk
 		if !s.IsReserved() && s.DataType == DateTimeType {
 			tsFields = append(tsFields, tsApi.Field{
@@ -230,16 +248,16 @@ func buildSearchSchema(name string, queryableFields []*QueryableField) *tsApi.Co
 		}
 	}
 
-	return &tsApi.CollectionSchema{
+	s.StoreSchema = &tsApi.CollectionSchema{
 		Name:   name,
 		Fields: tsFields,
 	}
 }
 
-func GetSearchDeltaFields(forSearchIndex bool, existingFields []*QueryableField, incomingFields []*Field, fieldsInSearch []tsApi.Field) []tsApi.Field {
+func (s *SearchIndex) GetSearchDeltaFields(existingFields []*QueryableField, fieldsInSearch []tsApi.Field) []tsApi.Field {
 	ptrTrue := true
 
-	incomingQueryable := NewQueryableFieldsBuilder(forSearchIndex).BuildQueryableFields(incomingFields, fieldsInSearch)
+	incomingQueryable := NewQueryableFieldsBuilder().BuildQueryableFields(s.Fields, fieldsInSearch)
 
 	existingFieldMap := make(map[string]*QueryableField)
 	for _, f := range existingFields {
@@ -256,26 +274,18 @@ func GetSearchDeltaFields(forSearchIndex bool, existingFields []*QueryableField,
 		e := existingFieldMap[f.FieldName]
 		delete(existingFieldMap, f.FieldName)
 
-		if e != nil && f.SearchType == e.SearchType {
+		if e != nil && f.SearchType == e.SearchType && f.SearchIndexed == e.SearchIndexed && f.Faceted == e.Faceted && f.Sortable == e.Sortable {
 			continue
 		}
 
-		tsField := tsApi.Field{
-			Name:     f.FieldName,
-			Type:     f.SearchType,
-			Facet:    &f.Faceted,
-			Index:    &f.SearchIndexed,
-			Optional: &ptrTrue,
-		}
-
-		// type changed. drop the field first
+		// attribute changed, drop the field first
 		if e != nil {
 			tsFields = append(tsFields, tsApi.Field{
 				Name: f.FieldName,
 				Drop: &ptrTrue,
 			})
-		} else if f.FieldName == "created_at" || f.FieldName == "updated_at" {
-			// if we have our internal old "created_at"/"updated_at" then drop it first
+		} else {
+			// this can happen if update request is timed out on Tigris side but succeed on search
 			if _, found := fieldsInSearchMap[f.FieldName]; found {
 				tsFields = append(tsFields, tsApi.Field{
 					Name: f.FieldName,
@@ -285,7 +295,14 @@ func GetSearchDeltaFields(forSearchIndex bool, existingFields []*QueryableField,
 		}
 
 		// add new field
-		tsFields = append(tsFields, tsField)
+		tsFields = append(tsFields, tsApi.Field{
+			Name:     f.FieldName,
+			Type:     f.SearchType,
+			Facet:    &f.Faceted,
+			Index:    &f.SearchIndexed,
+			Sort:     &f.Sortable,
+			Optional: &ptrTrue,
+		})
 	}
 
 	// drop fields non existing in new schema
@@ -313,20 +330,168 @@ type ImplicitSearchIndex struct {
 	// one queryableFields. As queryableFields represent a flattened state these can be used as-is to index in memory.
 	QueryableFields []*QueryableField
 
-	fieldsInSearch []tsApi.Field
+	prevVersionInSearch []tsApi.Field
 }
 
-func NewImplicitSearchIndex(name string, searchStoreName string, fields []*Field, fieldsInSearch []tsApi.Field) *ImplicitSearchIndex {
+func NewImplicitSearchIndex(name string, searchStoreName string, fields []*Field, prevVersionInSearch []tsApi.Field) *ImplicitSearchIndex {
 	// this is created by collection so the forSearchIndex is false.
-	queryableFields := NewQueryableFieldsBuilder(false).BuildQueryableFields(fields, fieldsInSearch)
-	return &ImplicitSearchIndex{
-		Name:            name,
-		QueryableFields: queryableFields,
-		StoreSchema:     buildSearchSchema(searchStoreName, queryableFields),
-		fieldsInSearch:  fieldsInSearch,
+	queryableFields := NewQueryableFieldsBuilder().BuildQueryableFields(fields, prevVersionInSearch)
+	index := &ImplicitSearchIndex{
+		Name:                name,
+		QueryableFields:     queryableFields,
+		prevVersionInSearch: prevVersionInSearch,
 	}
+
+	index.buildSearchSchema(searchStoreName)
+
+	return index
 }
 
 func (s *ImplicitSearchIndex) StoreIndexName() string {
 	return s.StoreSchema.Name
+}
+
+func (s *ImplicitSearchIndex) buildSearchSchema(searchStoreName string) {
+	ptrTrue, ptrFalse := true, false
+	tsFields := make([]tsApi.Field, 0, len(s.QueryableFields))
+
+	for _, f := range s.QueryableFields {
+		// the implicit search index by default index all the fields that are indexable and same applies to facet/sort.
+		shouldIndex := SupportedSearchIndexableType(f.DataType, f.SubType)
+		shouldFacet := DefaultFacetableType(f.DataType)
+		shouldSort := DefaultSortableType(f.DataType)
+
+		if !shouldSort && f.Sortable {
+			// honor schema i.e. in case of strings user can explicitly enable sorting.
+			shouldSort = true
+		}
+		if !shouldFacet && f.Faceted {
+			shouldFacet = true
+		}
+
+		tsFields = append(tsFields, tsApi.Field{
+			Name:     f.Name(),
+			Type:     f.SearchType,
+			Facet:    &shouldFacet,
+			Index:    &shouldIndex,
+			Sort:     &shouldSort,
+			Optional: &ptrTrue,
+		})
+
+		if f.InMemoryName() != f.Name() {
+			// we are storing this field differently in in-memory store
+			tsFields = append(tsFields, tsApi.Field{
+				Name:     f.InMemoryName(),
+				Type:     f.SearchType,
+				Facet:    &shouldFacet,
+				Index:    &shouldIndex,
+				Sort:     &shouldSort,
+				Optional: &ptrTrue,
+			})
+		}
+		// Save original date as string to disk
+		if !f.IsReserved() && f.DataType == DateTimeType {
+			tsFields = append(tsFields, tsApi.Field{
+				Name:     ToSearchDateKey(f.Name()),
+				Type:     toSearchFieldType(StringType, UnknownType),
+				Facet:    &ptrFalse,
+				Index:    &ptrFalse,
+				Sort:     &ptrFalse,
+				Optional: &ptrTrue,
+			})
+		}
+	}
+
+	s.StoreSchema = &tsApi.CollectionSchema{
+		Name:   searchStoreName,
+		Fields: tsFields,
+	}
+}
+
+func (s *ImplicitSearchIndex) GetSearchDeltaFields(existingFields []*QueryableField, incomingFields []*Field) []tsApi.Field {
+	ptrTrue := true
+
+	incomingQueryable := NewQueryableFieldsBuilder().BuildQueryableFields(incomingFields, s.prevVersionInSearch)
+
+	existingFieldMap := make(map[string]*QueryableField)
+	for _, f := range existingFields {
+		existingFieldMap[f.FieldName] = f
+	}
+
+	fieldsInSearchMap := make(map[string]tsApi.Field)
+	for _, f := range s.prevVersionInSearch {
+		fieldsInSearchMap[f.Name] = f
+	}
+
+	tsFields := make([]tsApi.Field, 0, len(incomingQueryable))
+	for _, f := range incomingQueryable {
+		e := existingFieldMap[f.FieldName]
+		delete(existingFieldMap, f.FieldName)
+
+		shouldIndex := SupportedSearchIndexableType(f.DataType, f.SubType)
+		shouldFacet := DefaultFacetableType(f.DataType)
+		shouldSort := DefaultSortableType(f.DataType)
+		if !shouldSort && f.Sortable {
+			shouldSort = true
+		}
+		if !shouldFacet && f.Faceted {
+			shouldFacet = true
+		}
+
+		stateChanged := false
+		if e != nil {
+			inSearchState, found := fieldsInSearchMap[f.FieldName]
+			if found && inSearchState.Index != nil && *inSearchState.Index != shouldIndex {
+				stateChanged = true
+			}
+			if found && inSearchState.Facet != nil && *inSearchState.Facet != shouldFacet {
+				stateChanged = true
+			}
+			if found && inSearchState.Sort != nil && *inSearchState.Sort != shouldSort {
+				stateChanged = true
+			}
+
+			if !stateChanged {
+				continue
+			}
+		}
+
+		// attribute changed, drop the field first
+		if e != nil && stateChanged {
+			tsFields = append(tsFields, tsApi.Field{
+				Name: f.FieldName,
+				Drop: &ptrTrue,
+			})
+		} else {
+			// this can happen if update request is timed out on Tigris side but succeed on search
+			if _, found := fieldsInSearchMap[f.FieldName]; found {
+				tsFields = append(tsFields, tsApi.Field{
+					Name: f.FieldName,
+					Drop: &ptrTrue,
+				})
+			}
+		}
+
+		// add new field
+		tsFields = append(tsFields, tsApi.Field{
+			Name:     f.FieldName,
+			Type:     f.SearchType,
+			Facet:    &shouldFacet,
+			Index:    &shouldIndex,
+			Sort:     &shouldSort,
+			Optional: &ptrTrue,
+		})
+	}
+
+	// drop fields non existing in new schema
+	for _, f := range existingFieldMap {
+		tsField := tsApi.Field{
+			Name: f.FieldName,
+			Drop: &ptrTrue,
+		}
+
+		tsFields = append(tsFields, tsField)
+	}
+
+	return tsFields
 }

--- a/schema/search_test.go
+++ b/schema/search_test.go
@@ -103,7 +103,7 @@ func TestSearchIndex_CollectionSchema(t *testing.T) {
 	"primary_key": ["id"]
 }`)
 
-	schFactory, err := Build("t1", reqSchema)
+	schFactory, err := NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(t, err)
 
 	expFlattenedFields := []string{
@@ -125,24 +125,20 @@ func TestSearchIndex_Schema(t *testing.T) {
 		expErrorMsg string
 	}{
 		{
-			[]byte(`{"title": "t1", "properties": { "simple_items": {"type": "array", "items": {"type": "integer"}, "sort": true}}}`),
-			"sort is not allowed",
-		},
-		{
 			[]byte(`{"title": "t1", "properties": { "simple_items": {"type": "array", "items": {"type": "integer"}, "facet": true}}}`),
-			"facet is not allowed",
+			"",
 		},
 		{
 			[]byte(`{"title": "t1", "properties": { "simple_items": {"type": "object", "facet": true}}}`),
-			"facet is not allowed",
+			"Cannot have search attributes on object 'simple_items', set it on object fields",
 		},
 		{
 			[]byte(`{"title": "t1", "properties": { "a": {"type": "string", "format": "byte", "facet": true}}}`),
-			"facet is not allowed",
+			"Cannot enable search index on field 'a' of type 'byte'",
 		},
 		{
 			[]byte(`{"title": "t1", "properties": { "a": {"type": "string", "format": "byte", "sort": true}}}`),
-			"sort is not allowed",
+			"Cannot enable search index on field 'a' of type 'byte'",
 		},
 		{
 			[]byte(`{"title": "t1", "properties": { "a": {"type": "integer", "sort": true, "facet": true}, "b": {"type": "string", "sort": true, "facet": true}, "c": {"type": "number", "sort": true, "facet": true}}}`),
@@ -150,9 +146,7 @@ func TestSearchIndex_Schema(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		schFactory, err := BuildSearch("t1", c.schema)
-		require.NoError(t, err)
-		err = ValidateSearchSchema(schFactory)
+		_, err := NewFactoryBuilder(true).BuildSearch("t1", c.schema)
 		if len(c.expErrorMsg) > 0 {
 			require.Contains(t, err.Error(), c.expErrorMsg)
 		} else {

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -432,7 +432,7 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 		"primary_key": ["K1", "K2"]
 	}`)
 
-		factory, err := schema.Build("test_collection", jsSchema)
+		factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 		require.NoError(t, err)
 		require.NoError(t, tenant.CreateCollection(ctx, tx, db2, factory))
 
@@ -497,7 +497,7 @@ func TestTenantManager_DropCollection(t *testing.T) {
 		"primary_key": ["K1"]
 	}`)
 
-		factory, err := schema.Build("test_collection", jsSchema)
+		factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 		require.NoError(t, err)
 		require.NoError(t, tenant.CreateCollection(ctx, tx, db2, factory))
 		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
@@ -563,7 +563,7 @@ func TestTenantManager_SearchIndexes(t *testing.T) {
 		}
 	}`)
 
-	factory, err := schema.BuildSearch("test_index", jsSchema)
+	factory, err := schema.NewFactoryBuilder(true).BuildSearch("test_index", jsSchema)
 	require.NoError(t, err)
 	require.NoError(t, tenant.CreateSearchIndex(ctx, tx, proj1, factory))
 

--- a/server/quota/quota_test.go
+++ b/server/quota/quota_test.go
@@ -67,7 +67,7 @@ func TestQuota(t *testing.T) {
 		  "primary_key": ["K1", "K2"]
 	    }`)
 
-	factory, err := schema.Build("test_collection", jsSchema)
+	factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 	require.NoError(t, err)
 
 	err = tenant.Reload(ctx, tx, []byte("aaa"))

--- a/server/quota/storage_test.go
+++ b/server/quota/storage_test.go
@@ -58,7 +58,7 @@ func TestStorageQuota(t *testing.T) {
 		  "primary_key": ["K1", "K2"]
 	    }`)
 
-	factory, err := schema.Build("test_collection", jsSchema)
+	factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 	require.NoError(t, err)
 
 	err = tenant.Reload(ctx, tx, []byte("aaa"))

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -260,7 +260,7 @@ func (runner *BaseQueryRunner) getSortOrdering(coll *schema.DefaultCollection, s
 		}
 
 		if !cf.Sortable {
-			return nil, errors.InvalidArgument("Cannot sort on `%s` field", sf.Name)
+			return nil, errors.InvalidArgument("Search results can't be sorted on `%s` field. Enable sorting on this field", sf.Name)
 		}
 	}
 	return ordering, nil

--- a/server/services/v1/database/collection_runner.go
+++ b/server/services/v1/database/collection_runner.go
@@ -102,7 +102,7 @@ func (runner *CollectionQueryRunner) createOrUpdate(ctx context.Context, tx tran
 		return Response{}, ctx, errors.AlreadyExists("collection already exist")
 	}
 
-	schFactory, err := schema.Build(req.GetCollection(), req.GetSchema())
+	schFactory, err := schema.NewFactoryBuilder(true).Build(req.GetCollection(), req.GetSchema())
 	if err != nil {
 		return Response{}, ctx, err
 	}

--- a/server/services/v1/database/import_runner.go
+++ b/server/services/v1/database/import_runner.go
@@ -60,7 +60,7 @@ func (runner *ImportQueryRunner) evolveSchema(ctx context.Context, tenant *metad
 
 	log.Debug().Str("from", string(rawSchema)).Str("to", string(b)).Msg("evolving schema on import")
 
-	schFactory, err := schema.Build(req.GetCollection(), b)
+	schFactory, err := schema.NewFactoryBuilder(true).Build(req.GetCollection(), b)
 	if err != nil {
 		return err
 	}

--- a/server/services/v1/database/mutator_test.go
+++ b/server/services/v1/database/mutator_test.go
@@ -58,7 +58,7 @@ func TestMutateSetDefaults(t *testing.T) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := schema.Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(t, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestMutateSetDefaultsComplexSchema(t *testing.T) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := schema.Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(t, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestMutatePayload(t *testing.T) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := schema.Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(t, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)
@@ -365,7 +365,7 @@ func BenchmarkStringToInteger(b *testing.B) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := schema.Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
 	require.NoError(b, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(b, err)

--- a/server/services/v1/database/search_indexer_test.go
+++ b/server/services/v1/database/search_indexer_test.go
@@ -161,7 +161,7 @@ func TestPackSearchFields(t *testing.T) {
 		}
 		f := &schema.Field{DataType: schema.ArrayType, FieldName: "arrayField"}
 		coll := &schema.DefaultCollection{
-			QueryableFields: schema.NewQueryableFieldsBuilder(false).BuildQueryableFields([]*schema.Field{f}, nil),
+			QueryableFields: schema.NewQueryableFieldsBuilder().BuildQueryableFields([]*schema.Field{f}, nil),
 		}
 
 		res, err := PackSearchFields(context.TODO(), td, coll, "123")
@@ -179,7 +179,7 @@ func TestPackSearchFields(t *testing.T) {
 		}
 		f := &schema.Field{DataType: schema.DateTimeType, FieldName: "dateField"}
 		coll := &schema.DefaultCollection{
-			QueryableFields: schema.NewQueryableFieldsBuilder(false).BuildQueryableFields([]*schema.Field{f}, nil),
+			QueryableFields: schema.NewQueryableFieldsBuilder().BuildQueryableFields([]*schema.Field{f}, nil),
 		}
 		res, err := PackSearchFields(context.TODO(), td, coll, "123")
 		require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestUnpackSearchFields(t *testing.T) {
 		}
 		f := &schema.Field{DataType: schema.ArrayType, FieldName: "arrayField"}
 		coll := &schema.DefaultCollection{
-			QueryableFields: schema.NewQueryableFieldsBuilder(false).BuildQueryableFields([]*schema.Field{f}, nil),
+			QueryableFields: schema.NewQueryableFieldsBuilder().BuildQueryableFields([]*schema.Field{f}, nil),
 		}
 		_, _, unpacked, err := UnpackSearchFields(doc, coll)
 		require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestUnpackSearchFields(t *testing.T) {
 		}
 		f := &schema.Field{DataType: schema.ArrayType, FieldName: "arrayField"}
 		coll := &schema.DefaultCollection{
-			QueryableFields: schema.NewQueryableFieldsBuilder(false).BuildQueryableFields([]*schema.Field{f}, nil),
+			QueryableFields: schema.NewQueryableFieldsBuilder().BuildQueryableFields([]*schema.Field{f}, nil),
 		}
 		_, _, unpacked, err := UnpackSearchFields(doc, coll)
 		require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestUnpackSearchFields(t *testing.T) {
 		}
 		f := &schema.Field{DataType: schema.DateTimeType, FieldName: "dateField"}
 		coll := &schema.DefaultCollection{
-			QueryableFields: schema.NewQueryableFieldsBuilder(false).BuildQueryableFields([]*schema.Field{f}, nil),
+			QueryableFields: schema.NewQueryableFieldsBuilder().BuildQueryableFields([]*schema.Field{f}, nil),
 		}
 		_, _, unpacked, err := UnpackSearchFields(doc, coll)
 		require.NoError(t, err)

--- a/server/services/v1/database/search_runner.go
+++ b/server/services/v1/database/search_runner.go
@@ -192,7 +192,7 @@ func (runner *SearchQueryRunner) getSearchFields(coll *schema.DefaultCollection)
 	if len(searchFields) == 0 {
 		// this is to include all searchable fields if not present in the query
 		for _, cf := range coll.GetQueryableFields() {
-			if cf.DataType == schema.StringType {
+			if cf.DataType == schema.StringType && cf.SearchIndexed {
 				searchFields = append(searchFields, cf.InMemoryName())
 			}
 		}
@@ -203,7 +203,7 @@ func (runner *SearchQueryRunner) getSearchFields(coll *schema.DefaultCollection)
 				return nil, err
 			}
 			if !cf.SearchIndexed {
-				return nil, errors.InvalidArgument("`%s` is not a searchable field. Only indexed fields can be queried", sf)
+				return nil, errors.InvalidArgument("`%s` is not a searchable field. Enable search indexing on this field", sf)
 			}
 			if cf.InMemoryName() != cf.Name() {
 				searchFields[i] = cf.InMemoryName()
@@ -226,7 +226,7 @@ func (runner *SearchQueryRunner) getFacetFields(coll *schema.DefaultCollection) 
 		}
 		if !cf.Faceted {
 			return qsearch.Facets{}, errors.InvalidArgument(
-				"Cannot generate facets for `%s`. Faceting is only supported for numeric and text fields", ff.Name)
+				"Cannot generate facets for `%s`. Enable faceting on this field", ff.Name)
 		}
 		if cf.InMemoryName() != cf.Name() {
 			facets.Fields[i].Name = cf.InMemoryName()

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -693,7 +693,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 }
 
 func setupTest(t *testing.T, reqSchema []byte) *SecondaryIndexer {
-	schFactory, err := schema.Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
 	assert.NoError(t, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	assert.NoError(t, err)

--- a/server/services/v1/search/runner.go
+++ b/server/services/v1/search/runner.go
@@ -654,7 +654,7 @@ func (runner *SearchRunner) getSearchFields(index *schema.SearchIndex) ([]string
 	if len(searchFields) == 0 {
 		// this is to include all searchable fields if not present in the query
 		for _, cf := range index.QueryableFields {
-			if cf.DataType == schema.StringType {
+			if cf.DataType == schema.StringType && cf.SearchIndexed {
 				searchFields = append(searchFields, cf.InMemoryName())
 			}
 		}
@@ -814,11 +814,9 @@ func (runner *IndexRunner) Run(ctx context.Context, tx transaction.Tx, tenant *m
 
 	switch {
 	case runner.create != nil:
-		factory, err := schema.BuildSearch(runner.create.GetName(), runner.create.GetSchema())
+		fb := schema.NewFactoryBuilder(true)
+		factory, err := fb.BuildSearch(runner.create.GetName(), runner.create.GetSchema())
 		if err != nil {
-			return Response{}, err
-		}
-		if err := schema.ValidateSearchSchema(factory); err != nil {
 			return Response{}, err
 		}
 

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -3917,9 +3917,9 @@ func TestRead_Sorted(t *testing.T) {
 			"schema": Map{
 				"title": coll,
 				"properties": Map{
-					"id":           Map{"type": "integer"},
+					"id":           Map{"type": "integer", "searchIndex": true, "sort": true},
 					"int_value":    Map{"type": "integer"},
-					"string_value": Map{"type": "string", "sort": true},
+					"string_value": Map{"type": "string", "searchIndex": true, "sort": true},
 				},
 			},
 		}).Status(http.StatusOK)

--- a/test/v1/server/integration_test.go
+++ b/test/v1/server/integration_test.go
@@ -44,6 +44,8 @@ var testCreateSchema = Map{
 			"pkey_int": Map{
 				"description": "primary key field",
 				"type":        "integer",
+				"searchIndex": true,
+				"sort": true,
 			},
 			"int_value": Map{
 				"description": "simple int field",

--- a/test/v1/server/search_test.go
+++ b/test/v1/server/search_test.go
@@ -54,11 +54,6 @@ var testSearchIndexSchema = Map{
 				"description": "simple double field",
 				"type":        "number",
 			},
-			"bytes_value": Map{
-				"description": "simple bytes field",
-				"type":        "string",
-				"format":      "byte",
-			},
 			"uuid_value": Map{
 				"description": "uuid field",
 				"type":        "string",
@@ -224,7 +219,6 @@ func TestCreate_ById(t *testing.T) {
 			"string_value":       "simple_insert",
 			"bool_value":         true,
 			"double_value":       10.01,
-			"bytes_value":        []byte(`"simple_insert"`),
 			"array_simple_value": []string{"a", "b"},
 			"array_obj_value":    []any{map[string]any{"integer_value": 10}},
 			"object_value":       map[string]any{"string_value": "a"},
@@ -676,13 +670,12 @@ type res struct {
 }
 
 func getSearchResults(t *testing.T, project string, index string, query Map) *res {
-	req := expect(t).POST(fmt.Sprintf("/v1/projects/%s/search/indexes/%s/documents/search", project, index)).
+	var req = expect(t).POST(fmt.Sprintf("/v1/projects/%s/search/indexes/%s/documents/search", project, index)).
 		WithJSON(query).
 		Expect().
 		Status(http.StatusOK).
 		Body().
 		Raw()
-
 	dec := jsoniter.NewDecoder(bytes.NewReader([]byte(req)))
 
 	var res *res


### PR DESCRIPTION
## Describe your changes

- A user can enable a search index on a field by setting `searchIndex: true` in the schema. Same applies for enabling faceting or sorting i.e. `facet: true` and for sorted search results `sort: true`
- Faceting is now supported on primitive Arrays.
- Sorting/Faceting/Search Indexing can be enabled at any point i.e. even after the collection is already created.
- With this change, search will return an error if the field is not enabled for search.
- Moving all the validations on fields during the request so that when we are reloading the schemas there is no need to perform the validations again.
- Enhancing the field validations by validating nested fields as well.  

## How best to test these changes

## Issue ticket number and link
