### PR TITLE
feat: Support Accept header to stream application/json for read queries

### DIFF
--- a/api/server/v1/header.go
+++ b/api/server/v1/header.go
@@ -29,6 +29,8 @@ const (
 	// values. For ex, 0.1 means 100milliseconds.
 	HeaderRequestTimeout = "Request-Timeout"
 
+	HeaderAccept = "Accept"
+
 	HeaderAccessControlAllowOrigin = "Access-Control-Allow-Origin"
 	HeaderAuthorization            = "authorization"
 
@@ -48,7 +50,7 @@ const (
 func CustomMatcher(key string) (string, bool) {
 	key = textproto.CanonicalMIMEHeaderKey(key)
 	switch key {
-	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie:
+	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie, HeaderAccept:
 		return key, true
 	default:
 		if strings.HasPrefix(key, HeaderPrefix) {
@@ -64,4 +66,8 @@ func GetHeader(ctx context.Context, header string) string {
 	}
 
 	return metautils.ExtractIncoming(ctx).Get(grpcGatewayPrefix + header)
+}
+
+func GetNonGRPCGatewayHeader(ctx context.Context, header string) string {
+	return metautils.ExtractIncoming(ctx).Get(header)
 }

--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -836,13 +836,19 @@ func (x *UpdateResponse) MarshalJSON() ([]byte, error) {
 // Note: This also means any changes in ReadResponse proto needs to make sure that we add that here and similarly
 // the openAPI specs needs to be specified Data as object instead of bytes.
 func (x *ReadResponse) MarshalJSON() ([]byte, error) {
+	var md *Metadata
+	if x.Metadata != nil {
+		md1 := CreateMDFromResponseMD(x.Metadata)
+		md = &md1
+	}
+
 	resp := struct {
 		Data        jsoniter.RawMessage `json:"data,omitempty"`
-		Metadata    Metadata            `json:"metadata,omitempty"`
+		Metadata    *Metadata           `json:"metadata,omitempty"`
 		ResumeToken []byte              `json:"resume_token,omitempty"`
 	}{
 		Data:        x.Data,
-		Metadata:    CreateMDFromResponseMD(x.Metadata),
+		Metadata:    md,
 		ResumeToken: x.ResumeToken,
 	}
 	return jsoniter.Marshal(resp)

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -41,6 +41,10 @@ const (
 	Subject             = "sub"
 )
 
+const (
+	AcceptTypeApplicationJSON = "application/json"
+)
+
 var (
 	adminMethods = container.NewHashSet(api.CreateNamespaceMethodName, api.ListNamespaceMethodName, api.DescribeNamespacesMethodName)
 	tenantGetter metadata.TenantGetter
@@ -429,4 +433,9 @@ func NeedSchemaValidation(ctx context.Context) bool {
 
 func ReadSearchDataFromStorage(ctx context.Context) bool {
 	return api.GetHeader(ctx, api.HeaderReadSearchDataFromStorage) == "true"
+}
+
+func IsAcceptApplicationJSON(ctx context.Context) bool {
+	// we need to only check non grpc gateway prefix
+	return api.GetNonGRPCGatewayHeader(ctx, api.HeaderAccept) == AcceptTypeApplicationJSON
 }

--- a/test/v1/client/client_test.go
+++ b/test/v1/client/client_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/tigrisdata/tigris-client-go/tigris"
 )
 
-func TestClientCollectionBasic(t *testing.T) {
+func testClientCollectionBasic(t *testing.T, protocol string) {
 	ctx := context.TODO()
 
 	type Coll1 struct {
@@ -47,11 +47,9 @@ func TestClientCollectionBasic(t *testing.T) {
 	h, p := getTestServerHostPort()
 	var db *tigris.Database
 	var err error
-	var cfg *tigris.Config
+	cfg := &tigris.Config{URL: net.JoinHostPort(h, p), Project: projectName, Protocol: protocol}
 	for {
-		cfg = &tigris.Config{URL: net.JoinHostPort(h, p), Project: projectName}
-
-		drv, err := driver.NewDriver(ctx, &config.Driver{URL: cfg.URL})
+		drv, err := driver.NewDriver(ctx, &config.Driver{URL: cfg.URL, Protocol: protocol})
 		require.NoError(t, err)
 
 		deleteIfExists(ctx, drv, projectName)
@@ -120,7 +118,7 @@ func TestClientCollectionBasic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClientCollectionTx(t *testing.T) {
+func testClientCollectionTx(t *testing.T, protocol string) {
 	ctx := context.TODO()
 
 	type Coll1 struct {
@@ -131,9 +129,9 @@ func TestClientCollectionTx(t *testing.T) {
 	h, p := getTestServerHostPort()
 	var err error
 	var db *tigris.Database
-	cfg := &tigris.Config{URL: net.JoinHostPort(h, p), Project: projectName}
+	cfg := &tigris.Config{URL: net.JoinHostPort(h, p), Project: projectName, Protocol: protocol}
 	for {
-		drv, err := driver.NewDriver(ctx, &config.Driver{URL: cfg.URL})
+		drv, err := driver.NewDriver(ctx, &config.Driver{URL: cfg.URL, Protocol: protocol})
 		require.NoError(t, err)
 
 		deleteIfExists(ctx, drv, projectName)
@@ -221,6 +219,13 @@ func TestClientCollectionTx(t *testing.T) {
 
 	err = c.Drop(ctx)
 	require.NoError(t, err)
+}
+
+func TestClient(t *testing.T) {
+	for _, p := range []string{driver.GRPC, driver.HTTP} {
+		testClientCollectionBasic(t, p)
+		testClientCollectionTx(t, p)
+	}
 }
 
 func deleteIfExists(ctx context.Context, drv driver.Driver, project string) error {


### PR DESCRIPTION
## Describe your changes
The client can choose to pass the "**Accept**" header with the string "**application/json**" when they want to consume the `JSON` format instead of `NDJSON` for read response. 

The default behavior with no "accept" header is still `ndjson`.

**Default**:
```
 ~ curl -XPOST 'localhost:8081/v1/projects/p1/database/collections/c1/documents/read' -d '{ "filter": {}}' | jq .
{
  "result": {
    "data": {
      "addr": "aa",
      "balance": 1.3,
      "num": 1
    },
    "metadata": {
      "created_at": "2023-03-27T03:33:00.277006Z"
    },
    "resume_token": "ZGF0YQAAAAEAAAAQAAAAEQEA/wD/AP8SAAJhYQAVAQ=="
  }
}
{
  "result": {
    "data": {
      "addr": "aa",
      "balance": 1.3,
      "num": 2
    },
    "metadata": {
      "created_at": "2023-03-27T03:32:53.126956Z"
    },
    "resume_token": "ZGF0YQAAAAEAAAAQAAAAEQEA/wD/AP8SAAJhYQAVAg=="
  }
}
{
  "result": {
    "data": {
      "addr": "bb",
      "balance": 2.3,
      "num": 3
    },
    "metadata": {
      "created_at": "2023-03-27T03:32:47.933325Z"
    },
    "resume_token": "ZGF0YQAAAAEAAAAQAAAAEQEA/wD/AP8SAAJiYgAVAw=="
  }
}
```

**With Header Accept application/JSON**: 
```
 ~ curl -XPOST 'localhost:8081/v1/projects/p1/database/collections/c1/documents/read' -H "accept: application/json" -d '{ "filter": {}}' | jq .
{
  "result": {
    "data": [
      {
        "addr": "aa",
        "balance": 1.3,
        "num": 1,
        "_tigris_created_at": "2023-03-27T03:33:00.277006Z"
      },
      {
        "addr": "aa",
        "balance": 1.3,
        "num": 2,
        "_tigris_created_at": "2023-03-27T03:32:53.126956Z"
      },
      {
        "addr": "aa",
        "balance": 9.9,
        "num": 10,
        "_tigris_created_at": "2023-03-27T22:18:31.368834Z",
        "_tigris_updated_at": "2023-03-27T22:38:25.392061Z"
      },
      {
        "addr": "bb",
        "balance": 9.9,
        "num": 3,
        "_tigris_created_at": "2023-03-27T03:32:47.933325Z",
        "_tigris_updated_at": "2023-03-27T22:38:25.392061Z"
      }
    ]
  }
}
```

Note the data returned is an array and there is no top-level metadata. Each element of this array has the actual **user document** and **Tigris internal metadata fields** as well. This is done so that the user can deserialize the response array directly into their model.  

## How best to test these changes

## Issue ticket number and link
