### PR TITLE
feat: Manage secondary indexes via metadata

### DIFF
--- a/schema/collection.go
+++ b/schema/collection.go
@@ -193,6 +193,12 @@ func (d *DefaultCollection) GetName() string {
 	return d.Name
 }
 
+// The subspace within a collection where the secondary index information
+// is stored.
+func (d *DefaultCollection) SecondaryIndexName() string {
+	return "skey"
+}
+
 func (d *DefaultCollection) GetVersion() int32 {
 	return int32(d.SchVer)
 }
@@ -211,6 +217,17 @@ func (d *DefaultCollection) GetIndexes() *Indexes {
 
 func (d *DefaultCollection) GetQueryableFields() []*QueryableField {
 	return d.QueryableFields
+}
+
+// Indexes that can be used for queries.
+func (d *DefaultCollection) GetActiveIndexedFields() []*QueryableField {
+	var indexed []*QueryableField
+	for _, q := range d.QueryableFields {
+		if q.Indexed && d.Indexes.IsActiveIndex(q.FieldName) {
+			indexed = append(indexed, q)
+		}
+	}
+	return indexed
 }
 
 func (d *DefaultCollection) GetIndexedFields() []*QueryableField {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -243,9 +243,17 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 					Fields: []*Field{{FieldName: "id", DataType: Int64Type, PrimaryKeyField: &b}},
 					Name:   "pkey",
 				},
-				SecondaryIndex: &Index{
-					Fields: []*Field{},
-					Name:   "skey",
+				SecondaryIndex: []*Index{
+					{
+						Name:    ReservedFields[CreatedAt],
+						IdxType: SECONDARY_INDEX,
+						State:   UNKNOWN,
+					},
+					{
+						Name:    ReservedFields[UpdatedAt],
+						IdxType: SECONDARY_INDEX,
+						State:   UNKNOWN,
+					},
 				},
 			},
 			Fields: []*Field{

--- a/server/metadata/index.go
+++ b/server/metadata/index.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/transaction"
 	ulog "github.com/tigrisdata/tigris/util/log"
 )
@@ -33,8 +34,10 @@ type IndexSubspace struct {
 
 // IndexMetadata contains index wide metadata.
 type IndexMetadata struct {
-	ID   uint32 `json:"id"`
-	Name string `json:"name"`
+	ID      uint32            `json:"id"`
+	Name    string            `json:"name"`
+	State   schema.IndexState `json:"state"`
+	IdxType schema.IndexType  `json:"index_type"`
 }
 
 const indexMetaValueVersion int32 = 1
@@ -42,6 +45,8 @@ const indexMetaValueVersion int32 = 1
 func newIndexStore(nameRegistry *NameRegistry) *IndexSubspace {
 	return &IndexSubspace{
 		metadataSubspace{
+			// TODO:Should this be encoding subspace or its own one?
+			// IF we do change to secondary index what about existing Primary Keys stored here?
 			SubspaceName: nameRegistry.EncodingSubspaceName(),
 			KeyVersion:   []byte{encKeyVersion},
 		},

--- a/server/metadata/index_manager.go
+++ b/server/metadata/index_manager.go
@@ -1,0 +1,81 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+
+	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/transaction"
+)
+
+type IndexManager struct {
+	indexStore *IndexSubspace
+	queueStore *QueueSubspace
+}
+
+func newIndexManager(mdNameRegistry *NameRegistry) *IndexManager {
+	return &IndexManager{
+		indexStore: newIndexStore(mdNameRegistry),
+		queueStore: newQueueStore(mdNameRegistry),
+	}
+}
+
+func (im *IndexManager) InsertActiveIndex(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32, idx *schema.Index, id uint32) (*IndexMetadata, error) {
+	return im.InsertIndexWithState(ctx, tx, nsID, dbID, collID, idx, id, schema.INDEX_ACTIVE)
+}
+
+func (im *IndexManager) InsertIndex(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32, idx *schema.Index, id uint32) (*IndexMetadata, error) {
+	return im.InsertIndexWithState(ctx, tx, nsID, dbID, collID, idx, id, schema.INDEX_WRITE_MODE)
+}
+
+func (im *IndexManager) InsertIndexWithState(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32, idx *schema.Index, id uint32, state schema.IndexState) (*IndexMetadata, error) {
+	meta := &IndexMetadata{ID: id, State: state, IdxType: idx.IndexType(), Name: idx.Name}
+
+	err := im.indexStore.insert(ctx, tx, nsID, dbID, collID, meta.Name, meta)
+	if err != nil {
+		return nil, err
+	}
+	idx.State = state
+
+	// TODO: if not active add job to index
+	// if meta.State == WRITE {
+	// im.queueStore.insert....
+	// }
+	return meta, nil
+}
+
+func (im *IndexManager) SoftDelete(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32, idxMeta *IndexMetadata) error {
+	idxMeta.State = schema.INDEX_DELETED
+	err := im.indexStore.Update(ctx, tx, nsID, dbID, collID, idxMeta.Name, idxMeta)
+	if err != nil {
+		return err
+	}
+	// TODO: Add job to delete index
+	// im.queueStore.insert...
+	return im.indexStore.softDelete(ctx, tx, nsID, dbID, collID, idxMeta.Name)
+}
+
+func (im *IndexManager) GetIndexes(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32) (map[string]*IndexMetadata, error) {
+	return im.indexStore.list(ctx, tx, nsID, dbID, collID)
+}
+
+func (im *IndexManager) Get(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, collID uint32, name string) (*IndexMetadata, error) {
+	return im.indexStore.Get(ctx, tx, nsID, dbID, collID, name)
+}
+
+func (im *IndexManager) GetActiveIndexes() []*schema.QueryableField {
+	return nil
+}

--- a/server/metadata/index_test.go
+++ b/server/metadata/index_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/transaction"
 )
 
@@ -81,7 +82,9 @@ func TestIndexSubspace(t *testing.T) {
 		defer cleanupTx()
 
 		appPayload := &IndexMetadata{
-			Name: "name111",
+			Name:    "name111",
+			State:   schema.INDEX_WRITE_MODE,
+			IdxType: schema.SECONDARY_INDEX,
 		}
 
 		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, "name2", appPayload))
@@ -127,15 +130,34 @@ func TestIndexSubspace(t *testing.T) {
 		tx, cleanupTx := initTx(t, ctx, tm)
 		defer cleanupTx()
 
-		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, "name8", testIndexMetadata))
-		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, "name9", testIndexMetadata))
+		idx8 := &IndexMetadata{
+			Name:    "name8",
+			State:   schema.INDEX_WRITE_MODE,
+			IdxType: schema.SECONDARY_INDEX,
+		}
+
+		idx9 := &IndexMetadata{
+			Name:    "name9",
+			State:   schema.INDEX_ACTIVE,
+			IdxType: schema.SECONDARY_INDEX,
+		}
+
+		idx10 := &IndexMetadata{
+			Name:    "name10",
+			State:   schema.INDEX_ACTIVE,
+			IdxType: schema.PRIMARY_INDEX,
+		}
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx8.Name, idx8))
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx9.Name, idx9))
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx10.Name, idx10))
 
 		colls, err := c.list(ctx, tx, 1, 1, 1)
 		require.NoError(t, err)
 
 		require.Equal(t, map[string]*IndexMetadata{
-			"name8": {},
-			"name9": {},
+			"name8":  idx8,
+			"name9":  idx9,
+			"name10": idx10,
 		}, colls)
 	})
 }

--- a/server/metadata/queue.go
+++ b/server/metadata/queue.go
@@ -225,7 +225,6 @@ func (q *QueueSubspace) RenewLease(ctx context.Context, tx transaction.Tx, item 
 //
 //nolint:unused
 func (q *QueueSubspace) scanTable(ctx context.Context, tx transaction.Tx) error {
-	//nolint:unused
 	minVesting := time.UnixMilli(int64(1678281734380)) // 8 March 2023 - No queue item will be before this
 	currentTime := time.Now().Add(2 * time.Hour)
 	t := time.Now()

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -228,7 +228,7 @@ func (runner *BaseQueryRunner) buildSecondaryIndexKeysUsingFilter(coll *schema.D
 		return nil, errors.InvalidArgument("secondary indexes do not support case insensitive collation")
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetActiveIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err
@@ -313,7 +313,7 @@ func (runner *BaseQueryRunner) getSecondaryWriterIterator(ctx context.Context, t
 		return nil, err
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetActiveIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -79,13 +79,13 @@ func BuildSecondaryIndexKeys(coll *schema.DefaultCollection, queryFilters []filt
 		return nil, errors.InvalidArgument("Cannot index with an empty filter")
 	}
 
-	indexeableFields := coll.GetIndexedFields()
+	indexeableFields := coll.GetActiveIndexedFields()
 	if len(indexeableFields) == 0 {
 		return nil, errors.InvalidArgument("No indexable fields")
 	}
 
 	encoder := func(indexParts ...interface{}) (keys.Key, error) {
-		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.Indexes.SecondaryIndex.Name, "kvs"), nil
+		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.SecondaryIndexName(), "kvs"), nil
 	}
 
 	buildIndexParts := func(fieldName string, datatype schema.FieldType, value interface{}) []interface{} {

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -105,14 +105,14 @@ func NewSecondaryIndexer(coll *schema.DefaultCollection) *SecondaryIndexer {
 }
 
 func (q *SecondaryIndexer) scanIndex(ctx context.Context, tx transaction.Tx) (kv.Iterator, error) {
-	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
-	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
+	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
+	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
 	return tx.ReadRange(ctx, start, end, false)
 }
 
 func (q *SecondaryIndexer) IndexSize(ctx context.Context, tx transaction.Tx) (int64, error) {
-	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
-	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
+	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
+	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
 	return tx.RangeSize(ctx, q.coll.EncodedTableIndexName, lKey, rKey)
 }
 
@@ -318,7 +318,7 @@ func (q *SecondaryIndexer) buildTSRows(tableData *internal.TableData) ([]IndexRo
 
 func (q *SecondaryIndexer) buildIndexKey(row IndexRow, primaryKey []interface{}) keys.Key {
 	version := getFieldVersion(row.name, q.coll)
-	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
+	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
 }
 
 func (q *SecondaryIndexer) createKeysAndIndexInfo(primaryKey []interface{}, rows []IndexRow) ([]keys.Key, map[string]int64, map[string]int64) {


### PR DESCRIPTION
## Describe your changes

Manage secondary indexes via index metadata. All secondary indexes state are now tracked in the index metadata. The index can be in an `ACTIVE` state, meaning it can be used for querying. 

**One thing** I'm not sure about at the moment is that all secondary index information is stored under the encoding subspace. That should be ok. Changing it means we need to have two `indexStores`, one for the primary key and one for the secondary indexes

## How best to test these changes
All current tests should pass

## Issue ticket number and link
closes #912 
