### PR TITLE
feat: Implement chunker to split/merge the data to support bigger payloads

### DIFF
--- a/internal/data.go
+++ b/internal/data.go
@@ -53,6 +53,8 @@ const (
 	JsonEncoding    UserDataEncType = 2
 )
 
+var EmptyData = &TableData{}
+
 // CreateNewTimestamp is a method used to construct timestamp from unixNano. In search backend we store internal
 // timestamps as unixNano.
 func CreateNewTimestamp(nano int64) *Timestamp {
@@ -112,6 +114,21 @@ func NewTableDataWithVersion(data []byte, version int32) *TableData {
 	}
 }
 
+func (x *TableData) CloneWithAttributesOnly(newRawData []byte) *TableData {
+	return &TableData{
+		Ver:         x.Ver,
+		Encoding:    x.Encoding,
+		CreatedAt:   x.CreatedAt,
+		UpdatedAt:   x.UpdatedAt,
+		TotalChunks: x.TotalChunks,
+		RawData:     newRawData,
+	}
+}
+
+func (x *TableData) IsChunkedData() bool {
+	return x.TotalChunks != nil && *x.TotalChunks > 1
+}
+
 func (x *TableData) SetVersion(ver int32) {
 	x.Ver = ver
 }
@@ -147,6 +164,17 @@ func (x *TableData) TimestampsToJSON() ([]byte, error) {
 	return jsoniter.Marshal(data)
 }
 
+// ActualUserPayloadSize returns size of the user data. This is used by splitter to split the value if it is
+// greater than the maximum allowed by the underlying storage.
+func (x *TableData) ActualUserPayloadSize() int32 {
+	return int32(len(x.RawData))
+}
+
+func (x *TableData) SetTotalChunks(chunkSize int32) {
+	totalChunks := (x.ActualUserPayloadSize() + chunkSize - 1) / chunkSize
+	x.TotalChunks = &totalChunks
+}
+
 // Encode is used to encode data to the raw bytes which is used to store in storage as value. The first byte is storing
 // the type corresponding to this Data. This is important and used by the decoder later to decode back.
 func Encode(data *TableData) ([]byte, error) {
@@ -174,6 +202,7 @@ func Decode(b []byte) (*TableData, error) {
 	if len(b) == 0 {
 		return nil, errors.Internal("unable to decode table data is empty")
 	}
+
 	dataType := DataType(b[0])
 	return decodeInternal(dataType, b[1:])
 }

--- a/internal/data.proto
+++ b/internal/data.proto
@@ -34,6 +34,7 @@ message TableData {
   Timestamp updated_at = 4;
   // raw_data is the raw bytes stored, caller controls how they want to store these raw bytes in database.
   bytes raw_data = 5;
+  optional int32 total_chunks = 6;
 }
 
 // StreamData is used to store a serialized data that has user data, some Tigris metadata in Cache Stream. Some options

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -404,6 +404,7 @@ type SchemaConfig struct {
 // FoundationDBConfig keeps FoundationDB configuration parameters.
 type FoundationDBConfig struct {
 	ClusterFile string `mapstructure:"cluster_file" json:"cluster_file" yaml:"cluster_file"`
+	Chunking    bool   `mapstructure:"chunking" json:"chunking" yaml:"chunking"`
 }
 
 type SearchConfig struct {

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -192,7 +192,7 @@ func (q *SecondaryIndexer) Update(ctx context.Context, tx transaction.Tx, newTd 
 	}
 
 	for _, indexKey := range updateSet.addKeys {
-		if err := tx.Replace(ctx, indexKey, nil, false); err != nil {
+		if err := tx.Replace(ctx, indexKey, internal.EmptyData, false); err != nil {
 			return err
 		}
 	}

--- a/server/transaction/manager.go
+++ b/server/transaction/manager.go
@@ -41,7 +41,6 @@ type BaseTx interface {
 	GetTxCtx() *api.TransactionCtx
 	Insert(ctx context.Context, key keys.Key, data *internal.TableData) error
 	Replace(ctx context.Context, key keys.Key, data *internal.TableData, isUpdate bool) error
-	Update(ctx context.Context, key keys.Key, apply func(*internal.TableData) (*internal.TableData, error)) (int32, error)
 	Delete(ctx context.Context, key keys.Key) error
 	Read(ctx context.Context, key keys.Key) (kv.Iterator, error)
 	ReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key, isSnapshot bool) (kv.Iterator, error)
@@ -50,7 +49,6 @@ type BaseTx interface {
 	SetVersionstampedKey(ctx context.Context, key []byte, value []byte) error
 	AtomicAdd(ctx context.Context, key keys.Key, value int64) error
 	AtomicRead(ctx context.Context, key keys.Key) (int64, error)
-	AtomicReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key, isSnapshot bool) (kv.AtomicIterator, error)
 	RangeSize(ctx context.Context, table []byte, lKey keys.Key, rKey keys.Key) (size int64, err error)
 }
 
@@ -151,6 +149,7 @@ func (s *TxSession) start(ctx context.Context) error {
 	if s.kTx, err = s.kvStore.BeginTx(ctx); err != nil {
 		return err
 	}
+
 	s.state = sessionActive
 
 	return nil
@@ -187,17 +186,6 @@ func (s *TxSession) Replace(ctx context.Context, key keys.Key, data *internal.Ta
 	}
 
 	return s.kTx.Replace(ctx, key.Table(), kv.BuildKey(key.IndexParts()...), data, isUpdate)
-}
-
-func (s *TxSession) Update(ctx context.Context, key keys.Key, apply func(*internal.TableData) (*internal.TableData, error)) (int32, error) {
-	s.Lock()
-	defer s.Unlock()
-
-	if err := s.validateSession(); err != nil {
-		return -1, err
-	}
-
-	return s.kTx.Update(ctx, key.Table(), kv.BuildKey(key.IndexParts()...), apply)
 }
 
 func (s *TxSession) Delete(ctx context.Context, key keys.Key) error {
@@ -281,23 +269,6 @@ func (s *TxSession) AtomicRead(ctx context.Context, key keys.Key) (int64, error)
 	}
 
 	return s.kTx.AtomicRead(ctx, key.Table(), kv.BuildKey(key.IndexParts()...))
-}
-
-func (s *TxSession) AtomicReadRange(ctx context.Context, lKey keys.Key, rKey keys.Key, isSnapshot bool) (kv.AtomicIterator, error) {
-	s.Lock()
-	defer s.Unlock()
-
-	if err := s.validateSession(); err != nil {
-		return nil, err
-	}
-
-	if rKey != nil && lKey != nil {
-		return s.kTx.AtomicReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), kv.BuildKey(rKey.IndexParts()...), isSnapshot)
-	} else if lKey != nil {
-		return s.kTx.AtomicReadRange(ctx, lKey.Table(), kv.BuildKey(lKey.IndexParts()...), nil, isSnapshot)
-	}
-
-	return s.kTx.AtomicReadRange(ctx, rKey.Table(), nil, kv.BuildKey(rKey.IndexParts()...), isSnapshot)
 }
 
 func (s *TxSession) Get(ctx context.Context, key []byte, isSnapshot bool) (kv.Future, error) {

--- a/store/kv/chunk.go
+++ b/store/kv/chunk.go
@@ -1,0 +1,226 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+const (
+	KB   = 1000
+	KB99 = 99 * KB
+
+	chunkIdentifier = "__"
+)
+
+var chunkSize = KB99
+
+type chunkCB func(chunkNo int32, chunkData []byte) error
+
+// ChunkTxStore is used as a layer on top of KeyValueTxStore. The idea is that chunk store will automatically split the
+// user payload if it is greater than 99KB. It adds some metadata in the zeroth chunk like total chunks so that it
+// can easily merge the value again. The attributes of data passed by the caller is only needed in the first chunk, the
+// remaining chunks only have body. The chunk number is appended at the end in the format "__<chunk number>". This number
+// is used during merging from the key so there is no information apart from total chunk is persisted in the value.
+type ChunkTxStore struct {
+	*KeyValueTxStore
+}
+
+func NewChunkStore(cfg *config.FoundationDBConfig) (*ChunkTxStore, error) {
+	kvStore, err := newTxStore(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChunkTxStore{KeyValueTxStore: kvStore}, nil
+}
+
+func (txStore *ChunkTxStore) BeginTx(ctx context.Context) (Tx, error) {
+	btx, err := txStore.KeyValueTxStore.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChunkTx{
+		KeyValueTx: btx.(*KeyValueTx),
+	}, nil
+}
+
+func (tx *ChunkTx) executeChunks(data *internal.TableData, cb chunkCB) error {
+	originalDoc := data.RawData
+	chunk := int32(0)
+	for start := 0; start < len(originalDoc); start += chunkSize {
+		end := start + chunkSize
+		if end > len(originalDoc) {
+			end = len(originalDoc)
+		}
+
+		if err := cb(chunk, originalDoc[start:end]); err != nil {
+			return err
+		}
+		chunk++
+	}
+
+	return nil
+}
+
+func (tx *ChunkTx) isChunkingNeeded(data *internal.TableData) bool {
+	return data.ActualUserPayloadSize() > int32(chunkSize)
+}
+
+type ChunkTx struct {
+	*KeyValueTx
+}
+
+func (tx *ChunkTx) Insert(ctx context.Context, table []byte, key Key, data *internal.TableData) error {
+	if !tx.isChunkingNeeded(data) {
+		return tx.KeyValueTx.Insert(ctx, table, key, data)
+	}
+
+	data.SetTotalChunks(int32(chunkSize))
+
+	return tx.executeChunks(data, func(chunk int32, chunkData []byte) error {
+		chunkKey := key
+		if chunk == 0 {
+			// first part
+			return tx.KeyValueTx.Insert(ctx, table, chunkKey, data.CloneWithAttributesOnly(chunkData))
+		}
+
+		// we don't care about any other attributes for this case
+		chunked := internal.NewTableData(chunkData)
+		// int is encoded as int64 by FDB client so better use int64 to avoid any confusion.
+		chunkKey = append(chunkKey, []KeyPart{chunkIdentifier, int64(chunk)}...)
+
+		return tx.KeyValueTx.Replace(ctx, table, chunkKey, chunked, false)
+	})
+}
+
+func (tx *ChunkTx) Replace(ctx context.Context, table []byte, key Key, data *internal.TableData, isUpdate bool) error {
+	if !tx.isChunkingNeeded(data) {
+		return tx.KeyValueTx.Replace(ctx, table, key, data, isUpdate)
+	}
+
+	data.SetTotalChunks(int32(chunkSize))
+
+	// cleanup the existing range
+	if err := tx.KeyValueTx.Delete(ctx, table, key); err != nil {
+		return err
+	}
+
+	return tx.executeChunks(data, func(chunk int32, chunkData []byte) error {
+		var chunked *internal.TableData
+		chunkKey := key
+		if chunk == 0 {
+			// first part
+			chunked = data.CloneWithAttributesOnly(chunkData)
+		} else {
+			chunked = internal.NewTableData(chunkData)
+			// int is encoded as int64 by FDB client so better use int64 to avoid any confusion.
+			chunkKey = append(chunkKey, []KeyPart{chunkIdentifier, int64(chunk)}...)
+		}
+
+		return tx.KeyValueTx.Replace(ctx, table, chunkKey, chunked, isUpdate)
+	})
+}
+
+// Read needs to return chunk iterator so that it can merge and returned merged chunk to caller.
+func (tx *ChunkTx) Read(ctx context.Context, table []byte, key Key) (Iterator, error) {
+	iterator, err := tx.KeyValueTx.Read(ctx, table, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChunkIterator{
+		Iterator: iterator,
+	}, nil
+}
+
+func (tx *ChunkTx) ReadRange(ctx context.Context, table []byte, lKey Key, rKey Key, isSnapshot bool) (Iterator, error) {
+	iterator, err := tx.KeyValueTx.ReadRange(ctx, table, lKey, rKey, isSnapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChunkIterator{
+		Iterator: iterator,
+	}, nil
+}
+
+type ChunkIterator struct {
+	Iterator
+
+	err error
+}
+
+func (it *ChunkIterator) Next(value *KeyValue) bool {
+	if !it.Iterator.Next(value) {
+		return false
+	}
+
+	if !value.Data.IsChunkedData() {
+		return true
+	}
+
+	var buf bytes.Buffer
+	buf.Write(value.Data.RawData)
+	hasNext := false
+	chunk := int32(1)
+	for ; chunk < *value.Data.TotalChunks; chunk++ {
+		var chunked KeyValue
+		if hasNext = it.Iterator.Next(&chunked); !hasNext {
+			break
+		}
+
+		if it.validChunkKey(chunked.Key, chunk); it.Err() != nil {
+			return false
+		}
+
+		buf.Write(chunked.Data.RawData)
+	}
+	if chunk != *value.Data.TotalChunks {
+		it.err = fmt.Errorf("mismatch in total chunk read '%d' versus total chunks expected '%d'",
+			chunk, *value.Data.TotalChunks)
+		return false
+	}
+
+	value.Data.RawData = buf.Bytes()
+	return hasNext
+}
+
+func (it *ChunkIterator) validChunkKey(key Key, expChunk int32) {
+	switch {
+	case len(key) < 2:
+		it.err = fmt.Errorf("key shorter than expected chunked key '%v'", key)
+	case key[len(key)-2] != chunkIdentifier:
+		it.err = fmt.Errorf("chunk identifier not found in the key '%v'", key)
+	default:
+		if chunkNo, ok := key[len(key)-1].(int64); !ok || expChunk != int32(chunkNo) {
+			it.err = fmt.Errorf("chunk number mismatch found: '%v' exp: '%d'", key[len(key)-1], expChunk)
+		}
+	}
+}
+
+func (it *ChunkIterator) Err() error {
+	if it.err != nil {
+		return it.err
+	}
+
+	return it.Iterator.Err()
+}

--- a/store/kv/chunk_test.go
+++ b/store/kv/chunk_test.go
@@ -1,0 +1,251 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+func TestChunkStore(t *testing.T) {
+	cfg, err := config.GetTestFDBConfig("../..")
+	require.NoError(t, err)
+
+	kv, err := newFoundationDB(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	table := []byte("t1")
+	require.NoError(t, kv.DropTable(ctx, table))
+	require.NoError(t, kv.CreateTable(ctx, table))
+
+	chunkStore, err := NewChunkStore(cfg)
+	require.NoError(t, err)
+
+	doc := []byte(`{
+    "a": 1,
+    "b": 10.2,
+    "c": "foo",
+    "d": "bar",
+    "e": "The fun begins starting here",
+    "f": "This is again a new line that has data",
+    "g": "what about a new which has all the necessary information that we need to form something",
+    "record": {
+        "browser": "Microsoft Edge",
+        "geo_coordinates": {
+            "IPv4": "56.235.92.239",
+            "city": "San Diego",
+            "countryCode": "PN",
+            "state": "Virginia",
+            "countryName": "Algeria"
+        },
+        "user_id": "8b880277-7b2c-4258-8f00-bd6b61549f2a",
+        "labels": [
+            "noOIOiI",
+            "NcWMBI"
+        ],
+        "timestamp": 492962963,
+        "vendor": "Housefax",
+        "platform": "Mozilla/5.0 (Windows NT 6.0) AppleWebKit/5340 (KHTML, like Gecko) Chrome/36.0.815.0 Mobile Safari/5340",
+        "hostname": "directout-of-the-box.io",
+        "capturedSessionState": "LRZVl",
+        "device": "Opera/8.21 (X11; Linux x86_64; en-US) Presto/2.9.334 Version/10.00",
+        "entry_url": "https://www.centralunleash.biz/mission-critical/efficient",
+        "language": "Tahitian"
+    },
+    "another_record": {
+        "device": "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4 rv:5.0; en-US) AppleWebKit/532.37.2 (KHTML, like Gecko) Version/4.2 Safari/532.37.2",
+        "geo_coordinates": {
+            "city": "San Diego",
+            "countryName": "Northern Mariana Islands",
+            "state": "South Carolina",
+            "IPv4": "10.206.89.119",
+            "countryCode": "LI"
+        },
+        "hostname": "dynamicorchestrate.io",
+        "user_id": "95322585-765a-44c8-afae-ffc33d0942e4",
+        "entry_url": "https://www.districtredefine.name/reintermediate/b2b/facilitate",
+        "platform": "Mozilla/5.0 (Windows 98; Win 9x 4.90) AppleWebKit/5341 (KHTML, like Gecko) Chrome/37.0.820.0 Mobile Safari/5341",
+        "labels": [
+            "QNUvCwIEg",
+            "bHVLddOx"
+        ],
+        "capturedSessionState": "MCzGd",
+        "language": "Malayalam",
+        "vendor": "PeerJ",
+        "timestamp": 582254242,
+        "browser": "Brave"
+    }
+}`)
+	data := internal.NewTableData(doc)
+
+	cases := []struct {
+		chunkSize   int
+		totalChunks int32
+	}{
+		{
+			// chunkSize = exact size of the data + 1
+			2125,
+			1,
+		},
+
+		{
+			// chunkSize = exact size of the data
+			2124,
+			1,
+		},
+		{
+			// chunkSize = exact size of the data - 1
+			2123,
+			2,
+		},
+		{
+			KB,
+			3,
+		},
+		{
+			KB,
+			3,
+		},
+		{
+			KB / 2,
+			5,
+		},
+		{
+			KB / 4,
+			9,
+		},
+		{
+			KB / 10,
+			22,
+		},
+	}
+	for _, c := range cases {
+		chunkSize = c.chunkSize
+
+		tx, err := chunkStore.BeginTx(ctx)
+		require.NoError(t, err)
+
+		err = tx.Replace(ctx, table, BuildKey("p1_", 1), data, false)
+		require.NoError(t, err)
+		_ = tx.Commit(ctx)
+		if c.totalChunks == 1 {
+			require.Nil(t, data.TotalChunks)
+		} else {
+			require.True(t, data.IsChunkedData())
+			require.Equal(t, c.totalChunks, *data.TotalChunks)
+		}
+
+		tx, err = chunkStore.BeginTx(ctx)
+		require.NoError(t, err)
+		it, err := tx.Read(ctx, table, BuildKey("p1_", 1))
+		require.NoError(t, err)
+
+		found := 0
+		totalExp := 1
+		var keyValue KeyValue
+		for it.Next(&keyValue) {
+			require.Equal(t, doc, keyValue.Data.RawData)
+			found++
+		}
+		require.Equal(t, totalExp, found)
+		_ = tx.Commit(ctx)
+	}
+}
+
+func TestChunkStoreIterator(t *testing.T) {
+	ptr1, ptr2 := int32(1), int32(2)
+	cases := []struct {
+		expValues []*KeyValue
+		expError  error
+		expCall   int
+	}{
+		{
+			[]*KeyValue{{Key: BuildKey("k1"), Data: &internal.TableData{RawData: []byte(`{}`)}}},
+			nil,
+			1,
+		}, {
+			[]*KeyValue{{Key: BuildKey("k2"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr1}}},
+			nil,
+			1,
+		}, {
+			[]*KeyValue{{Key: BuildKey("k3"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr2}}},
+			fmt.Errorf("mismatch in total chunk read '1' versus total chunks expected '2'"),
+			0,
+		}, {
+			[]*KeyValue{
+				{Key: BuildKey("k4"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr2}},
+				{Key: BuildKey("k4"), Data: &internal.TableData{RawData: []byte(`{}`)}},
+			},
+			fmt.Errorf("key shorter than expected chunked key '[k4]'"),
+			0,
+		}, {
+			[]*KeyValue{
+				{Key: BuildKey("k5"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr2}},
+				{Key: BuildKey("k5", "something", "random"), Data: &internal.TableData{RawData: []byte(`{}`)}},
+			},
+			fmt.Errorf("chunk identifier not found in the key '[k5 something random]'"),
+			0,
+		}, {
+			[]*KeyValue{
+				{Key: BuildKey("k6"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr2}},
+				{Key: BuildKey("k6", "__", "random"), Data: &internal.TableData{RawData: []byte(`{}`)}},
+			},
+			fmt.Errorf("chunk number mismatch found: 'random' exp: '1'"),
+			0,
+		},
+	}
+	for _, c := range cases {
+		it := &ChunkIterator{
+			Iterator: &mockedIterator{
+				values: c.expValues,
+			},
+		}
+
+		times := 0
+		var keyValue KeyValue
+		for it.Next(&keyValue) {
+			times++
+		}
+		require.Equal(t, c.expError, it.err)
+		require.Equal(t, c.expCall, times)
+	}
+}
+
+type mockedIterator struct {
+	idx    int
+	values []*KeyValue
+}
+
+func (it *mockedIterator) Next(value *KeyValue) bool {
+	if it.idx >= len(it.values) {
+		return false
+	}
+
+	hasNext := it.idx < len(it.values)
+	value.Key = it.values[it.idx].Key
+	value.Data = it.values[it.idx].Data
+	it.idx++
+
+	return hasNext
+}
+
+func (it *mockedIterator) Err() error { return nil }

--- a/store/kv/fdb.go
+++ b/store/kv/fdb.go
@@ -416,6 +416,9 @@ func (t *ftx) Read(_ context.Context, table []byte, key Key) (baseIterator, erro
 		return nil, err
 	}
 
+	// It is possible that caller may be chunking the payload. Therefore, the "iterator" returned by this API is only
+	// applicable for ascending order. Once we add support to do reverse reads then we should return a different iterator
+	// or some other signal to the caller.
 	r := t.tx.GetRange(k, fdb.RangeOptions{})
 
 	return &fdbIterator{it: r.Iterator(), subspace: subspace.FromBytes(table)}, nil

--- a/store/kv/kv_store.go
+++ b/store/kv/kv_store.go
@@ -26,6 +26,10 @@ type KeyValueTxStore struct {
 }
 
 func NewTxStore(cfg *config.FoundationDBConfig) (TxStore, error) {
+	return newTxStore(cfg)
+}
+
+func newTxStore(cfg *config.FoundationDBConfig) (*KeyValueTxStore, error) {
 	kv, err := newFoundationDB(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Describe your changes
FoundationDB only allows a maximum value size of 100KB. This diff is adding the functionality to have a layer that splits the value into multiple chunks and then store it in the underlying engine and similarly during reads merge these values back and return a single payload to the caller. This functionality is not tied to FDB directly but provide a generic mechanism to chunk and merge. 

This is not currently enabled. The following diffs will hook this class to actually start using it. The first step will be to do it for search indexes. 

## How best to test these changes

## Issue ticket number and link
