### PR TITLE
feat: Add background queue api

### DIFF
--- a/server/metadata/queue.go
+++ b/server/metadata/queue.go
@@ -1,0 +1,241 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/lib/uuid"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/kv"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+const (
+	queueMetaValueVersion int32  = 1
+	itemsSpace            int64  = 1
+	maxId                 string = "$MAX"
+	maxPriority                  = 10
+)
+
+type QueueSubspace struct {
+	metadataSubspace
+}
+
+type QueueItem struct {
+	Id          string `json:"id"`
+	Priority    int64  `json:"priority"`
+	ErrorCount  uint8  `json:"error_count"`
+	LeaseId     string `json:"lease_id,omitempty"`
+	Data        []byte `json:"data"`
+	VestingTime int64  `json:"vesting_time"`
+}
+
+func NewQueueItem(priority int64, data []byte) *QueueItem {
+	return &QueueItem{
+		Id:         uuid.NewUUIDAsString(),
+		Priority:   priority,
+		ErrorCount: 0,
+		Data:       data,
+	}
+}
+
+func newQueueStore(nameRegistry *NameRegistry) *QueueSubspace {
+	return &QueueSubspace{
+		metadataSubspace{
+			SubspaceName: nameRegistry.QueueSubspaceName(),
+			KeyVersion:   []byte{byte(queueMetaValueVersion)},
+		},
+	}
+}
+
+func (q *QueueSubspace) getKey(vestingTime int64, priority int64, id string) keys.Key {
+	if id == maxId {
+		return keys.NewKey(q.SubspaceName, q.KeyVersion, itemsSpace, vestingTime, priority, 0xFF)
+	}
+
+	return keys.NewKey(q.SubspaceName, q.KeyVersion, itemsSpace, vestingTime, priority, id)
+}
+
+func (q *QueueSubspace) Enqueue(ctx context.Context, tx transaction.Tx, item *QueueItem, delay time.Duration) error {
+	if len(item.Id) == 0 {
+		return errors.Internal("cannot enqueue without an id")
+	}
+	item.VestingTime = time.Now().Add(delay).UnixMilli()
+	key := q.getKey(item.VestingTime, item.Priority, item.Id)
+	tableData, err := q.encodeItem(item)
+	if err != nil {
+		return err
+	}
+	return tx.Replace(ctx, key, tableData, false)
+}
+
+func (q *QueueSubspace) Peak(ctx context.Context, tx transaction.Tx, max int) ([]QueueItem, error) {
+	var items []QueueItem
+	count := 0
+	currentTime := time.Now().UnixMilli()
+	endKey := q.getKey(currentTime, maxPriority, maxId)
+	iter, err := tx.ReadRange(ctx, nil, endKey, false)
+	if err != nil {
+		return items, err
+	}
+	var v kv.KeyValue
+	for iter.Next(&v) && count < max {
+		count += 1
+		item, err := q.decodeItem(v.Data)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, *item)
+	}
+
+	return items, iter.Err()
+}
+
+func (q *QueueSubspace) Find(ctx context.Context, tx transaction.Tx, item *QueueItem) (*QueueItem, error) {
+	startKey := q.getKey(item.VestingTime, 0, item.Id)
+	endKey := q.getKey(item.VestingTime, maxPriority, item.Id)
+
+	iter, err := tx.ReadRange(ctx, startKey, endKey, false)
+	if err != nil {
+		return nil, err
+	}
+	var v kv.KeyValue
+	for iter.Next(&v) {
+		found, err := q.decodeItem(v.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		if item.Id == found.Id {
+			return item, nil
+		}
+	}
+
+	if iter.Err() != nil {
+		return nil, iter.Err()
+	}
+	return nil, errors.Internal("QueueItem \"%s\" was not found", item.Id)
+}
+
+func (q *QueueSubspace) Dequeue(ctx context.Context, tx transaction.Tx, item *QueueItem) error {
+	itemKey := q.getKey(item.VestingTime, item.Priority, item.Id)
+	return tx.Delete(ctx, itemKey)
+}
+
+func (q *QueueSubspace) ObtainLease(ctx context.Context, tx transaction.Tx, item *QueueItem, leaseTime time.Duration) (*QueueItem, error) {
+	item, err := q.Find(ctx, tx, item)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		return nil, errors.Internal("Queue Item was not found")
+	}
+
+	if err = q.Dequeue(ctx, tx, item); err != nil {
+		return nil, err
+	}
+
+	item.LeaseId = uuid.NewUUIDAsString()
+	if err = q.Enqueue(ctx, tx, item, leaseTime); ulog.E(err) {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+func (q *QueueSubspace) Complete(ctx context.Context, tx transaction.Tx, item *QueueItem) error {
+	found, err := q.Find(ctx, tx, item)
+	if err != nil {
+		return err
+	}
+
+	if found.LeaseId != item.LeaseId {
+		return errors.Internal("another worker has claimed this item")
+	}
+
+	return q.Dequeue(ctx, tx, item)
+}
+
+func (q *QueueSubspace) RenewLease(ctx context.Context, tx transaction.Tx, item *QueueItem, leaseTime time.Duration) error {
+	found, err := q.Find(ctx, tx, item)
+	if err != nil {
+		return err
+	}
+
+	if found.LeaseId != item.LeaseId {
+		return errors.Internal("another worker has claimed this item")
+	}
+
+	if err := q.Dequeue(ctx, tx, item); err != nil {
+		return err
+	}
+	if err := q.Enqueue(ctx, tx, item, leaseTime); err != nil {
+		return err
+	}
+	return nil
+}
+
+// For local debugging and testing.
+//
+//nolint:unused
+func (q *QueueSubspace) scanTable(ctx context.Context, tx transaction.Tx) error {
+	//nolint:unused
+	minVestingTime := int64(1678281734380) // 8 March 2023 - No queue item will be before this
+	currentTime := time.Now().Add(2 * time.Hour).UnixMilli()
+	t := time.Now().UnixMilli()
+	startKey := q.getKey(minVestingTime, 0, "")
+	endKey := q.getKey(currentTime, maxPriority, maxId)
+
+	iter, err := tx.ReadRange(ctx, startKey, endKey, false)
+	if err != nil {
+		return err
+	}
+	log.Debug().Msg("Queue Table Scan")
+	var v kv.KeyValue
+	for iter.Next(&v) {
+		item, err := q.decodeItem(v.Data)
+		if err != nil {
+			return err
+		}
+		log.Debug().Msgf("scan key: %s id: %s time: %d Greater: %t", v.Key, item.Id, item.VestingTime, item.VestingTime > t)
+	}
+
+	return iter.Err()
+}
+
+func (q *QueueSubspace) decodeItem(data *internal.TableData) (*QueueItem, error) {
+	var item QueueItem
+	if err := jsoniter.Unmarshal(data.RawData, &item); err != nil {
+		return nil, errors.Internal("failed to unmarshal queue item")
+	}
+
+	return &item, nil
+}
+
+func (q *QueueSubspace) encodeItem(item *QueueItem) (*internal.TableData, error) {
+	jsonItem, err := jsoniter.Marshal(item)
+	if ulog.E(err) {
+		return nil, errors.Internal("failed to marshal queue item")
+	}
+	data := internal.NewTableDataWithVersion(jsonItem, queueMetaValueVersion)
+	return data, nil
+}

--- a/server/metadata/queue_test.go
+++ b/server/metadata/queue_test.go
@@ -1,0 +1,260 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/transaction"
+)
+
+func initQueueTest(t *testing.T) (*QueueSubspace, transaction.Tx, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := newQueueStore(newTestNameRegistry(t))
+
+	_ = kvStore.DropTable(ctx, s.SubspaceName)
+
+	tm := transaction.NewManager(kvStore)
+	tx, err := tm.StartTx(ctx)
+	require.NoError(t, err)
+
+	return s, tx, func() {
+		assert.NoError(t, tx.Rollback(ctx))
+	}
+}
+
+func TestEnqueueAndPeak(t *testing.T) {
+	t.Run("insert 1 and peak", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		queue, tx, cleanup := initQueueTest(t)
+		defer cleanup()
+
+		checkQueueEmpty(t, queue, ctx, tx)
+
+		item := NewQueueItem(0, []byte("item1"))
+		assert.NoError(t, queue.Enqueue(ctx, tx, item, 100*time.Millisecond))
+
+		checkQueueEmpty(t, queue, ctx, tx)
+		time.Sleep(500 * time.Millisecond)
+
+		items, err := queue.Peak(ctx, tx, 10)
+		assert.NoError(t, err)
+		assert.Equal(t, item.Data, items[0].Data)
+	})
+
+	t.Run("insert many and peak", func(t *testing.T) {
+		toEnQueue := []string{"one", "two", "three", "four", "five"}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		queue, tx, cleanup := initQueueTest(t)
+		defer cleanup()
+
+		for i, data := range toEnQueue {
+			item := NewQueueItem(0, []byte(data))
+			assert.NoError(t, queue.Enqueue(ctx, tx, item, time.Duration(i*100)*time.Millisecond))
+		}
+
+		// Assert items only appear after certain times
+		for i := 1; i < 6; i++ {
+			items, err := queue.Peak(ctx, tx, 5)
+			assert.NoError(t, err)
+			assert.Len(t, items, i)
+			time.Sleep(101 * time.Millisecond)
+			for z, item := range items {
+				assert.Equal(t, item.Data, []byte(toEnQueue[z]))
+			}
+		}
+	})
+
+	t.Run("peak limits work", func(t *testing.T) {
+		toEnQueue := []string{"one", "two", "three", "four", "five"}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		queue, tx, cleanup := initQueueTest(t)
+		defer cleanup()
+
+		for _, data := range toEnQueue {
+			item := NewQueueItem(0, []byte(data))
+			assert.NoError(t, queue.Enqueue(ctx, tx, item, 1*time.Millisecond))
+		}
+
+		time.Sleep(10 * time.Millisecond)
+
+		for i := 0; i < 5; i++ {
+			checkQueueLength(t, queue, ctx, tx, i)
+		}
+	})
+}
+
+func TestPriorityInPeak(t *testing.T) {
+	t.Run("orderd by different time and priority", func(t *testing.T) {
+		item1 := NewQueueItem(0, []byte("one-item"))
+		item2 := NewQueueItem(1, []byte("two-item"))
+		item3 := NewQueueItem(0, []byte("one-item"))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		queue, tx, cleanup := initQueueTest(t)
+		defer cleanup()
+
+		// Enqueue Item
+		assert.NoError(t, queue.Enqueue(ctx, tx, item1, 10*time.Millisecond))
+		assert.NoError(t, queue.Enqueue(ctx, tx, item2, 20*time.Millisecond))
+		assert.NoError(t, queue.Enqueue(ctx, tx, item3, 30*time.Millisecond))
+
+		time.Sleep(100 * time.Millisecond)
+
+		items := checkQueueLength(t, queue, ctx, tx, 3)
+
+		assert.Equal(t, item1.Id, items[0].Id)
+		assert.Equal(t, item2.Id, items[1].Id)
+		assert.Equal(t, item3.Id, items[2].Id)
+	})
+
+	t.Run("ordered by same time and different priority", func(t *testing.T) {
+		item1 := NewQueueItem(2, []byte("one-item"))
+		item2 := NewQueueItem(1, []byte("two-item"))
+		item3 := NewQueueItem(0, []byte("one-item"))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		queue, tx, cleanup := initQueueTest(t)
+		defer cleanup()
+
+		// Enqueue Item
+		assert.NoError(t, queue.Enqueue(ctx, tx, item1, 10*time.Millisecond))
+		assert.NoError(t, queue.Enqueue(ctx, tx, item2, 10*time.Millisecond))
+		assert.NoError(t, queue.Enqueue(ctx, tx, item3, 10*time.Millisecond))
+
+		time.Sleep(100 * time.Millisecond)
+
+		items := checkQueueLength(t, queue, ctx, tx, 3)
+
+		assert.Equal(t, item3.Id, items[0].Id)
+		assert.Equal(t, item2.Id, items[1].Id)
+		assert.Equal(t, item1.Id, items[2].Id)
+	})
+}
+
+func TestEnqueueObtainComplete(t *testing.T) {
+	item := NewQueueItem(0, []byte("one-item"))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue, tx, cleanup := initQueueTest(t)
+	defer cleanup()
+
+	checkQueueEmpty(t, queue, ctx, tx)
+
+	// Enqueue Item
+	assert.NoError(t, queue.Enqueue(ctx, tx, item, 10*time.Millisecond))
+	time.Sleep(11 * time.Millisecond)
+
+	items, err := queue.Peak(ctx, tx, 5)
+	assert.NoError(t, err)
+	assert.Len(t, items, 1)
+
+	working, err := queue.ObtainLease(ctx, tx, &items[0], 100*time.Millisecond)
+	assert.NoError(t, err)
+	checkQueueEmpty(t, queue, ctx, tx)
+
+	time.Sleep(101 * time.Millisecond)
+	checkQueueLength(t, queue, ctx, tx, 1)
+	working, err = queue.ObtainLease(ctx, tx, working, 30*time.Millisecond)
+	assert.NoError(t, err)
+	checkQueueEmpty(t, queue, ctx, tx)
+
+	assert.NoError(t, queue.Complete(ctx, tx, working))
+	time.Sleep(200 * time.Millisecond)
+	checkQueueEmpty(t, queue, ctx, tx)
+}
+
+func TestErrors(t *testing.T) {
+	item := NewQueueItem(0, []byte("one-item"))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue, tx, cleanup := initQueueTest(t)
+	defer cleanup()
+
+	_, err := queue.ObtainLease(ctx, tx, item, 100*time.Millisecond)
+	assert.Error(t, err, "QueueItem \"%s\" was not found", item.Id)
+
+	err = queue.Complete(ctx, tx, item)
+	assert.Error(t, err, "QueueItem \"%s\" was not found", item.Id)
+}
+
+func TestWorkProcessFlow(t *testing.T) {
+	items := make([]*QueueItem, 0, 5)
+	activeItems := make([]QueueItem, 0, 5)
+	for _, data := range []string{"one", "two", "three", "four", "five"} {
+		items = append(items, NewQueueItem(0, []byte(data)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue, tx, cleanup := initQueueTest(t)
+	defer cleanup()
+
+	// Enqueue Items
+	for i, item := range items {
+		assert.NoError(t, queue.Enqueue(ctx, tx, item, time.Duration(i*10)*time.Millisecond))
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	waiting := checkQueueLength(t, queue, ctx, tx, 5)
+
+	// Claim items Items
+	for z := 4; z >= 0; z-- {
+		item := waiting[z]
+		active, err := queue.ObtainLease(ctx, tx, &item, 10*time.Second)
+		assert.Equal(t, active.Id, item.Id)
+		assert.NoError(t, err)
+		activeItems = append(activeItems, *active)
+
+		checkQueueLength(t, queue, ctx, tx, z)
+	}
+
+	// Work on items
+	time.Sleep(1 * time.Second)
+	for i := range activeItems {
+		err := queue.Complete(ctx, tx, &activeItems[i])
+		assert.NoError(t, err)
+	}
+
+	// Check empty queue
+	checkQueueEmpty(t, queue, ctx, tx)
+}
+
+func checkQueueLength(t *testing.T, queue *QueueSubspace, ctx context.Context, tx transaction.Tx, length int) []QueueItem {
+	items, err := queue.Peak(ctx, tx, length)
+	assert.NoError(t, err)
+	assert.Len(t, items, length)
+	return items
+}
+
+func checkQueueEmpty(t *testing.T, queue *QueueSubspace, ctx context.Context, tx transaction.Tx) {
+	checkQueueLength(t, queue, ctx, tx, 0)
+}

--- a/server/metadata/subscope_registry.go
+++ b/server/metadata/subscope_registry.go
@@ -47,6 +47,7 @@ type NameRegistry struct {
 	NamespaceSB string
 	ClusterSB   string
 	VersionKey  string
+	QueueSB     string
 
 	BaseCounterValue uint32
 }
@@ -59,6 +60,7 @@ var DefaultNameRegistry = &NameRegistry{
 	UserSB:      "user",
 	NamespaceSB: "namespace",
 	ClusterSB:   "cluster",
+	QueueSB:     "queue",
 
 	BaseCounterValue: reservedBaseValue,
 }
@@ -91,6 +93,10 @@ func (d *NameRegistry) ClusterSubspaceName() []byte {
 	return []byte(d.ClusterSB)
 }
 
+func (d *NameRegistry) QueueSubspaceName() []byte {
+	return []byte(d.QueueSB)
+}
+
 func (d *NameRegistry) GetVersionKey() []byte {
 	return []byte(d.VersionKey)
 }
@@ -107,6 +113,7 @@ func newTestNameRegistry(t *testing.T) *NameRegistry {
 		UserSB:      "test_user_" + s,
 		NamespaceSB: "test_namespace_" + s,
 		ClusterSB:   "test_cluster_" + s,
+		QueueSB:     "test_queue_" + s,
 		VersionKey:  "test_version_key" + s,
 
 		BaseCounterValue: r.Uint32(),


### PR DESCRIPTION
## Describe your changes
Adds a background queue table and api to enqueue, peak, dequeue and complete items in the queue.
The queue using vesting time which is current time plus delay time to hide items that are not ready to be worked on or are currently being worked on.

## How best to test these changes
Tests should all pass

## Issue ticket number and link
Closes #910 
