### PR TITLE
feat: report usage based metrics

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -50,6 +50,7 @@ type Config struct {
 	Quota          QuotaConfig
 	Observability  ObservabilityConfig `yaml:"observability" json:"observability"`
 	Management     ManagementConfig    `yaml:"management" json:"management"`
+	GlobalStatus   GlobalStatusConfig  `yaml:"global_status" json:"global_status"`
 	Schema         SchemaConfig
 }
 
@@ -207,6 +208,11 @@ type ObservabilityConfig struct {
 	ApiKey      string `mapstructure:"api_key" yaml:"api_key" json:"api_key"`
 	AppKey      string `mapstructure:"app_key" yaml:"app_key" json:"app_key"`
 	ProviderUrl string `mapstructure:"provider_url" yaml:"provider_url" json:"provider_url"`
+}
+
+type GlobalStatusConfig struct {
+	Enabled     bool `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	EmitMetrics bool `mapstructure:"emit_metrics" yaml:"emit_metrics" json:"emit_metrics"`
 }
 
 type Billing struct {
@@ -416,6 +422,10 @@ var DefaultConfig = Config{
 	},
 	Schema: SchemaConfig{
 		AllowIncompatible: false,
+	},
+	GlobalStatus: GlobalStatusConfig{
+		Enabled:     true,
+		EmitMetrics: true,
 	},
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -71,7 +71,7 @@ func mainWithCode() int {
 	log.Info().Str("version", util.Version).Msgf("Starting server")
 
 	var searchStore search.Store
-	if defaultConfig.Tracing.Enabled {
+	if defaultConfig.Metrics.Search.Enabled {
 		searchStore, err = search.NewStoreWithMetrics(&defaultConfig.Search)
 	} else {
 		searchStore, err = search.NewStore(&defaultConfig.Search)

--- a/server/metadata/namespace.go
+++ b/server/metadata/namespace.go
@@ -97,7 +97,7 @@ func NewDefaultNamespace() *DefaultNamespace {
 	return &DefaultNamespace{}
 }
 
-// AccountIntegrations represents the external accounts
+// AccountIntegrations represents the external accounts.
 type AccountIntegrations struct {
 	Metronome *Metronome
 }

--- a/server/metrics/global_status.go
+++ b/server/metrics/global_status.go
@@ -1,0 +1,240 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+var ignoredFieldsForWrites = [][]byte{
+	[]byte("_tigris_created_at"),
+	[]byte("_tigris_updated_at"),
+}
+
+type GlobalStatus struct {
+	mu          sync.Mutex
+	activeChunk *TenantStatusTimeChunk
+}
+
+type TenantStatusTimeChunk struct {
+	startTime time.Time
+	// Only filled when Flush is called in the returned copy
+	endTime time.Time
+	tenants map[string]*TenantStatus
+}
+
+type TenantStatus struct {
+	// TODO: add support for collection level
+	// Counted from readBytes at the end of the request
+	readUnits int64
+	// Counted from writeBytes at the end of the request
+	writeUnits     int64
+	readBytes      int64
+	writeBytes     int64
+	ddlDropUnits   int64
+	ddlCreateUnits int64
+	ddlUpdateUnits int64
+	// TODO: separate ddl units for branches
+}
+
+type RequestStatus struct {
+	namespace string
+	// A read request will report the read bytes after the successful completion of the request. This is data read
+	// from storage, not the data returned to the client. readBytes is calculated while the data is streamed to
+	// the client if the request is streaming (reads). For example, a full table scan is a single request, but it
+	readBytes int64
+	// For write requests, both readBytes and writeBytes are calculated at the end of a successful request. Write
+	// bytes are the sum of document and index bytes written, and the read bytes in this case would be the data
+	// update or delete request where there may be a scan depending on the query filter.
+	writeBytes int64
+	// Some operations have a fixed cost, and it should be calculated at the iterator level
+	ddlDropUnits   int64
+	ddlCreateUnits int64
+	ddlUpdateUnits int64
+}
+
+type RequestStatusCtxKey struct{}
+
+func NewRequestStatus(tenantName string) *RequestStatus {
+	return &RequestStatus{namespace: tenantName, readBytes: 0, writeBytes: 0}
+}
+
+func NewGlobalStatus() *GlobalStatus {
+	startTime := time.Now()
+	tenantMap := make(map[string]*TenantStatus)
+	g := &GlobalStatus{
+		activeChunk: &TenantStatusTimeChunk{
+			startTime: startTime,
+			tenants:   tenantMap,
+		},
+	}
+	return g
+}
+
+func NewTenantStatusTimeChunk(startTime time.Time) *TenantStatusTimeChunk {
+	tenantMap := make(map[string]*TenantStatus)
+	return &TenantStatusTimeChunk{tenants: tenantMap, startTime: startTime}
+}
+
+func NewTenantStatus() *TenantStatus {
+	return &TenantStatus{}
+}
+
+func RequestStatusFromContext(ctx context.Context) (*RequestStatus, bool) {
+	r, ok := ctx.Value(RequestStatusCtxKey{}).(*RequestStatus)
+	return r, ok
+}
+
+func (r *RequestStatus) SaveRequestStatusToContext(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, RequestStatusCtxKey{}, r)
+	return ctx
+}
+
+func (r *RequestStatus) ClearRequestStatusFromContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, RequestStatusCtxKey{}, nil)
+}
+
+func (r *RequestStatus) AddReadBytes(value int64) {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	r.readBytes += value
+	log.Debug().Int64("Bytes read", value).Int64("Total bytes read", r.readBytes).Msg("Added read bytes")
+}
+
+func (r *RequestStatus) AddWriteBytes(value int64) {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	r.writeBytes += value
+	log.Debug().Int64("Bytes written", value).Int64("Total bytes written", r.writeBytes).Msg("Added written bytes")
+}
+
+func (r *RequestStatus) AddDDLDropUnit() {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	r.ddlDropUnits += 1
+	log.Debug().Msg("Added drop unit")
+}
+
+func (r *RequestStatus) AddDDLCreateUnit() {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	r.ddlCreateUnits += 1
+	log.Debug().Msg("Add ddl create unit")
+}
+
+func (r *RequestStatus) AddDDLUpdateUnit() {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	r.ddlUpdateUnits += 1
+	log.Debug().Msg("Add ddl update unit")
+}
+
+func (r *RequestStatus) OnlyCountKeyLength(fdbKey []byte) bool {
+	for _, ignoredField := range ignoredFieldsForWrites {
+		// Do not count if it is an ignored secondary index or not a secondary index
+		if bytes.Contains(fdbKey, []byte("skey")) && !bytes.Contains(fdbKey, ignoredField) {
+			log.Debug().Bytes("field", fdbKey).Msg("Ignoring field")
+			return true
+		}
+	}
+	log.Debug().Bytes("field", fdbKey).Msg("Not ignoring field")
+	return false
+}
+
+func (r *RequestStatus) SetWriteBytes(value int64) {
+	r.writeBytes = value
+}
+
+func (r *RequestStatus) SetReadBytes(value int64) {
+	r.readBytes = value
+}
+
+func (r *RequestStatus) GetReadBytes() int64 {
+	return r.readBytes
+}
+
+func (r *RequestStatus) GetWriteBytes() int64 {
+	return r.writeBytes
+}
+
+func (r *RequestStatus) GetDDLDropUnits() int64 {
+	return r.ddlDropUnits
+}
+
+func (r *RequestStatus) GetDDLUpdateUnits() int64 {
+	return r.ddlUpdateUnits
+}
+
+func (r *RequestStatus) GetDDLCreateUnits() int64 {
+	return r.ddlCreateUnits
+}
+
+func (g *GlobalStatus) ensureTenantForActiveChunk(tenantName string) {
+	_, ok := g.activeChunk.tenants[tenantName]
+	if !ok {
+		g.activeChunk.tenants[tenantName] = NewTenantStatus()
+	}
+}
+
+func (g *GlobalStatus) RecordRequestToActiveChunk(r *RequestStatus, tenantName string) {
+	if !config.DefaultConfig.GlobalStatus.Enabled {
+		return
+	}
+	log.Debug().Msg("Recording request to active chunk")
+	g.mu.Lock()
+	writeUnits := getUnitsFromBytes(r.writeBytes, config.WriteUnitSize)
+	readUnits := getUnitsFromBytes(r.readBytes, config.ReadUnitSize)
+	g.ensureTenantForActiveChunk(tenantName)
+	log.Debug().Int64("writeBytes", r.writeBytes).Str("tenantName", tenantName).Msg("Recording write bytes")
+	g.activeChunk.tenants[tenantName].writeBytes += r.writeBytes
+	log.Debug().Int64("readBytes", r.readBytes).Str("tenantName", tenantName).Msg("Recording read bytes")
+	g.activeChunk.tenants[tenantName].readBytes += r.readBytes
+	log.Debug().Int64("writeUnits", writeUnits).Str("tenantName", tenantName).Msg("Recording write units")
+	g.activeChunk.tenants[tenantName].writeUnits += writeUnits
+	log.Debug().Int64("readUnits", readUnits).Str("tenantName", tenantName).Msg("Recording read units")
+	g.activeChunk.tenants[tenantName].readUnits += readUnits
+	g.activeChunk.tenants[tenantName].ddlDropUnits += r.ddlDropUnits
+	g.activeChunk.tenants[tenantName].ddlCreateUnits += r.ddlCreateUnits
+	g.activeChunk.tenants[tenantName].ddlUpdateUnits += r.ddlUpdateUnits
+	g.mu.Unlock()
+}
+
+func (g *GlobalStatus) Flush() TenantStatusTimeChunk {
+	g.mu.Lock()
+	startTime := time.Now()
+	g.activeChunk.endTime = startTime
+	res := *g.activeChunk
+	g.activeChunk = NewTenantStatusTimeChunk(startTime)
+	g.mu.Unlock()
+	log.Debug().Int("number of tenants", len(res.tenants)).Msg("Flushing global status")
+	for tenantName, status := range res.tenants {
+		status.writeUnits = getUnitsFromBytes(status.writeBytes, config.WriteUnitSize)
+		status.readUnits = getUnitsFromBytes(status.readBytes, config.ReadUnitSize)
+		log.Debug().Int64("read units", status.readUnits).Int64("read bytes", status.readBytes).Int64("write units", status.writeUnits).Int64("write bytes", status.writeBytes).Int64("ddl drop units", status.ddlDropUnits).Int64("ddl update units", status.ddlUpdateUnits).Int64("ddl create units", status.ddlCreateUnits).Str("tenant name", tenantName).Msg("Flushed global status for tenant")
+	}
+
+	return res
+}

--- a/server/metrics/global_status_test.go
+++ b/server/metrics/global_status_test.go
@@ -1,0 +1,93 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestStatus(t *testing.T) {
+	t.Run("Test RequestStatus", func(t *testing.T) {
+		dataSize8K := int64(8192)
+		dataSize16K := int64(16384)
+		ctx := context.Background()
+		rs := NewRequestStatus("test_tenant")
+		ctx = rs.SaveRequestStatusToContext(ctx)
+		_, ok := RequestStatusFromContext(ctx)
+		assert.True(t, ok)
+		ctx = rs.ClearRequestStatusFromContext(ctx)
+		_, ok = RequestStatusFromContext(ctx)
+		assert.False(t, ok)
+
+		rs.AddReadBytes(dataSize8K)
+		rs.AddWriteBytes(dataSize8K)
+		rs.AddDDLDropUnit()
+		rs.AddDDLUpdateUnit()
+		rs.AddDDLCreateUnit()
+		assert.Equal(t, dataSize8K, rs.GetReadBytes())
+		assert.Equal(t, dataSize8K, rs.GetWriteBytes())
+		assert.Equal(t, int64(1), rs.GetDDLDropUnits())
+		assert.Equal(t, int64(1), rs.GetDDLCreateUnits())
+		assert.Equal(t, int64(1), rs.GetDDLUpdateUnits())
+
+		rs.SetReadBytes(int64(0))
+		rs.SetWriteBytes(int64(0))
+		assert.Equal(t, int64(0), rs.GetReadBytes())
+		assert.Equal(t, int64(0), rs.GetWriteBytes())
+
+		rs.SetReadBytes(dataSize16K)
+		rs.SetWriteBytes(dataSize16K)
+		assert.Equal(t, dataSize16K, rs.GetReadBytes())
+		assert.Equal(t, dataSize16K, rs.GetWriteBytes())
+	})
+}
+
+func TestGlobalStatus(t *testing.T) {
+	t.Run("Test Global status", func(t *testing.T) {
+		dataSize16K := int64(16384)
+
+		globalStatus := NewGlobalStatus()
+		assert.NotNil(t, globalStatus)
+		assert.NotNil(t, globalStatus.activeChunk)
+
+		rs := NewRequestStatus("test_tenant")
+		rs.AddReadBytes(dataSize16K)
+		rs.AddWriteBytes(dataSize16K)
+		rs.AddReadBytes(dataSize16K)
+		rs.AddDDLDropUnit()
+		rs.AddDDLUpdateUnit()
+		rs.AddDDLCreateUnit()
+
+		globalStatus.RecordRequestToActiveChunk(rs, "test_tenant")
+		assert.Equal(t, globalStatus.activeChunk.tenants["test_tenant"].readBytes, 2*dataSize16K)
+		assert.Equal(t, globalStatus.activeChunk.tenants["test_tenant"].writeBytes, dataSize16K)
+		assert.Equal(t, globalStatus.activeChunk.tenants["test_tenant"].ddlDropUnits, int64(1))
+		assert.Equal(t, globalStatus.activeChunk.tenants["test_tenant"].ddlCreateUnits, int64(1))
+		assert.Equal(t, globalStatus.activeChunk.tenants["test_tenant"].ddlUpdateUnits, int64(1))
+
+		oldChunk := globalStatus.Flush()
+		assert.Equal(t, oldChunk.tenants["test_tenant"].readBytes, 2*dataSize16K)
+		assert.Equal(t, oldChunk.tenants["test_tenant"].writeBytes, dataSize16K)
+		assert.Equal(t, oldChunk.tenants["test_tenant"].ddlDropUnits, int64(1))
+		assert.Equal(t, oldChunk.tenants["test_tenant"].ddlUpdateUnits, int64(1))
+		assert.Equal(t, oldChunk.tenants["test_tenant"].ddlCreateUnits, int64(1))
+
+		_, ok := globalStatus.activeChunk.tenants["test_tenant"]
+		assert.False(t, ok)
+	})
+}

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -83,6 +83,21 @@ func (m *Measurement) countOk(scope tally.Scope, tags map[string]string) {
 	scope.Tagged(tags).Counter("ok").Inc(1)
 }
 
+func (m *Measurement) CountUnits(reqStatus *RequestStatus, tags map[string]string) {
+	if !config.DefaultConfig.GlobalStatus.EmitMetrics {
+		return
+	}
+	readBytes := reqStatus.GetReadBytes()
+	writeBytes := reqStatus.GetWriteBytes()
+	RequestsReadBytes.Tagged(tags).Counter("bytes").Inc(readBytes)
+	RequestsWriteBytes.Tagged(tags).Counter("bytes").Inc(writeBytes)
+	RequestsReadUnits.Tagged(tags).Counter("units").Inc(getUnitsFromBytes(readBytes, config.ReadUnitSize))
+	RequestsWriteUnits.Tagged(tags).Counter("units").Inc(getUnitsFromBytes(writeBytes, config.WriteUnitSize))
+	RequestsDDLDropUnits.Tagged(tags).Counter("units").Inc(reqStatus.GetDDLDropUnits())
+	RequestsDDLUpdateUnits.Tagged(tags).Counter("units").Inc(reqStatus.GetDDLUpdateUnits())
+	RequestsDDLCreateUnits.Tagged(tags).Counter("units").Inc(reqStatus.GetDDLCreateUnits())
+}
+
 func (m *Measurement) CountErrorForScope(scope tally.Scope, tags map[string]string) {
 	if scope != nil {
 		m.countError(scope, tags)

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -38,6 +38,7 @@ var (
 	NetworkMetrics tally.Scope
 	AuthMetrics    tally.Scope
 	SchemaMetrics  tally.Scope
+	GlobalSt       *GlobalStatus
 )
 
 func getVersion() string {
@@ -143,6 +144,7 @@ func InitializeMetrics() func() {
 		initializeQuotaScopes()
 
 		SchemaMetrics = root.SubScope("schema")
+		GlobalSt = NewGlobalStatus()
 	}
 
 	return func() {

--- a/server/metrics/requests.go
+++ b/server/metrics/requests.go
@@ -19,10 +19,17 @@ import (
 )
 
 var (
-	RequestsOkCount       tally.Scope
-	RequestsErrorCount    tally.Scope
-	RequestsRespTime      tally.Scope
-	RequestsErrorRespTime tally.Scope
+	RequestsOkCount        tally.Scope
+	RequestsErrorCount     tally.Scope
+	RequestsRespTime       tally.Scope
+	RequestsErrorRespTime  tally.Scope
+	RequestsReadBytes      tally.Scope
+	RequestsReadUnits      tally.Scope
+	RequestsWriteBytes     tally.Scope
+	RequestsWriteUnits     tally.Scope
+	RequestsDDLDropUnits   tally.Scope
+	RequestsDDLUpdateUnits tally.Scope
+	RequestsDDLCreateUnits tally.Scope
 )
 
 func getRequestOkTagKeys() []string {
@@ -70,4 +77,11 @@ func initializeRequestScopes() {
 	RequestsErrorCount = Requests.SubScope("count")
 	RequestsRespTime = Requests.SubScope("response")
 	RequestsErrorRespTime = Requests.SubScope("error_response")
+	RequestsReadBytes = Requests.SubScope("read")
+	RequestsReadUnits = Requests.SubScope("read")
+	RequestsWriteBytes = Requests.SubScope("write")
+	RequestsWriteUnits = Requests.SubScope("write")
+	RequestsDDLDropUnits = Requests.SubScope("ddl_drop")
+	RequestsDDLUpdateUnits = Requests.SubScope("ddl_update")
+	RequestsDDLCreateUnits = Requests.SubScope("ddl_create")
 }

--- a/server/metrics/units.go
+++ b/server/metrics/units.go
@@ -1,0 +1,22 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+func getUnitsFromBytes(bytes int64, unitSize int) int64 {
+	if bytes%int64(unitSize) == 0 {
+		return bytes / int64(unitSize)
+	}
+	return bytes/int64(unitSize) + 1
+}

--- a/server/metrics/units_test.go
+++ b/server/metrics/units_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+func TestGetUnitsFromBytes(t *testing.T) {
+	t.Run("Test getUnitsFromBytes", func(t *testing.T) {
+		assert.Equal(t, int64(0), getUnitsFromBytes(int64(0), config.WriteUnitSize))
+		assert.Equal(t, int64(1), getUnitsFromBytes(int64(1), config.WriteUnitSize))
+		assert.Equal(t, int64(1), getUnitsFromBytes(int64(4095), config.WriteUnitSize))
+		assert.Equal(t, int64(1), getUnitsFromBytes(int64(4096), config.WriteUnitSize))
+		assert.Equal(t, int64(2), getUnitsFromBytes(int64(4097), config.WriteUnitSize))
+		assert.Equal(t, int64(4), getUnitsFromBytes(int64(16384), config.WriteUnitSize))
+	})
+}

--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/config"
 	"golang.org/x/net/context/ctxhttp"
-	"github.com/tigrisdata/tigris/errors"
 )
 
 const (

--- a/server/services/v1/database/database_runner.go
+++ b/server/services/v1/database/database_runner.go
@@ -204,6 +204,9 @@ func (runner *BranchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		if err != nil {
 			return Response{}, ctx, createApiError(err)
 		}
+
+		countDDLCreateUnit(ctx)
+
 		return Response{
 			Response: &api.CreateBranchResponse{
 				Status: CreatedStatus,
@@ -215,6 +218,9 @@ func (runner *BranchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		if err != nil {
 			return Response{}, ctx, createApiError(err)
 		}
+
+		countDDLDropUnit(ctx)
+
 		return Response{
 			Response: &api.DeleteBranchResponse{
 				Status: DeletedStatus,

--- a/server/services/v1/database/measure.go
+++ b/server/services/v1/database/measure.go
@@ -1,0 +1,55 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metrics"
+)
+
+func countDDLCreateUnit(ctx context.Context) {
+	if config.DefaultConfig.GlobalStatus.Enabled {
+		reqStatus, ok := metrics.RequestStatusFromContext(ctx)
+		if ok && reqStatus != nil {
+			reqStatus.AddDDLCreateUnit()
+			reqStatus.SetWriteBytes(int64(0))
+			reqStatus.SetReadBytes(int64(0))
+		}
+	}
+}
+
+func countDDLDropUnit(ctx context.Context) {
+	if config.DefaultConfig.GlobalStatus.Enabled {
+		reqStatus, ok := metrics.RequestStatusFromContext(ctx)
+		if ok && reqStatus != nil {
+			reqStatus.AddDDLDropUnit()
+			reqStatus.SetWriteBytes(int64(0))
+			reqStatus.SetReadBytes(int64(0))
+		}
+	}
+}
+
+func countDDLUpdateUnit(ctx context.Context, cond bool) {
+	if config.DefaultConfig.GlobalStatus.Enabled {
+		reqStatus, ok := metrics.RequestStatusFromContext(ctx)
+		if cond && ok && reqStatus != nil {
+			reqStatus.AddDDLUpdateUnit()
+			reqStatus.SetWriteBytes(int64(0))
+			reqStatus.SetReadBytes(int64(0))
+		}
+	}
+}

--- a/server/services/v1/database/measure_test.go
+++ b/server/services/v1/database/measure_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigris/server/metrics"
+)
+
+func TestCountDDLCreateUnit(t *testing.T) {
+	t.Run("Test measurement helpers", func(t *testing.T) {
+		ctx := context.Background()
+		rs := metrics.NewRequestStatus("test_tenant")
+		ctx = rs.SaveRequestStatusToContext(ctx)
+
+		rs.AddReadBytes(int64(16384))
+		rs.AddWriteBytes(int64(16384))
+		countDDLCreateUnit(ctx)
+
+		assert.Equal(t, int64(0), rs.GetReadBytes())
+		assert.Equal(t, int64(0), rs.GetWriteBytes())
+		assert.Equal(t, int64(1), rs.GetDDLCreateUnits())
+	})
+}
+
+func TestCountDDLUpdateUnit(t *testing.T) {
+	t.Run("Test measurement helpers", func(t *testing.T) {
+		ctx := context.Background()
+		rs := metrics.NewRequestStatus("test_tenant")
+		ctx = rs.SaveRequestStatusToContext(ctx)
+
+		rs.AddReadBytes(int64(16384))
+		rs.AddWriteBytes(int64(16384))
+		countDDLUpdateUnit(ctx, true)
+
+		assert.Equal(t, int64(0), rs.GetReadBytes())
+		assert.Equal(t, int64(0), rs.GetWriteBytes())
+		assert.Equal(t, int64(1), rs.GetDDLUpdateUnits())
+	})
+}
+
+func TestCountDDLDropUnit(t *testing.T) {
+	t.Run("Test measurement helpers", func(t *testing.T) {
+		ctx := context.Background()
+		rs := metrics.NewRequestStatus("test_tenant")
+		ctx = rs.SaveRequestStatusToContext(ctx)
+
+		rs.AddReadBytes(int64(16384))
+		rs.AddWriteBytes(int64(16384))
+		countDDLDropUnit(ctx)
+
+		assert.Equal(t, int64(0), rs.GetReadBytes())
+		assert.Equal(t, int64(0), rs.GetWriteBytes())
+		assert.Equal(t, int64(1), rs.GetDDLDropUnits())
+	})
+}

--- a/server/services/v1/database/row_reader.go
+++ b/server/services/v1/database/row_reader.go
@@ -39,6 +39,7 @@ type Iterator interface {
 }
 
 type ScanIterator struct {
+	ctx context.Context
 	it  kv.Iterator
 	err error
 }
@@ -50,7 +51,8 @@ func NewScanIterator(ctx context.Context, tx transaction.Tx, from keys.Key, to k
 	}
 
 	return &ScanIterator{
-		it: it,
+		ctx: ctx,
+		it:  it,
 	}, nil
 }
 

--- a/store/kv/fdb.go
+++ b/store/kv/fdb.go
@@ -52,6 +52,7 @@ type fdbIterator struct {
 }
 
 type fdbIteratorTxCloser struct {
+	ctx context.Context
 	baseIterator
 	tx baseTx
 }
@@ -83,7 +84,7 @@ func (d *fdbkv) Read(ctx context.Context, table []byte, key Key) (baseIterator, 
 	if err != nil {
 		return nil, err
 	}
-	return &fdbIteratorTxCloser{it, tx}, nil
+	return &fdbIteratorTxCloser{ctx, it, tx}, nil
 }
 
 func (d *fdbkv) ReadRange(ctx context.Context, table []byte, lKey Key, rKey Key, isSnapshot bool) (baseIterator, error) {
@@ -95,7 +96,7 @@ func (d *fdbkv) ReadRange(ctx context.Context, table []byte, lKey Key, rKey Key,
 	if err != nil {
 		return nil, err
 	}
-	return &fdbIteratorTxCloser{it, tx}, nil
+	return &fdbIteratorTxCloser{ctx, it, tx}, nil
 }
 
 func (d *fdbkv) txWithRetry(ctx context.Context, fn func(fdb.Transaction) (interface{}, error)) (interface{}, error) {
@@ -199,7 +200,7 @@ func (d *fdbkv) AtomicReadRange(ctx context.Context, table []byte, lKey Key, rKe
 	if err != nil {
 		return nil, err
 	}
-	return &AtomicIteratorImpl{it, nil}, nil
+	return &AtomicIteratorImpl{ctx, it, nil}, nil
 }
 
 func (d *fdbkv) Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error) {
@@ -400,7 +401,7 @@ func (t *ftx) AtomicReadRange(ctx context.Context, table []byte, lkey Key, rkey 
 		return nil, err
 	}
 
-	return &AtomicIteratorImpl{iter, nil}, nil
+	return &AtomicIteratorImpl{ctx, iter, nil}, nil
 }
 
 func (t *ftx) Get(_ context.Context, key []byte, isSnapshot bool) (Future, error) {

--- a/store/kv/listener.go
+++ b/store/kv/listener.go
@@ -94,7 +94,7 @@ func (l *DefaultListener) GetEvents() []*Event {
 type NoopEventListener struct{}
 
 func (l *NoopEventListener) OnSet(string, []byte, Key, *internal.TableData) {}
-func (l *NoopEventListener) OnClear(string, []byte, Key)               {}
+func (l *NoopEventListener) OnClear(string, []byte, Key)                    {}
 func (l *NoopEventListener) GetEvents() []*Event                            { return nil }
 
 func WrapEventListenerCtx(ctx context.Context) context.Context {


### PR DESCRIPTION
## Describe your changes

Report usage based metrics as read and write units. It reports metrics through global status (caller needs to flush it on sending it to 3rd party service), it also exposes the same metrics through the `/metrics` endpoint. 

## How best to test these changes

Have some traffic on the databases and check `/metrics`, tests are added as well.

## Issue ticket number and link

#918 