### PR TITLE
Codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 3 # integration tests + cli tests + reviewpad
+    wait_for_ci: true
+coverage:
+  range: "50...60"


### PR DESCRIPTION
* Wait for all tests to finish before sending coverage notification.
* Set coverage bounds.