### PR TITLE
feat: Persist search indexes in foundationDB to have faster recovery in case of DR

### DIFF
--- a/api/server/v1/header.go
+++ b/api/server/v1/header.go
@@ -37,11 +37,12 @@ const (
 
 	HeaderPrefix = "Tigris-"
 
-	HeaderTxID            = "Tigris-Tx-Id"
-	HeaderTxOrigin        = "Tigris-Tx-Origin"
-	grpcGatewayPrefix     = "Grpc-Gateway-"
-	HeaderSchemaSignOff   = "Tigris-Schema-Sign-Off"
-	HeaderBypassAuthCache = "Tigris-Bypass-Auth-Cache" // #nosec G101
+	HeaderTxID                      = "Tigris-Tx-Id"
+	HeaderTxOrigin                  = "Tigris-Tx-Origin"
+	grpcGatewayPrefix               = "Grpc-Gateway-"
+	HeaderSchemaSignOff             = "Tigris-Schema-Sign-Off"
+	HeaderBypassAuthCache           = "Tigris-Bypass-Auth-Cache" // #nosec G101
+	HeaderReadSearchDataFromStorage = "Tigris-Search-Read-From-Storage"
 )
 
 func CustomMatcher(key string) (string, bool) {

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,16 @@ require (
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
 	github.com/auth0/go-auth0 v0.9.3
 	github.com/auth0/go-jwt-middleware/v2 v2.0.1
+	github.com/bluele/gcache v0.0.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
+	github.com/brianvoe/gofakeit/v6 v6.20.2
 	github.com/buger/jsonparser v1.1.1
 	github.com/davecgh/go-spew v1.1.1
+	github.com/deepmap/oapi-codegen v1.12.2
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fullstorydev/grpchan v1.1.1
 	github.com/gertd/go-pluralize v0.2.1
+	github.com/getkin/kin-openapi v0.107.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1
 	github.com/go-redis/redis/v8 v8.11.5
@@ -25,11 +29,9 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iancoleman/strcase v0.2.0
 	github.com/json-iterator/go v1.1.12
 	github.com/lucsky/cuid v1.2.1
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.28.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.2
@@ -72,15 +74,12 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/deepmap/oapi-codegen v1.12.2 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 // indirect
-	github.com/getkin/kin-openapi v0.107.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/brianvoe/gofakeit/v6 v6.20.2 h1:FLloufuC7NcbHqDzVQ42CG9AKryS1gAGCRt8nQRsW+Y=
+github.com/brianvoe/gofakeit/v6 v6.20.2/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -280,8 +282,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
@@ -385,8 +385,6 @@ github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=

--- a/internal/data.go
+++ b/internal/data.go
@@ -28,6 +28,7 @@ import (
 var (
 	UserTableKeyPrefix      = []byte("data")
 	SecondaryTableKeyPrefix = []byte("idx")
+	SearchTableKeyPrefix    = []byte("sea")
 	PartitionKeyPrefix      = []byte("part")
 	CacheKeyPrefix          = "cache"
 )

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -237,10 +237,12 @@ var DefaultConfig = Config{
 		StreamBuffer:   200,
 	},
 	Search: SearchConfig{
-		Host:         "localhost",
-		Port:         8108,
-		ReadEnabled:  true,
-		WriteEnabled: true,
+		Host:           "localhost",
+		Port:           8108,
+		ReadEnabled:    true,
+		WriteEnabled:   true,
+		StorageEnabled: true,
+		Chunking:       true,
 	},
 	SecondaryIndex: SecondaryIndexConfig{
 		ReadEnabled:   false,
@@ -404,7 +406,6 @@ type SchemaConfig struct {
 // FoundationDBConfig keeps FoundationDB configuration parameters.
 type FoundationDBConfig struct {
 	ClusterFile string `mapstructure:"cluster_file" json:"cluster_file" yaml:"cluster_file"`
-	Chunking    bool   `mapstructure:"chunking" json:"chunking" yaml:"chunking"`
 }
 
 type SearchConfig struct {
@@ -413,6 +414,10 @@ type SearchConfig struct {
 	AuthKey      string `mapstructure:"auth_key" json:"auth_key" yaml:"auth_key"`
 	ReadEnabled  bool   `mapstructure:"read_enabled" yaml:"read_enabled" json:"read_enabled"`
 	WriteEnabled bool   `mapstructure:"write_enabled" yaml:"write_enabled" json:"write_enabled"`
+	// StorageEnabled only applies to standalone search indexes. This is to enable persisting search indexes to storage.
+	StorageEnabled bool `mapstructure:"storage_enabled" yaml:"storage_enabled" json:"storage_enabled"`
+	// Chunking allows us to persist bigger search indexes payload in storage.
+	Chunking bool `mapstructure:"chunking" yaml:"chunking" json:"chunking"`
 }
 
 type SecondaryIndexConfig struct {

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -829,6 +829,10 @@ func (tenant *Tenant) deleteSearchIndex(ctx context.Context, tx transaction.Tx, 
 		return errors.Internal(err.Error())
 	}
 
+	if err = tenant.kvStore.DropTable(ctx, tenant.Encoder.EncodeFDBSearchTableName(index.StoreIndexName())); err != nil {
+		return errors.Internal(err.Error())
+	}
+
 	// clean up from the underlying search store
 	if err := tenant.searchStore.DropCollection(ctx, index.StoreIndexName()); err != nil && !search.IsErrNotFound(err) {
 		return err

--- a/server/muxer/muxer.go
+++ b/server/muxer/muxer.go
@@ -41,12 +41,12 @@ func NewMuxer(cfg *config.Config) *Muxer {
 	return &Muxer{servers: []Server{NewHTTPServer(cfg), NewGRPCServer(cfg)}}
 }
 
-func (m *Muxer) RegisterServices(cfg *config.ServerConfig, kvStore kv.TxStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) {
+func (m *Muxer) RegisterServices(cfg *config.ServerConfig, kvStore kv.TxStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager, chunkTxMgr *transaction.Manager) {
 	var services []v1.Service
 	if cfg.Type == config.RealtimeServerType {
 		services = v1.GetRegisteredServicesRealtime(kvStore, searchStore, tenantMgr, txMgr)
 	} else {
-		services = v1.GetRegisteredServices(kvStore, searchStore, tenantMgr, txMgr)
+		services = v1.GetRegisteredServices(kvStore, searchStore, tenantMgr, txMgr, chunkTxMgr)
 	}
 	for _, r := range services {
 		for _, v := range m.servers {

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -426,3 +426,7 @@ func IsWrite(ctx context.Context) bool {
 func NeedSchemaValidation(ctx context.Context) bool {
 	return api.GetHeader(ctx, api.HeaderSchemaSignOff) != "true"
 }
+
+func ReadSearchDataFromStorage(ctx context.Context) bool {
+	return api.GetHeader(ctx, api.HeaderReadSearchDataFromStorage) == "true"
+}

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -484,7 +484,7 @@ func (runner *StreamingQueryRunner) ReadOnly(ctx context.Context, tenant *metada
 	}
 	if options.inMemoryStore {
 		if err = runner.iterateOnSearchStore(ctx, collection, options); err != nil {
-			return Response{}, ctx, err
+			return Response{}, ctx, createApiError(err)
 		}
 		return Response{}, ctx, nil
 	}
@@ -514,7 +514,7 @@ func (runner *StreamingQueryRunner) ReadOnly(ctx context.Context, tenant *metada
 		}
 
 		if err != nil {
-			return Response{}, ctx, err
+			return Response{}, ctx, createApiError(err)
 		}
 
 		ctx = runner.instrumentRunner(ctx, options)
@@ -543,18 +543,18 @@ func (runner *StreamingQueryRunner) Run(ctx context.Context, tx transaction.Tx, 
 	ctx = runner.instrumentRunner(ctx, options)
 	if options.inMemoryStore {
 		if err = runner.iterateOnSearchStore(ctx, coll, options); err != nil {
-			return Response{}, ctx, err
+			return Response{}, ctx, createApiError(err)
 		}
 		return Response{}, ctx, nil
 	} else {
 		if options.plan != nil {
 			if _, err = runner.iterateOnSecondaryIndexStore(ctx, tx, coll, options); err != nil {
-				return Response{}, ctx, err
+				return Response{}, ctx, createApiError(err)
 			}
 			return Response{}, ctx, nil
 		}
 		if _, err = runner.iterateOnKvStore(ctx, tx, coll, options); err != nil {
-			return Response{}, ctx, err
+			return Response{}, ctx, createApiError(err)
 		}
 		return Response{}, ctx, nil
 	}
@@ -658,5 +658,5 @@ func (runner *StreamingQueryRunner) iterate(coll *schema.DefaultCollection, iter
 		}
 	}
 
-	return row.Key, createApiError(iterator.Interrupted())
+	return row.Key, iterator.Interrupted()
 }

--- a/server/services/v1/search.go
+++ b/server/services/v1/search.go
@@ -50,7 +50,7 @@ func newSearchService(store searchStore.Store, tenantMgr *metadata.TenantManager
 		tenantMgr:     tenantMgr,
 		versionH:      tenantMgr.GetVersionHandler(),
 		sessions:      search.NewSessionManager(txMgr, tenantMgr, metadata.NewCacheTracker(tenantMgr, txMgr)),
-		runnerFactory: search.NewRunnerFactory(store, tenantMgr.GetEncoder()),
+		runnerFactory: search.NewRunnerFactory(store, tenantMgr.GetEncoder(), txMgr),
 	}
 }
 

--- a/server/services/v1/service.go
+++ b/server/services/v1/service.go
@@ -41,7 +41,7 @@ func GetRegisteredServicesRealtime(kvStore kv.TxStore, searchStore search.Store,
 	return v1Services
 }
 
-func GetRegisteredServices(kvStore kv.TxStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager) []Service {
+func GetRegisteredServices(kvStore kv.TxStore, searchStore search.Store, tenantMgr *metadata.TenantManager, txMgr *transaction.Manager, chunkTxMgr *transaction.Manager) []Service {
 	var v1Services []Service
 	v1Services = append(v1Services, newHealthService(txMgr))
 
@@ -59,6 +59,11 @@ func GetRegisteredServices(kvStore kv.TxStore, searchStore search.Store, tenantM
 
 	v1Services = append(v1Services, newObservabilityService(tenantMgr))
 	v1Services = append(v1Services, newCacheService(tenantMgr, txMgr))
-	v1Services = append(v1Services, newSearchService(searchStore, tenantMgr, txMgr))
+
+	if config.DefaultConfig.Search.Chunking {
+		v1Services = append(v1Services, newSearchService(searchStore, tenantMgr, chunkTxMgr))
+	} else {
+		v1Services = append(v1Services, newSearchService(searchStore, tenantMgr, txMgr))
+	}
 	return v1Services
 }

--- a/store/kv/chunk.go
+++ b/store/kv/chunk.go
@@ -27,7 +27,7 @@ const (
 	KB   = 1000
 	KB99 = 99 * KB
 
-	chunkIdentifier = "__"
+	chunkIdentifier = "_C_"
 )
 
 var chunkSize = KB99
@@ -43,7 +43,7 @@ type ChunkTxStore struct {
 	*KeyValueTxStore
 }
 
-func NewChunkStore(cfg *config.FoundationDBConfig) (*ChunkTxStore, error) {
+func NewChunkStore(cfg *config.FoundationDBConfig) (TxStore, error) {
 	kvStore, err := newTxStore(cfg)
 	if err != nil {
 		return nil, err

--- a/store/kv/chunk_test.go
+++ b/store/kv/chunk_test.go
@@ -207,7 +207,7 @@ func TestChunkStoreIterator(t *testing.T) {
 		}, {
 			[]*KeyValue{
 				{Key: BuildKey("k6"), Data: &internal.TableData{RawData: []byte(`{}`), TotalChunks: &ptr2}},
-				{Key: BuildKey("k6", "__", "random"), Data: &internal.TableData{RawData: []byte(`{}`)}},
+				{Key: BuildKey("k6", "_C_", "random"), Data: &internal.TableData{RawData: []byte(`{}`)}},
 			},
 			fmt.Errorf("chunk number mismatch found: 'random' exp: '1'"),
 			0,

--- a/store/kv/measure.go
+++ b/store/kv/measure.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/tigrisdata/tigris/internal"
-	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metrics"
 )
 
@@ -26,15 +25,9 @@ type TxStoreWithMetrics struct {
 	kv TxStore
 }
 
-func NewKeyValueStoreWithMetrics(cfg *config.FoundationDBConfig) (TxStore, error) {
-	kv, err := newFoundationDB(cfg)
-	if err != nil {
-		return nil, err
-	}
+func NewKeyValueStoreWithMetrics(txStore TxStore) (TxStore, error) {
 	return &TxStoreWithMetrics{
-		kv: &KeyValueTxStore{
-			fdbkv: kv,
-		},
+		kv: txStore,
 	}, nil
 }
 

--- a/test/v1/server/document.go
+++ b/test/v1/server/document.go
@@ -1,0 +1,238 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+var FakeDocumentSchema = []byte(`{
+  "schema": {
+    "title": "fake_index",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "sentence": {
+        "type": "string"
+      },
+      "quote": {
+        "type": "string"
+      },
+      "phrase": {
+        "type": "string"
+      },
+      "paragraph1": {
+        "type": "string"
+      },
+      "paragraph2": {
+        "type": "string"
+      },
+      "paragraph3": {
+        "type": "string"
+      },
+      "paragraph": {
+        "type": "string"
+      },
+      "random": {
+        "type": "string"
+      },
+      "number": {
+        "type": "number"
+      },
+      "url": {
+        "type": "string"
+      },
+      "placeholder": {
+        "type": "string"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "map": {
+        "searchIndex": false,
+        "type": "object",
+        "properties": {}
+      },
+      "cars": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "animals": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "fruits": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "nested": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "integer"
+          },
+          "paragraph": {
+            "type": "string"
+          },
+          "places": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vegetables": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dessert": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "object": {
+            "searchIndex": false,
+            "type": "object",
+            "properties": {}
+          },
+          "address": {
+            "type": "object",
+            "properties": {
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "country_name": {
+                "type": "string"
+              },
+              "latitude": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "longitude": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+type FakeDocument struct {
+	Id         string  `json:"id"`
+	Name       string  `json:"name" fake:"{firstname}"`
+	Sentence   string  `json:"sentence" fake:"{sentence:50}"`
+	Quote      string  `json:"quote" fake:"{quote}"`
+	Phrase     string  `json:"phrase" fake:"{phrase}"`
+	Paragraph  string  `json:"paragraph" fake:"{paragraph:10,10,50}"`
+	Paragraph1 string  `json:"paragraph1" fake:"{paragraph:10,10,50}"`
+	Paragraph2 string  `json:"paragraph2" fake:"{paragraph:10,10,50}"`
+	Paragraph3 string  `json:"paragraph3" fake:"{paragraph:10,10,50}"`
+	Random     string  `json:"random" fake:"{nouncollectivething}"`
+	Number     float64 `json:"number" fake:"{number:1,10000}"`
+	URL        string  `json:"url" fake:"{url}"`
+
+	Cars        []string  `json:"cars" fake:"{carmaker}" fakesize:"10000"`
+	Animals     []string  `json:"animals" fake:"{animal}" fakesize:"10000"`
+	Fruits      []string  `json:"fruits" fake:"{fruit}" fakesize:"10000"`
+	Placeholder string    `json:"placeholder"`
+	Nested      Nested    `json:"nested"`
+	CreatedAt   time.Time `json:"created_at"  fake:"{date}"`
+	UpdatedAt   time.Time `json:"updated_at"  fake:"{date}"`
+}
+
+type Nested struct {
+	Timestamp  int64    `json:"timestamp" fake:"{nanosecond}"`
+	Paragraph  string   `json:"city"  fake:"{paragraph:10,10,50}"`
+	Address    Address  `json:"address"`
+	Places     []string `json:"places"  fake:"{city}" fakesize:"10000"`
+	Vegetables []string `json:"vegetables"  fake:"{vegetable}" fakesize:"10000"`
+	Dessert    []string `json:"dessert"  fake:"{dessert}" fakesize:"10000"`
+}
+
+type Address struct {
+	City        string    `json:"city"  fake:"{city}"`
+	State       string    `json:"state"  fake:"{state}"`
+	CountryName string    `json:"countryName"  fake:"{country}"`
+	Latitude    []float64 `json:"latitude"  fake:"{latitude}" fakesize:"10000"`
+	Longitude   []float64 `json:"longitude"  fake:"{longitude}" fakesize:"10000"`
+}
+
+// NewFakeDocument generates a ~3MB fake document by default.
+func NewFakeDocument(id string, placeholder string) FakeDocument {
+	var address Address
+	_ = gofakeit.Struct(&address)
+
+	var nested Nested
+	_ = gofakeit.Struct(&nested)
+	nested.Address = address
+
+	var f FakeDocument
+	_ = gofakeit.Struct(&f)
+	f.Nested = nested
+	f.Placeholder = placeholder
+	f.Id = id
+
+	return f
+}
+
+func Serialize(f FakeDocument) ([]byte, error) {
+	return jsoniter.Marshal(f)
+}
+
+func GenerateFakes(t *testing.T, ids []string, placeholder []string) ([]FakeDocument, [][]byte) {
+	var fakes []FakeDocument
+	var serialized [][]byte
+	for i := 0; i < len(ids); i++ {
+		fake := NewFakeDocument(ids[i], placeholder[i])
+		payload, err := Serialize(fake)
+		require.NoError(t, err)
+
+		fakes = append(fakes, fake)
+		serialized = append(serialized, payload)
+	}
+
+	return fakes, serialized
+}


### PR DESCRIPTION
## Describe your changes
This diff enables to have FoundationDB as the source of truth for the indexed data. This improves the reliability story of search indexes. As the search index document size can easily be greater than 100kb therefore this diff also enabling chunking for search indexes. 

There are two knobs to control this behavior,

- storage_enabled: This is enabled as part of this diff. If this is true then the write request to search will also write to FDB. 
- chunking: This is also enabled as part of this diff for search. This means any value greater than 100kb will be chunked. 

## How best to test these changes

## Issue ticket number and link
