### PR TITLE
fix: looking up unknown namespace triggered an error

### DIFF
--- a/server/request/request.go
+++ b/server/request/request.go
@@ -223,6 +223,12 @@ func (m *Metadata) SetNamespace(ctx context.Context, namespace string) {
 		m.namespaceName = defaults.DefaultNamespaceName
 		return
 	}
+	if namespace == defaults.UnknownValue {
+		// The namespace is unknown for reporting purposes, no need to get the tenant metadata for further
+		// metadata for that.
+		m.namespaceName = "unknown"
+		return
+	}
 	tenant, err := tenantGetter.GetTenant(ctx, namespace)
 	if err != nil {
 		m.namespaceName = defaults.DefaultNamespaceName


### PR DESCRIPTION
## Describe your changes

Metrics will use the value "unknown" for a tag that is present on the time series, but not known. This "unknown" string is later looked up as a tenant, but not found. In the phase of creating request metadata, the namespace tag will just have the value "unknown", but the lookup of the tenant will be skipped after this patch.

## How best to test these changes

Fixes triggering an unnecessary error message for requests with an unknown tenant.

## Issue ticket number and link
TIG-1162
