### PR TITLE
Allow persisting arrays with incomplete schema

### DIFF
--- a/schema/factory_builder.go
+++ b/schema/factory_builder.go
@@ -100,12 +100,12 @@ func (fb *FactoryBuilder) deserializeProperties(properties jsoniter.RawMessage, 
 		}
 
 		if builder.Type == jsonSpecArray {
-			if builder.Items == nil {
+			if builder.Items != nil {
+				if err = fb.deserializeArray(builder.Items, &builder.Fields); err != nil {
+					return err
+				}
+			} else if builder.MaxItems == nil || *builder.MaxItems != 0 {
 				return errors.InvalidArgument("missing items for array field")
-			}
-
-			if err = fb.deserializeArray(builder.Items, &builder.Fields); err != nil {
-				return err
 			}
 		}
 

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -270,6 +270,7 @@ var SupportedFieldProperties = container.NewHashSet(
 	"index",
 	"facet",
 	"searchIndex",
+	"maxItems",
 )
 
 // Indexes is to wrap different index that a collection can have.
@@ -330,6 +331,7 @@ type FieldBuilder struct {
 	CreatedAt   *bool               `json:"createdAt,omitempty"`
 	UpdatedAt   *bool               `json:"updatedAt,omitempty"`
 	MaxLength   *int32              `json:"maxLength,omitempty"`
+	MaxItems    *int32              `json:"maxItems,omitempty"`
 	Auto        *bool               `json:"autoGenerate,omitempty"`
 	Sorted      *bool               `json:"sort,omitempty"`
 	Index       *bool               `json:"index,omitempty"`

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -317,6 +317,10 @@ func validateObjectFields(f *Field, notSupported bool) error {
 
 func validateFields(f *Field, notSupported bool) error {
 	if f.DataType == ArrayType {
+		if len(f.Fields) == 0 {
+			return nil
+		}
+
 		if f.Fields[0].DataType != ObjectType {
 			return validateFieldAttribute(f, notSupported)
 		}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -67,6 +67,10 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		"K7": {
 			"type": "string",
 			"format": "date-time"
+		},
+		"K8": {
+			"type": "array",
+			"maxItems": 0
 		}
 	},
 	"primary_key": ["K1", "K2"]
@@ -83,6 +87,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		require.Equal(t, ByteType, fields[4].DataType)
 		require.Equal(t, UUIDType, fields[5].DataType)
 		require.Equal(t, DateTimeType, fields[6].DataType)
+		require.Equal(t, ArrayType, fields[7].DataType)
 	})
 	t.Run("test_supported_primary_keys", func(t *testing.T) {
 		schema := []byte(`{

--- a/util/util.go
+++ b/util/util.go
@@ -100,18 +100,22 @@ func flatMap(key string, obj map[string]any, resp map[string]any, notFlat contai
 
 func UnFlatMap(flat map[string]any) map[string]any {
 	result := make(map[string]any)
+
 	for k, v := range flat {
 		keys := strings.Split(k, ObjFlattenDelimiter)
 		m := result
-		for i := 1; i < len(keys); i++ {
-			if _, ok := m[keys[i-1]]; !ok {
-				m[keys[i-1]] = make(map[string]any)
-			} else if m[keys[i-1]] == nil {
-				m[keys[i-1]] = make(map[string]any)
+
+		for i := 0; i < len(keys)-1; i++ {
+			if m[keys[i]] == nil {
+				m[keys[i]] = make(map[string]any)
 			}
-			m = m[keys[i-1]].(map[string]any)
+
+			m = m[keys[i]].(map[string]any)
 		}
-		m[keys[len(keys)-1]] = v
+
+		if v != nil {
+			m[keys[len(keys)-1]] = v
+		}
 	}
 
 	return result


### PR DESCRIPTION
Allow define field type as array, without specifying the type of array elements.
This allow to persist empty arrays.

Element types can be specified later, and is a compatible schema schema change.

Additionally: Fix UnflatMap case where nil value may come after map has been created for the object already.