### PR TITLE
fix: Move shared secret to Gotrue struct

### DIFF
--- a/config/server.test.yaml
+++ b/config/server.test.yaml
@@ -40,7 +40,7 @@ auth:
       algorithm: RS256
     - issuer: http://tigris_gotrue:8086
       algorithm: HS256
-      shared_secret: test_shared_secret
+      shared_secret_env_key: HS256_SIGNATURE_KEY
   token_cache_size: 100
   audience: https://tigris-test
   oauth_provider: gotrue

--- a/config/server.test.yaml
+++ b/config/server.test.yaml
@@ -40,7 +40,6 @@ auth:
       algorithm: RS256
     - issuer: http://tigris_gotrue:8086
       algorithm: HS256
-      shared_secret_env_key: HS256_SIGNATURE_KEY
   token_cache_size: 100
   audience: https://tigris-test
   oauth_provider: gotrue

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -59,6 +59,8 @@ type Gotrue struct {
 	AdminPassword      string `mapstructure:"admin_password" yaml:"admin_password" json:"admin_password"`
 	ClientIdLength     int    `mapstructure:"client_id_length" yaml:"client_id_length" json:"client_id_length"`
 	ClientSecretLength int    `mapstructure:"client_secret_length" yaml:"client_secret_length" json:"client_secret_length"`
+	// this is used to sign tokens with symmetric key signature algorithm
+	SharedSecret string `mapstructure:"shared_secret" yaml:"shared_secret" json:"shared_secret"`
 }
 
 type AuthConfig struct {
@@ -83,9 +85,8 @@ type AuthConfig struct {
 }
 
 type IssuerConfig struct {
-	Issuer             string                       `mapstructure:"issuer" yaml:"issuer" json:"issuer"`
-	Algorithm          validator.SignatureAlgorithm `mapstructure:"algorithm" yaml:"algorithm" json:"algorithm"`
-	SharedSecretEnvKey string                       `mapstructure:"shared_secret_env_key" yaml:"shared_secret_env_key" json:"shared_secret_env_key"`
+	Issuer    string                       `mapstructure:"issuer" yaml:"issuer" json:"issuer"`
+	Algorithm validator.SignatureAlgorithm `mapstructure:"algorithm" yaml:"algorithm" json:"algorithm"`
 }
 
 type CdcConfig struct {

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -83,9 +83,9 @@ type AuthConfig struct {
 }
 
 type IssuerConfig struct {
-	Issuer       string                       `mapstructure:"issuer" yaml:"issuer" json:"issuer"`
-	Algorithm    validator.SignatureAlgorithm `mapstructure:"algorithm" yaml:"algorithm" json:"algorithm"`
-	SharedSecret string                       `mapstructure:"shared_secret" yaml:"shared_secret" json:"shared_secret"`
+	Issuer             string                       `mapstructure:"issuer" yaml:"issuer" json:"issuer"`
+	Algorithm          validator.SignatureAlgorithm `mapstructure:"algorithm" yaml:"algorithm" json:"algorithm"`
+	SharedSecretEnvKey string                       `mapstructure:"shared_secret_env_key" yaml:"shared_secret_env_key" json:"shared_secret_env_key"`
 }
 
 type CdcConfig struct {

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -17,7 +17,6 @@ package middleware
 import (
 	"context"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -108,7 +107,7 @@ func GetJWTValidators(config *config.Config) []*validator.Validator {
 			keyFunc = provider.KeyFunc
 		case validator.HS256:
 			keyFunc = func(ctx context.Context) (interface{}, error) {
-				return []byte(os.Getenv(issuerCfg.SharedSecretEnvKey)), nil
+				return []byte(config.Auth.Gotrue.SharedSecret), nil
 			}
 		default:
 			panic("Unsupported Token signature algorithm")

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -17,6 +17,7 @@ package middleware
 import (
 	"context"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -107,7 +108,7 @@ func GetJWTValidators(config *config.Config) []*validator.Validator {
 			keyFunc = provider.KeyFunc
 		case validator.HS256:
 			keyFunc = func(ctx context.Context) (interface{}, error) {
-				return []byte(issuerCfg.SharedSecret), nil
+				return []byte(os.Getenv(issuerCfg.SharedSecretEnvKey)), nil
 			}
 		default:
 			panic("Unsupported Token signature algorithm")

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     image: tigris_server2
     environment:
       - TIGRIS_CONFIG_FILE=/etc/tigrisdata/tigris/server.test.yaml
+      - HS256_SIGNATURE_KEY=test_shared_secret
     build:
       context: ../../
       dockerfile: docker/Dockerfile

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -91,7 +91,7 @@ services:
     image: tigris_server2
     environment:
       - TIGRIS_CONFIG_FILE=/etc/tigrisdata/tigris/server.test.yaml
-      - HS256_SIGNATURE_KEY=test_shared_secret
+      - TIGRIS_SERVER_AUTH_GOTRUE_SHARED_SECRET=test_shared_secret
     build:
       context: ../../
       dockerfile: docker/Dockerfile


### PR DESCRIPTION
## Describe your changes
Moving the shared secret into gotrue config. This was motivated by limitation in deployment system's config rendering support.

## How best to test these changes
Updated tests with this mechanism.

## Issue ticket number and link
