### PR TITLE
feat: ability to count bytes across iterator calls

### DIFF
--- a/server/cdc/manager.go
+++ b/server/cdc/manager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 
+
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"

--- a/server/metadata/dictionary.go
+++ b/server/metadata/dictionary.go
@@ -136,7 +136,7 @@ func (r *reservedSubspace) reload(ctx context.Context, tx transaction.Tx) error 
 	}
 
 	var row kv.KeyValue
-	for it.Next(&row) {
+	for it.Next(ctx, &row) {
 		if len(row.Key) < 3 {
 			return errors.Internal("not a valid key %v", row.Key)
 		}
@@ -223,7 +223,7 @@ func (r *reservedSubspace) allocateToken(ctx context.Context, tx transaction.Tx,
 	newValue := r.BaseCounterValue
 
 	var row kv.KeyValue
-	if it.Next(&row) {
+	if it.Next(ctx, &row) {
 		newValue = ByteToUInt32(row.Data.RawData) + 1
 	}
 

--- a/server/metadata/key_generator.go
+++ b/server/metadata/key_generator.go
@@ -73,7 +73,7 @@ func (g *TableKeyGenerator) generateCounter(ctx context.Context, tx transaction.
 
 	id := uint32(1)
 	var row kv.KeyValue
-	if it.Next(&row) {
+	if it.Next(ctx, &row) {
 		id = ByteToUInt32(row.Data.RawData) + uint32(1)
 	}
 	if err := it.Err(); err != nil {

--- a/server/metadata/metadata.go
+++ b/server/metadata/metadata.go
@@ -77,7 +77,7 @@ func (m *metadataSubspace) getPayload(ctx context.Context, tx transaction.Tx, in
 	}
 
 	var row kv.KeyValue
-	if !it.Next(&row) {
+	if !it.Next(ctx, &row) {
 		if it.Err() != nil {
 			return nil, it.Err()
 		}
@@ -176,7 +176,7 @@ func (m *metadataSubspace) softDeleteMetadata(ctx context.Context, tx transactio
 	}
 
 	var row kv.KeyValue
-	if !it.Next(&row) {
+	if !it.Next(ctx, &row) {
 		return it.Err()
 	}
 
@@ -197,7 +197,7 @@ func (m *metadataSubspace) listMetadata(ctx context.Context, tx transaction.Tx, 
 
 	var v kv.KeyValue
 
-	for it.Next(&v) {
+	for it.Next(ctx, &v) {
 		if len(v.Key) != keyLen {
 			log.Error().Interface("key", v.Key).Str("subspace", string(m.SubspaceName)).Msg("invalid key")
 			return errors.Internal("not a valid key %v", v.Key)

--- a/server/metadata/queue.go
+++ b/server/metadata/queue.go
@@ -125,7 +125,7 @@ func (q *QueueSubspace) Peek(ctx context.Context, tx transaction.Tx, max int) ([
 		return items, err
 	}
 	var v kv.KeyValue
-	for iter.Next(&v) && count < max {
+	for iter.Next(ctx, &v) && count < max {
 		count += 1
 		item, err := q.decodeItem(v.Data)
 		if err != nil {
@@ -146,7 +146,7 @@ func (q *QueueSubspace) Find(ctx context.Context, tx transaction.Tx, item *Queue
 		return nil, err
 	}
 	var v kv.KeyValue
-	for iter.Next(&v) {
+	for iter.Next(ctx, &v) {
 		found, err := q.decodeItem(v.Data)
 		if err != nil {
 			return nil, err
@@ -238,7 +238,7 @@ func (q *QueueSubspace) scanTable(ctx context.Context, tx transaction.Tx) error 
 	}
 	log.Debug().Msg("Queue Table Scan")
 	var v kv.KeyValue
-	for iter.Next(&v) {
+	for iter.Next(ctx, &v) {
 		item, err := q.decodeItem(v.Data)
 		if err != nil {
 			return err

--- a/server/metadata/schema.go
+++ b/server/metadata/schema.go
@@ -153,7 +153,7 @@ func schemaGet(ctx context.Context, tx transaction.Tx, key keys.Key) (schema.Ver
 		row      kv.KeyValue
 	)
 
-	for it.Next(&row) {
+	for it.Next(ctx, &row) {
 		ver, ok := row.Key[len(row.Key)-1].([]byte)
 		if !ok {
 			return nil, errors.Internal("not able to extract revision from schema %v", row.Key)

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -66,7 +66,8 @@ type Metadata struct {
 	collection string
 
 	// Current user/application
-	Sub string
+	Sub       string
+	readUnits int64
 }
 
 func Init(tg metadata.TenantGetter) {
@@ -167,6 +168,14 @@ func (m *Metadata) GetServiceName() string {
 
 func (m *Metadata) GetMethodInfo() grpc.MethodInfo {
 	return m.methodInfo
+}
+
+func (m *Metadata) AddReadUnits(v int64) {
+	m.readUnits += v
+}
+
+func (m *Metadata) GetReadUnits() int64 {
+	return m.readUnits
 }
 
 func (m *Metadata) GetInitialTags() map[string]string {

--- a/server/services/v1/database/search_reader.go
+++ b/server/services/v1/database/search_reader.go
@@ -208,7 +208,7 @@ func NewFilterableSearchIterator(collection *schema.DefaultCollection, reader *p
 	}
 }
 
-func (it *FilterableSearchIterator) Next(row *Row) bool {
+func (it *FilterableSearchIterator) Next(ctx context.Context, row *Row) bool {
 	if it.err != nil {
 		return false
 	}

--- a/server/services/v1/database/search_runner.go
+++ b/server/services/v1/database/search_runner.go
@@ -127,7 +127,7 @@ func (runner *SearchQueryRunner) ReadOnly(ctx context.Context, tenant *metadata.
 	for {
 		resp := &api.SearchResponse{}
 		var row Row
-		for iterator.Next(&row) {
+		for iterator.Next(ctx, &row) {
 			if searchQ.ReadFields != nil {
 				// apply field selection
 				newValue, err := searchQ.ReadFields.Apply(row.Data.RawData)

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -131,7 +131,7 @@ func indexedDataType(queryPlan filter.QueryPlan) bool {
 	}
 }
 
-func (it *SecondaryIndexReader) Next(row *Row) bool {
+func (it *SecondaryIndexReader) Next(ctx context.Context, row *Row) bool {
 	if it.err != nil {
 		return false
 	}
@@ -142,7 +142,7 @@ func (it *SecondaryIndexReader) Next(row *Row) bool {
 	}
 
 	var indexRow Row
-	if it.kvIter.Next(&indexRow) {
+	if it.kvIter.Next(ctx, &indexRow) {
 		indexKey, err := keys.FromBinary(it.coll.EncodedTableIndexName, indexRow.Key)
 		if err != nil {
 			it.err = err
@@ -159,7 +159,7 @@ func (it *SecondaryIndexReader) Next(row *Row) bool {
 		}
 
 		var keyValue kv.KeyValue
-		if docIter.Next(&keyValue) {
+		if docIter.Next(ctx, &keyValue) {
 			row.Data = keyValue.Data
 			row.Key = keyValue.FDBKey
 			return true
@@ -173,14 +173,14 @@ func (it *SecondaryIndexReader) Interrupted() error { return it.err }
 // For local debugging and testing.
 //
 //nolint:unused
-func (it *SecondaryIndexReader) dbgPrintIndex() {
+func (it *SecondaryIndexReader) dbgPrintIndex(ctx context.Context) {
 	indexer := NewSecondaryIndexer(it.coll)
 	tableIter, err := indexer.scanIndex(it.ctx, it.tx)
 	if err != nil {
 		panic(err)
 	}
 	var val kv.KeyValue
-	for tableIter.Next(&val) {
+	for tableIter.Next(ctx, &val) {
 		log.Debug().Msgf("%v", val.Key)
 	}
 }

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -135,7 +135,7 @@ func (q *SecondaryIndexer) IndexInfo(ctx context.Context, tx transaction.Tx) (*S
 	}
 
 	var val kv.KeyValue
-	for iter.Next(&val) {
+	for iter.Next(ctx, &val) {
 		rows += 1
 	}
 	if iter.Err() != nil {
@@ -154,7 +154,7 @@ func (q *SecondaryIndexer) ReadDocAndDelete(ctx context.Context, tx transaction.
 		return err
 	}
 	var oldDoc kv.KeyValue
-	if iter.Next(&oldDoc) {
+	if iter.Next(ctx, &oldDoc) {
 		err := q.Delete(ctx, tx, oldDoc.Data, key.IndexParts())
 		if err != nil {
 			return err

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -577,7 +577,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 		count := 0
 		var row kv.KeyValue
-		for iter.Next(&row) {
+		for iter.Next(ctx, &row) {
 			count += 1
 		}
 		assert.NoError(t, err)
@@ -607,7 +607,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 		count := 0
 		var row kv.KeyValue
-		for iter.Next(&row) {
+		for iter.Next(ctx, &row) {
 			count += 1
 		}
 		assert.NoError(t, err)
@@ -630,7 +630,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 		assert.NoError(t, err)
 
 		count = 0
-		for iter.Next(&row) {
+		for iter.Next(ctx, &row) {
 			count += 1
 		}
 		assert.NoError(t, err)
@@ -679,7 +679,7 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 
 		count := 0
 		var row kv.KeyValue
-		for iter.Next(&row) {
+		for iter.Next(ctx, &row) {
 			id := row.Key[len(row.Key)-1]
 
 			assert.Equal(t, int64(2), id)

--- a/store/kv/base.go
+++ b/store/kv/base.go
@@ -41,7 +41,7 @@ type baseKV interface {
 }
 
 type baseIterator interface {
-	Next(*baseKeyValue) bool
+	Next(context.Context, *baseKeyValue) bool
 	Err() error
 }
 

--- a/store/kv/fdb.go
+++ b/store/kv/fdb.go
@@ -575,7 +575,7 @@ func tupleToKey(t *tuple.Tuple) Key {
 	return *(*Key)(p)
 }
 
-func (i *fdbIterator) Next(kv *baseKeyValue) bool {
+func (i *fdbIterator) Next(ctx context.Context, kv *baseKeyValue) bool {
 	if i.err != nil {
 		return false
 	}
@@ -609,11 +609,11 @@ func (i *fdbIterator) Err() error {
 	return i.err
 }
 
-func (i *fdbIteratorTxCloser) Next(kv *baseKeyValue) bool {
+func (i *fdbIteratorTxCloser) Next(ctx context.Context, kv *baseKeyValue) bool {
 	if i.tx == nil {
 		return false
 	}
-	if !i.baseIterator.Next(kv) {
+	if !i.baseIterator.Next(ctx, kv) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		err := i.tx.Rollback(ctx)

--- a/store/kv/kv_test.go
+++ b/store/kv/kv_test.go
@@ -37,9 +37,10 @@ import (
 
 func readAllUsingIterator(t *testing.T, it Iterator) []KeyValue {
 	res := make([]KeyValue, 0)
+	ctx := context.Background()
 
 	var kv KeyValue
-	for it.Next(&kv) {
+	for it.Next(ctx, &kv) {
 		res = append(res, kv)
 	}
 
@@ -50,9 +51,10 @@ func readAllUsingIterator(t *testing.T, it Iterator) []KeyValue {
 
 func readAll(t *testing.T, it baseIterator) []baseKeyValue {
 	res := make([]baseKeyValue, 0)
+	ctx := context.Background()
 
 	var kv baseKeyValue
-	for it.Next(&kv) {
+	for it.Next(ctx, &kv) {
 		res = append(res, kv)
 	}
 
@@ -490,10 +492,10 @@ func testKVInsert(t *testing.T, kv baseKVStore) {
 				it, err := kv.Read(context.Background(), table, i.Key)
 				require.NoError(t, err)
 				var res baseKeyValue
-				require.True(t, it.Next(&res))
+				require.True(t, it.Next(ctx, &res))
 				require.NoError(t, it.Err())
 				require.Equal(t, i, res)
-				require.True(t, !it.Next(&res))
+				require.True(t, !it.Next(ctx, &res))
 				require.NoError(t, it.Err())
 			}
 		})
@@ -570,16 +572,16 @@ func testFDBKVIterator(t *testing.T, kv baseKVStore) {
 	require.True(t, ok)
 
 	var v baseKeyValue
-	assert.True(t, it.Next(nil))
-	assert.True(t, it.Next(&v))
+	assert.True(t, it.Next(ctx, nil))
+	assert.True(t, it.Next(ctx, &v))
 	assert.NotNil(t, ic.tx)
 
 	fi.subspace = subspace.FromBytes([]byte("invalid"))
 
-	assert.False(t, it.Next(&v))
+	assert.False(t, it.Next(ctx, &v))
 	assert.Nil(t, ic.tx)
 	// Next should not fail after error
-	assert.False(t, it.Next(&v))
+	assert.False(t, it.Next(ctx, &v))
 	assert.Error(t, it.Err())
 
 	err = kv.DropTable(ctx, table)
@@ -659,7 +661,7 @@ func testKVAddAtomicValue(t *testing.T, kv baseKVStore) {
 	var rangeVal FdbBaseKeyValue[int64]
 	count := 0
 	expected := []int64{11, 5}
-	for iter.Next(&rangeVal) {
+	for iter.Next(ctx, &rangeVal) {
 		require.Equal(t, expected[count], rangeVal.Data)
 		count += 1
 	}

--- a/store/kv/noop_store.go
+++ b/store/kv/noop_store.go
@@ -22,13 +22,15 @@ import (
 
 type NoopIterator struct{}
 
-func (n *NoopIterator) Next(value *KeyValue) bool { return false }
-func (n *NoopIterator) Err() error                { return nil }
+func (n *NoopIterator) Next(ctx context.Context, value *KeyValue) bool { return false }
+func (n *NoopIterator) Err() error                                     { return nil }
 
 type NoopFDBTypeIterator struct{}
 
-func (n *NoopFDBTypeIterator) Next(value *FdbBaseKeyValue[int64]) bool { return false }
-func (n *NoopFDBTypeIterator) Err() error                              { return nil }
+func (n *NoopFDBTypeIterator) Next(ctx context.Context, value *FdbBaseKeyValue[int64]) bool {
+	return false
+}
+func (n *NoopFDBTypeIterator) Err() error { return nil }
 
 type NoopTx struct {
 	*NoopKV


### PR DESCRIPTION
## Describe your changes

Adds context to the Next() calls of iterators to be able to track the read bytes inside an interator. In this form, this PR is requesting an early feedback on collecting telemetry data across multiple iterator calls in a streaming request.

## How best to test these changes

Because of the early feedback request, I made it log extensively. Issue a read call that will read multiple documents. The bytes read will be counted across iterator calls. 

```
2023-03-17T16:07:11Z INF v2@v2.0.0-rc.3/logger.go:33 started call env=test grpc.code=OK grpc.component=server grpc.method=Read grpc.method_type=server_stream grpc.request.deadline=2023-03-17T16:07:16Z grpc.service=tigrisdata.v1.Tigris grpc.start_time=2023-03-17T16:07:11Z grpc.time_ms=0.057 peer.address=192.168.224.1:65474 protocol=grpc service=tigris-server version=82f6681
2023-03-17T16:07:11Z INF kv/kv.go:661 Read bytes in this iteration Added bytes=1214
2023-03-17T16:07:11Z INF kv/kv.go:662 Total read bytes Total bytes=1214
2023-03-17T16:07:11Z INF middleware/measure.go:187 Total read units Read units=0
2023-03-17T16:07:11Z INF kv/kv.go:661 Read bytes in this iteration Added bytes=1214
2023-03-17T16:07:11Z INF kv/kv.go:662 Total read bytes Total bytes=2428
2023-03-17T16:07:11Z INF middleware/measure.go:187 Total read units Read units=0
2023-03-17T16:07:11Z INF kv/kv.go:661 Read bytes in this iteration Added bytes=1214
2023-03-17T16:07:11Z INF kv/kv.go:662 Total read bytes Total bytes=3642
2023-03-17T16:07:11Z INF middleware/measure.go:187 Total read units Read units=0
2023-03-17T16:07:11Z INF kv/kv.go:661 Read bytes in this iteration Added bytes=1214
2023-03-17T16:07:11Z INF kv/kv.go:662 Total read bytes Total bytes=4856
2023-03-17T16:07:11Z INF middleware/measure.go:187 Total read units Read units=0
2023-03-17T16:07:11Z INF kv/kv.go:661 Read bytes in this iteration Added bytes=1214
2023-03-17T16:07:11Z INF kv/kv.go:662 Total read bytes Total bytes=6070
```

The same mechanics can be used to trace read calls, etc. At this point it's a proof of concept + a refactor of passing Context in the iterators.

## Issue ticket number and link

https://github.com/tigrisdata/tigris/issues/918