### PR TITLE
fix: Fix unflatting object util method

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -106,6 +106,8 @@ func UnFlatMap(flat map[string]any) map[string]any {
 		for i := 1; i < len(keys); i++ {
 			if _, ok := m[keys[i-1]]; !ok {
 				m[keys[i-1]] = make(map[string]any)
+			} else if m[keys[i-1]] == nil {
+				m[keys[i-1]] = make(map[string]any)
 			}
 			m = m[keys[i-1]].(map[string]any)
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnFlatMap(t *testing.T) {
+	input := make(map[string]any)
+	input["app_metadata"] = nil
+	input["app_metadata.provider"] = "foo"
+	output := UnFlatMap(input)
+
+	require.Equal(t, 1, len(output))
+
+	expected := make(map[string]any)
+	expected["provider"] = "foo"
+	require.Equal(t, expected, output["app_metadata"])
+}


### PR DESCRIPTION
## Describe your changes
While unflatting the object, if the input map contains structure like this

"one" --> nil
"one.two" --> "v1"

then the method tries to access `nil` as the `map` and tries to insert ("two" in this case) into it and results into the error. This PR fixes that case. 

## How best to test these changes
Added test case.


## Issue ticket number and link
