### PR TITLE
feat: Manage secondary indexes via metadata

### DIFF
--- a/schema/collection.go
+++ b/schema/collection.go
@@ -48,7 +48,10 @@ type DefaultCollection struct {
 	// Fields are derived from the user schema.
 	Fields []*Field
 	// Indexes is a wrapper on the indexes part of this collection.
-	Indexes *Indexes
+	// Primary Key contains the fields used to make up the primary key
+	PrimaryKey *Index
+	// Secondary SecondaryIndexes for this collection
+	SecondaryIndexes *Indexes
 	// Validator is used to validate the JSON document. As it is expensive to create this, it is only created once
 	// during constructor of the collection.
 	Validator *jsonschema.Schema
@@ -85,6 +88,10 @@ type CollectionType string
 const (
 	DocumentsType CollectionType = "documents"
 )
+
+func (d *DefaultCollection) GetPrimaryKey() *Index {
+	return d.PrimaryKey
+}
 
 func disableAdditionalPropertiesAndAllowNullable(required []string, properties map[string]*jsonschema.Schema) {
 	for name, p := range properties {
@@ -168,7 +175,8 @@ func NewDefaultCollection(id uint32, schVer int, factory *Factory, schemas Versi
 		SchVer:                   schVer,
 		Name:                     factory.Name,
 		Fields:                   factory.Fields,
-		Indexes:                  factory.Indexes,
+		PrimaryKey:               factory.PrimaryKey,
+		SecondaryIndexes:         factory.Indexes,
 		Validator:                validator,
 		Schema:                   factory.Schema,
 		QueryableFields:          queryableFields,
@@ -198,6 +206,12 @@ func (d *DefaultCollection) GetName() string {
 	return d.Name
 }
 
+// The subspace within a collection where the secondary index information
+// is stored.
+func (d *DefaultCollection) SecondaryIndexName() string {
+	return "skey"
+}
+
 func (d *DefaultCollection) GetVersion() int32 {
 	return int32(d.SchVer)
 }
@@ -211,11 +225,22 @@ func (d *DefaultCollection) GetFields() []*Field {
 }
 
 func (d *DefaultCollection) GetIndexes() *Indexes {
-	return d.Indexes
+	return d.SecondaryIndexes
 }
 
 func (d *DefaultCollection) GetQueryableFields() []*QueryableField {
 	return d.QueryableFields
+}
+
+// Indexes that can be used for queries.
+func (d *DefaultCollection) GetActiveIndexedFields() []*QueryableField {
+	var indexed []*QueryableField
+	for _, q := range d.QueryableFields {
+		if q.Indexed && d.SecondaryIndexes.IsActiveIndex(q.FieldName) {
+			indexed = append(indexed, q)
+		}
+	}
+	return indexed
 }
 
 func (d *DefaultCollection) GetIndexedFields() []*QueryableField {

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -208,7 +208,7 @@ func (d *DefaultCollection) GetName() string {
 
 // The subspace within a collection where the secondary index information
 // is stored.
-func (d *DefaultCollection) SecondaryIndexName() string {
+func (d *DefaultCollection) SecondaryIndexKeyword() string {
 	return "skey"
 }
 

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -276,15 +276,39 @@ var SupportedFieldProperties = container.NewHashSet(
 
 // Indexes is to wrap different index that a collection can have.
 type Indexes struct {
-	PrimaryKey     *Index
-	SecondaryIndex *Index
+	All []*Index
 }
 
-func (i *Indexes) GetIndexes() []*Index {
-	var indexes []*Index
-	indexes = append(indexes, i.PrimaryKey)
-	return indexes
+func (i *Indexes) IsActiveIndex(name string) bool {
+	for _, idx := range i.All {
+		if idx.Name == name {
+			if idx.State == INDEX_ACTIVE {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+
+	return false
 }
+
+type IndexType uint8
+
+const (
+	PRIMARY_INDEX IndexType = iota
+	SECONDARY_INDEX
+)
+
+type IndexState uint8
+
+const (
+	UNKNOWN IndexState = iota
+	NOT_INDEXED
+	INDEX_DELETED
+	INDEX_WRITE_MODE
+	INDEX_ACTIVE
+)
 
 // Index can be composite, so it has a list of fields, each index has name and encoded id. The encoded is used for key
 // building.
@@ -295,6 +319,23 @@ type Index struct {
 	Name string
 	// Id is assigned to this index by the dictionary encoder.
 	Id uint32
+	// Secondary indexes can be in 4 states:
+	// 1. UNKNOWN = Have not fetched the index metadata yet so the state is unknown
+	// 2. NOT_INDEXED = field is not indexed
+	// 3. INDEX_WRITE_MODE = index is being built in the background and cannot be used for queries
+	// 4. INDEX_ACTIVE = index can be used for queries
+	// Note: this is not used for primary key indexes
+	State IndexState
+	// Either a PrimaryKey index or a Secondary Key index
+	IdxType IndexType
+}
+
+func (i *Index) IsSecondaryIndex() bool {
+	return i.IdxType == SECONDARY_INDEX
+}
+
+func (i *Index) IndexType() IndexType {
+	return i.IdxType
 }
 
 func (i *Index) IsCompatible(i1 *Index) error {

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -55,7 +55,7 @@ type SearchIndexValidator interface {
 type PrimaryIndexSchemaValidator struct{}
 
 func (v *PrimaryIndexSchemaValidator) Validate(existing *DefaultCollection, current *Factory) error {
-	return existing.Indexes.PrimaryKey.IsCompatible(current.Indexes.PrimaryKey)
+	return existing.GetPrimaryKey().IsCompatible(current.PrimaryKey)
 }
 
 type FieldSchemaValidator struct{}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -130,7 +130,7 @@ type Factory struct {
 	// Primary Key points to the fields used for the primary index. At this point the dictionary encoded value is not
 	// set for these indexes which is set as part of collection creation.
 	PrimaryKey *Index
-	// Indexes is a wrapper on the indexes part of this collection.
+	// Indexes is a wrapper on the secondary indexes part of this collection.
 	Indexes *Indexes
 	// Schema is the raw JSON schema received as part of CreateOrUpdateCollection request. This is stored as-is in the
 	// schema subspace.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -127,8 +127,10 @@ type Factory struct {
 	Name string
 	// Fields are derived from the user schema.
 	Fields []*Field
-	// Indexes is a wrapper on the indexes part of this collection. At this point the dictionary encoded value is not
+	// Primary Key points to the fields used for the primary index. At this point the dictionary encoded value is not
 	// set for these indexes which is set as part of collection creation.
+	PrimaryKey *Index
+	// Indexes is a wrapper on the indexes part of this collection.
 	Indexes *Indexes
 	// Schema is the raw JSON schema received as part of CreateOrUpdateCollection request. This is stored as-is in the
 	// schema subspace.
@@ -137,6 +139,10 @@ type Factory struct {
 	CollectionType  CollectionType
 	IndexingVersion string
 	Version         int32
+}
+
+func (f *Factory) SecondaryIndexes() []*Index {
+	return f.Indexes.All
 }
 
 func RemoveIndexingVersion(schema jsoniter.RawMessage) jsoniter.RawMessage {
@@ -224,17 +230,36 @@ func (fb *FactoryBuilder) Build(collection string, reqSchema jsoniter.RawMessage
 		}
 	}
 
+	// Create the secondary indexes with an unknown state
+	// to determine the state, tigris will need to read from the index metadata
+	secondaryIndex := []*Index{
+		{
+			Name:    ReservedFields[CreatedAt],
+			IdxType: SECONDARY_INDEX,
+			State:   UNKNOWN,
+		},
+		{
+			Name:    ReservedFields[UpdatedAt],
+			IdxType: SECONDARY_INDEX,
+			State:   UNKNOWN,
+		},
+	}
+	for _, field := range fields {
+		if field.Indexed != nil && *field.Indexed {
+			secondaryIndex = append(secondaryIndex, &Index{Name: field.Name(), IdxType: SECONDARY_INDEX, State: UNKNOWN, Fields: []*Field{field}})
+		}
+	}
+
 	factory := &Factory{
 		Fields: fields,
+		PrimaryKey: &Index{
+			Name:    PrimaryKeyIndexName,
+			Fields:  primaryKeyFields,
+			IdxType: PRIMARY_INDEX,
+			State:   INDEX_ACTIVE,
+		},
 		Indexes: &Indexes{
-			PrimaryKey: &Index{
-				Name:   PrimaryKeyIndexName,
-				Fields: primaryKeyFields,
-			},
-			SecondaryIndex: &Index{
-				Name:   SecondaryKeyIndexName,
-				Fields: []*Field{},
-			},
+			All: secondaryIndex,
 		},
 		Name:            collection,
 		Schema:          reqSchema,

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -32,8 +32,8 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, c.Name, "t1")
-		require.Equal(t, c.Indexes.PrimaryKey.Fields[0].FieldName, "cust_id")
-		require.Equal(t, c.Indexes.PrimaryKey.Fields[1].FieldName, "order_id")
+		require.Equal(t, c.GetPrimaryKey().Fields[0].FieldName, "cust_id")
+		require.Equal(t, c.GetPrimaryKey().Fields[1].FieldName, "order_id")
 	})
 	t.Run("test_create_failure", func(t *testing.T) {
 		reqSchema := []byte(`{"title":"Record of an order","properties":{"order_id":{"description":"A unique identifier for an order","type":"integer"},"cust_id":{"description":"A unique identifier for a customer","type":"integer"},"product":{"description":"name of the product","type":"string","maxLength":100},"quantity":{"description":"number of products ordered","type":"integer"},"price":{"description":"price of the product","type":"number"}},"primary_key":["cust_id","order_id"]}`)
@@ -118,11 +118,11 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 		require.NoError(t, err)
 		c, err := NewDefaultCollection(1, 1, sch, nil, nil)
 		require.NoError(t, err)
-		require.Equal(t, StringType, c.Indexes.PrimaryKey.Fields[0].DataType)
-		require.Equal(t, Int64Type, c.Indexes.PrimaryKey.Fields[1].DataType)
-		require.Equal(t, ByteType, c.Indexes.PrimaryKey.Fields[2].DataType)
-		require.Equal(t, UUIDType, c.Indexes.PrimaryKey.Fields[3].DataType)
-		require.Equal(t, DateTimeType, c.Indexes.PrimaryKey.Fields[4].DataType)
+		require.Equal(t, StringType, c.GetPrimaryKey().Fields[0].DataType)
+		require.Equal(t, Int64Type, c.GetPrimaryKey().Fields[1].DataType)
+		require.Equal(t, ByteType, c.GetPrimaryKey().Fields[2].DataType)
+		require.Equal(t, UUIDType, c.GetPrimaryKey().Fields[3].DataType)
+		require.Equal(t, DateTimeType, c.GetPrimaryKey().Fields[4].DataType)
 	})
 	t.Run("test_unsupported_primary_key", func(t *testing.T) {
 		schema := []byte(`{
@@ -243,14 +243,24 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 			Id:             1,
 			SchVer:         1,
 			Name:           "t1",
-			Indexes: &Indexes{
-				PrimaryKey: &Index{
-					Fields: []*Field{{FieldName: "id", DataType: Int64Type, PrimaryKeyField: &b}},
-					Name:   "pkey",
-				},
-				SecondaryIndex: &Index{
-					Fields: []*Field{},
-					Name:   "skey",
+			PrimaryKey: &Index{
+				Fields:  []*Field{{FieldName: "id", DataType: Int64Type, PrimaryKeyField: &b}},
+				Name:    "pkey",
+				IdxType: PRIMARY_INDEX,
+				State:   INDEX_ACTIVE,
+			},
+			SecondaryIndexes: &Indexes{
+				All: []*Index{
+					{
+						Name:    ReservedFields[CreatedAt],
+						IdxType: SECONDARY_INDEX,
+						State:   UNKNOWN,
+					},
+					{
+						Name:    ReservedFields[UpdatedAt],
+						IdxType: SECONDARY_INDEX,
+						State:   UNKNOWN,
+					},
 				},
 			},
 			Fields: []*Field{
@@ -523,7 +533,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 			}
 		}
 		require.True(t, primaryKeyPresent)
-		require.Equal(t, UUIDType, c.Indexes.PrimaryKey.Fields[0].DataType)
+		require.Equal(t, UUIDType, c.GetPrimaryKey().Fields[0].DataType)
 	})
 	t.Run("test_no-primary-key-user-id", func(t *testing.T) {
 		schema := []byte(`{
@@ -554,7 +564,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 			}
 		}
 		require.True(t, primaryKeyPresent)
-		require.Equal(t, Int64Type, c.Indexes.PrimaryKey.Fields[0].DataType)
+		require.Equal(t, Int64Type, c.GetPrimaryKey().Fields[0].DataType)
 	})
 }
 

--- a/server/metadata/collection.go
+++ b/server/metadata/collection.go
@@ -22,13 +22,15 @@ import (
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/transaction"
 	ulog "github.com/tigrisdata/tigris/util/log"
 )
 
 // CollectionMetadata contains collection wide metadata.
 type CollectionMetadata struct {
-	ID uint32 `json:"id,omitempty"`
+	ID      uint32          `json:"id,omitempty"`
+	Indexes []*schema.Index `json:"indexes"`
 }
 
 // CollectionSubspace is used to store metadata about Tigris collections.
@@ -53,6 +55,72 @@ func (c *CollectionSubspace) getKey(nsID uint32, dbID uint32, name string) keys.
 	}
 
 	return keys.NewKey(c.SubspaceName, c.KeyVersion, UInt32ToByte(nsID), UInt32ToByte(dbID), collectionKey, name, keyEnd)
+}
+
+func (c *CollectionSubspace) Create(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string, id uint32, indexes []*schema.Index,
+) (*CollectionMetadata, error) {
+	for _, index := range indexes {
+		index.State = schema.INDEX_ACTIVE
+		index.IdxType = schema.SECONDARY_INDEX
+	}
+
+	meta := &CollectionMetadata{
+		id,
+		indexes,
+	}
+
+	if err := c.insert(ctx, tx, nsID, dbID, name, meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+func (c *CollectionSubspace) Update(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string, id uint32, updatedIndexes []*schema.Index,
+) (*CollectionMetadata, error) {
+	metadata, err := c.Get(ctx, tx, nsID, dbID, name)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, updateIdx := range updatedIndexes {
+		if !hasIndex(metadata.Indexes, updateIdx) {
+			updateIdx.State = schema.INDEX_WRITE_MODE
+			if err = c.createBuildIndexTask(ctx, tx, nsID, dbID, name, id, updateIdx); err != nil {
+				return nil, err
+			}
+			metadata.Indexes = append(metadata.Indexes, updateIdx)
+		}
+	}
+
+	for _, existing := range metadata.Indexes {
+		if !hasIndex(updatedIndexes, existing) {
+			existing.State = schema.INDEX_DELETED
+			if err = c.createDeleteIndexTask(ctx, tx, nsID, dbID, name, id, existing); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	err = c.updateMetadata(ctx, tx,
+		c.validateArgs(nsID, dbID, name, &metadata),
+		c.getKey(nsID, dbID, name),
+		collMetaValueVersion,
+		metadata,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata, nil
+}
+
+func (c *CollectionSubspace) createBuildIndexTask(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string, id uint32, index *schema.Index) error {
+	return nil
+}
+
+func (c *CollectionSubspace) createDeleteIndexTask(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string, id uint32, index *schema.Index) error {
+	return nil
 }
 
 func (c *CollectionSubspace) insert(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string,
@@ -96,17 +164,6 @@ func (c *CollectionSubspace) Get(ctx context.Context, tx transaction.Tx, nsID ui
 	return c.decodeMetadata(name, payload)
 }
 
-func (c *CollectionSubspace) Update(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string,
-	metadata *CollectionMetadata,
-) error {
-	return c.updateMetadata(ctx, tx,
-		c.validateArgs(nsID, dbID, name, &metadata),
-		c.getKey(nsID, dbID, name),
-		collMetaValueVersion,
-		metadata,
-	)
-}
-
 func (c *CollectionSubspace) delete(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string,
 ) error {
 	return c.deleteMetadata(ctx, tx,
@@ -127,7 +184,7 @@ func (c *CollectionSubspace) softDelete(ctx context.Context, tx transaction.Tx, 
 	)
 }
 
-func (_ *CollectionSubspace) validateArgs(nsID uint32, dbID uint32, name string, metadata **CollectionMetadata) error {
+func (*CollectionSubspace) validateArgs(nsID uint32, dbID uint32, name string, metadata **CollectionMetadata) error {
 	if nsID == 0 || dbID == 0 {
 		return errors.InvalidArgument("invalid id")
 	}
@@ -180,4 +237,14 @@ func (c *CollectionSubspace) list(ctx context.Context, tx transaction.Tx, namesp
 	}
 
 	return collections, nil
+}
+
+func hasIndex(indexes []*schema.Index, idx *schema.Index) bool {
+	for _, index := range indexes {
+		if index.Name == idx.Name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/metadata/collection.go
+++ b/server/metadata/collection.go
@@ -60,8 +60,9 @@ func (c *CollectionSubspace) getKey(nsID uint32, dbID uint32, name string) keys.
 func (c *CollectionSubspace) Create(ctx context.Context, tx transaction.Tx, nsID uint32, dbID uint32, name string, id uint32, indexes []*schema.Index,
 ) (*CollectionMetadata, error) {
 	for _, index := range indexes {
+		// The indexes are created when the collection is created which means we do not need to
+		// do any background building, the index is already up to date and can be used for queries
 		index.State = schema.INDEX_ACTIVE
-		index.IdxType = schema.SECONDARY_INDEX
 	}
 
 	meta := &CollectionMetadata{

--- a/server/metadata/primary_index_test.go
+++ b/server/metadata/primary_index_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/tigrisdata/tigris/server/transaction"
 )
 
-var testIndexMetadata = &IndexMetadata{}
+var testIndexMetadata = &PrimaryIndexMetadata{}
 
-func initIndexTest(t *testing.T, ctx context.Context) (*IndexSubspace, *transaction.Manager) {
-	c := newIndexStore(newTestNameRegistry(t))
+func initIndexTest(t *testing.T, ctx context.Context) (*PrimaryIndexSubspace, *transaction.Manager) {
+	c := newPrimaryIndexStore(newTestNameRegistry(t))
 
 	_ = kvStore.DropTable(ctx, c.SubspaceName)
 
@@ -80,7 +80,7 @@ func TestIndexSubspace(t *testing.T) {
 		tx, cleanupTx := initTx(t, ctx, tm)
 		defer cleanupTx()
 
-		appPayload := &IndexMetadata{
+		appPayload := &PrimaryIndexMetadata{
 			Name: "name111",
 		}
 
@@ -99,7 +99,7 @@ func TestIndexSubspace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testIndexMetadata, index)
 
-		updatedPayload := &IndexMetadata{
+		updatedPayload := &PrimaryIndexMetadata{
 			Name: "name222",
 		}
 
@@ -127,15 +127,28 @@ func TestIndexSubspace(t *testing.T) {
 		tx, cleanupTx := initTx(t, ctx, tm)
 		defer cleanupTx()
 
-		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, "name8", testIndexMetadata))
-		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, "name9", testIndexMetadata))
+		idx8 := &PrimaryIndexMetadata{
+			Name: "name8",
+		}
+
+		idx9 := &PrimaryIndexMetadata{
+			Name: "name9",
+		}
+
+		idx10 := &PrimaryIndexMetadata{
+			Name: "name10",
+		}
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx8.Name, idx8))
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx9.Name, idx9))
+		require.NoError(t, c.insert(ctx, tx, 1, 1, 1, idx10.Name, idx10))
 
 		colls, err := c.list(ctx, tx, 1, 1, 1)
 		require.NoError(t, err)
 
-		require.Equal(t, map[string]*IndexMetadata{
-			"name8": {},
-			"name9": {},
+		require.Equal(t, map[string]*PrimaryIndexMetadata{
+			"name8":  idx8,
+			"name9":  idx9,
+			"name10": idx10,
 		}, colls)
 	})
 }
@@ -206,9 +219,9 @@ func TestIndexSubspaceMigrationV1(t *testing.T) {
 	// New code is able to read legacy version
 	meta, err := c.Get(ctx, tx, 1, 1, 1, "name7")
 	require.NoError(t, err)
-	require.Equal(t, &IndexMetadata{ID: 123}, meta)
+	require.Equal(t, &PrimaryIndexMetadata{ID: 123}, meta)
 
-	updatedMetadata := &IndexMetadata{
+	updatedMetadata := &PrimaryIndexMetadata{
 		ID:   123,
 		Name: "name333",
 	}
@@ -219,5 +232,5 @@ func TestIndexSubspaceMigrationV1(t *testing.T) {
 	// We are able to read in new format
 	meta, err = c.Get(ctx, tx, 1, 1, 1, "name7")
 	require.NoError(t, err)
-	require.Equal(t, &IndexMetadata{ID: 123, Name: "name333"}, meta)
+	require.Equal(t, &PrimaryIndexMetadata{ID: 123, Name: "name333"}, meta)
 }

--- a/server/metadata/queue.go
+++ b/server/metadata/queue.go
@@ -225,7 +225,6 @@ func (q *QueueSubspace) RenewLease(ctx context.Context, tx transaction.Tx, item 
 //
 //nolint:unused
 func (q *QueueSubspace) scanTable(ctx context.Context, tx transaction.Tx) error {
-	//nolint:unused
 	minVesting := time.UnixMilli(int64(1678281734380)) // 8 March 2023 - No queue item will be before this
 	currentTime := time.Now().Add(2 * time.Hour)
 	t := time.Now()

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1256,12 +1256,7 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 	primaryKeyIndex := schFactory.PrimaryKey
 	meta, ok := cHolder.primaryIdxMeta[primaryKeyIndex.Name]
 	if !ok {
-		// these are the new indexes present in the new collection
-		meta, err = tenant.metaStore.CreatePrimaryIndex(ctx, tx, primaryKeyIndex.Name, tenant.namespace.Id(), database.id, cHolder.id)
-		if err != nil {
-			return err
-		}
-		cHolder.addIndex(primaryKeyIndex.Name, meta)
+		return errors.InvalidArgument("cannot create a new primary key name")
 	}
 
 	primaryKeyIndex.Id = meta.ID
@@ -1679,13 +1674,6 @@ func (c *collectionHolder) clone() *collectionHolder {
 	}
 
 	return &copyC
-}
-
-func (c *collectionHolder) addIndex(name string, idx *PrimaryIndexMetadata) {
-	c.Lock()
-	defer c.Unlock()
-
-	c.primaryIdxMeta[name] = idx
 }
 
 // get returns the collection managed by this holder. At this point, a Collection object is safely constructed

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -422,10 +422,12 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 				"type": "string"
 			},
 			"K2": {
-				"type": "integer"
+				"type": "integer",
+				"index": true
 			},
 			"D1": {
 				"type": "string",
+				"index": true,
 				"maxLength": 128
 			}
 		},
@@ -444,7 +446,6 @@ func TestTenantManager_CreateCollections(t *testing.T) {
 		collection := db2.GetCollection("test_collection")
 		require.Equal(t, "test_collection", collection.Name)
 		require.Equal(t, "test_collection", db2.idToCollectionMap[collection.Id])
-		require.Equal(t, 1, len(db2.idToCollectionMap))
 
 		require.NoError(t, tx.Commit(ctx))
 
@@ -589,6 +590,175 @@ func TestTenantManager_SearchIndexes(t *testing.T) {
 	require.NoError(t, tx.Commit(ctx))
 
 	testClearDictionary(ctx, m.metaStore, m.kvStore)
+}
+
+func TestTenantManager_SecondaryIndexes(t *testing.T) {
+	tm := transaction.NewManager(kvStore)
+	t.Run("create_collections", func(t *testing.T) {
+		m, ctx, cancel := NewTestTenantMgr(t, kvStore)
+		defer cancel()
+
+		_, err := m.CreateOrGetTenant(ctx, &TenantNamespace{"ns-test1", 2, NewNamespaceMetadata(2, "ns-test1", "ns-test1-display_name")})
+		require.NoError(t, err)
+
+		tenant := m.tenants["ns-test1"]
+		tx, err := tm.StartTx(ctx)
+		require.NoError(t, err)
+		err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
+		require.NoError(t, err)
+		err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+		proj1, err := tenant.GetProject(tenantProj1)
+		require.NoError(t, err)
+		require.Equal(t, tenantProj1, proj1.Name())
+		db1 := proj1.database
+		require.NoError(t, err)
+		require.Equal(t, tenantDb1.Name(), db1.Name())
+		require.Equal(t, tenantDb1.Name(), tenant.idToDatabaseMap[db1.id].Name())
+
+		proj2, err := tenant.GetProject(tenantProj2)
+		require.NoError(t, err)
+		require.Equal(t, tenantProj2, proj2.Name())
+		db2 := proj2.database
+		require.Equal(t, tenantDb2.Name(), db2.Name())
+		require.Equal(t, tenantDb2.Name(), tenant.idToDatabaseMap[db2.id].Name())
+		require.Equal(t, 2, len(tenant.idToDatabaseMap))
+		require.Equal(t, 2, len(tenant.projects))
+
+		jsSchema := []byte(`{
+        "title": "test_collection",
+		"properties": {
+			"K1": {
+				"type": "string",
+				"index": true
+			},
+			"K2": {
+				"type": "integer",
+				"index": true
+			},
+			"D1": {
+				"type": "string",
+				"maxLength": 128
+			}
+		},
+		"primary_key": ["K1", "K2"]
+	}`)
+
+		factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
+		require.NoError(t, err)
+		require.NoError(t, tenant.CreateCollection(ctx, tx, db2, factory))
+
+		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+		proj2, err = tenant.GetProject(tenantProj2)
+		require.NoError(t, err)
+		db2 = proj2.database
+		collection := db2.GetCollection("test_collection")
+		require.Equal(t, "test_collection", collection.Name)
+		require.Equal(t, "test_collection", db2.idToCollectionMap[collection.Id])
+		require.Len(t, db2.idToCollectionMap, 1)
+		// K1, K2, _tigris_created_at, _tigris_updated_at
+		require.Len(t, collection.GetActiveIndexedFields(), 4)
+		require.Len(t, collection.GetIndexedFields(), 4)
+
+		require.NoError(t, tx.Commit(ctx))
+
+		testClearDictionary(ctx, m.metaStore, m.kvStore)
+	})
+
+	t.Run("update_collections", func(t *testing.T) {
+		m, ctx, cancel := NewTestTenantMgr(t, kvStore)
+		defer cancel()
+
+		_, err := m.CreateOrGetTenant(ctx, &TenantNamespace{"ns-test1", 2, NewNamespaceMetadata(2, "ns-test1", "ns-test1-display_name")})
+		require.NoError(t, err)
+
+		tenant := m.tenants["ns-test1"]
+		tx, err := tm.StartTx(ctx)
+		require.NoError(t, err)
+		err = tenant.CreateProject(ctx, tx, tenantProj1, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+		proj1, err := tenant.GetProject(tenantProj1)
+		require.NoError(t, err)
+		require.Equal(t, tenantProj1, proj1.Name())
+		db1 := proj1.database
+		require.NoError(t, err)
+		require.Equal(t, tenantDb1.Name(), db1.Name())
+		require.Equal(t, tenantDb1.Name(), tenant.idToDatabaseMap[db1.id].Name())
+
+		jsSchema := []byte(`{
+        "title": "test_collection",
+		"properties": {
+			"K1": {
+				"type": "string",
+				"index": true
+			},
+			"K2": {
+				"type": "integer"
+			},
+			"D1": {
+				"type": "string",
+				"maxLength": 128
+			}
+		},
+		"primary_key": ["K1", "K2"]
+	}`)
+
+		factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
+		require.NoError(t, err)
+		require.NoError(t, tenant.CreateCollection(ctx, tx, db1, factory))
+
+		require.NoError(t, tenant.reload(ctx, tx, nil, nil))
+
+		proj1, err = tenant.GetProject(tenantProj1)
+		require.NoError(t, err)
+		db1 = proj1.database
+		collection := db1.GetCollection("test_collection")
+		require.Equal(t, "test_collection", collection.Name)
+		require.Equal(t, "test_collection", db1.idToCollectionMap[collection.Id])
+		require.Len(t, db1.idToCollectionMap, 1)
+		// K1, _tigris_created_at, _tigris_updated_at
+		require.Len(t, collection.GetActiveIndexedFields(), 3)
+		require.Len(t, collection.GetIndexedFields(), 3)
+
+		jsSchemaUpdate := []byte(`{
+        "title": "test_collection",
+		"properties": {
+			"K1": {
+				"type": "string",
+				"index": true
+			},
+			"K2": {
+				"type": "integer",
+				"index": true
+			},
+			"D1": {
+				"type": "string",
+				"maxLength": 128,
+				"index": true
+			}
+		},
+		"primary_key": ["K1", "K2"]
+	}`)
+
+		factory, err = schema.NewFactoryBuilder(true).Build("test_collection", jsSchemaUpdate)
+		require.NoError(t, err)
+		require.NoError(t, tenant.CreateCollection(ctx, tx, db1, factory))
+		collection = db1.GetCollection("test_collection")
+		require.Len(t, collection.GetActiveIndexedFields(), 3)
+		// K1, K2, D1, _tigris_created_at, _tigris_updated_at
+		require.Len(t, collection.GetIndexedFields(), 5)
+
+		require.NoError(t, tx.Commit(ctx))
+
+		testClearDictionary(ctx, m.metaStore, m.kvStore)
+	})
 }
 
 func TestTenantManager_DataSize(t *testing.T) {

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -131,7 +131,7 @@ func (runner *BaseQueryRunner) insertOrReplace(ctx context.Context, tx transacti
 			return nil, nil, err
 		}
 
-		keyGen := newKeyGenerator(doc, tenant.TableKeyGenerator, coll.Indexes.PrimaryKey)
+		keyGen := newKeyGenerator(doc, tenant.TableKeyGenerator, coll.GetPrimaryKey())
 		key, err := keyGen.generate(ctx, runner.txMgr, runner.encoder, coll.EncodedName)
 		if err != nil {
 			return nil, nil, err
@@ -208,9 +208,9 @@ func (runner *BaseQueryRunner) buildKeysUsingFilter(coll *schema.DefaultCollecti
 	}
 
 	kb := filter.NewPrimaryKeyEqBuilder(func(indexParts ...interface{}) (keys.Key, error) {
-		return runner.encoder.EncodeKey(coll.EncodedName, coll.Indexes.PrimaryKey, indexParts)
+		return runner.encoder.EncodeKey(coll.EncodedName, coll.GetPrimaryKey(), indexParts)
 	})
-	queryPlan, err := kb.Build(filters, coll.Indexes.PrimaryKey.Fields)
+	queryPlan, err := kb.Build(filters, coll.GetPrimaryKey().Fields)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (runner *BaseQueryRunner) buildSecondaryIndexKeysUsingFilter(coll *schema.D
 		return nil, errors.InvalidArgument("secondary indexes do not support case insensitive collation")
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetActiveIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err
@@ -313,7 +313,7 @@ func (runner *BaseQueryRunner) getSecondaryWriterIterator(ctx context.Context, t
 		return nil, err
 	}
 
-	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetIndexedFields())
+	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetActiveIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
 	if err != nil {
 		return nil, err

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -264,7 +264,7 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		newKey := key
 		if primaryKeyMutation {
 			// we need to deleteReq old key and build new key from new data
-			keyGen := newKeyGenerator(newData.RawData, tenant.TableKeyGenerator, coll.Indexes.PrimaryKey)
+			keyGen := newKeyGenerator(newData.RawData, tenant.TableKeyGenerator, coll.GetPrimaryKey())
 			if newKey, err = keyGen.generate(ctx, runner.txMgr, runner.encoder, coll.EncodedName); err != nil {
 				return Response{}, nil, err
 			}

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -79,13 +79,13 @@ func BuildSecondaryIndexKeys(coll *schema.DefaultCollection, queryFilters []filt
 		return nil, errors.InvalidArgument("Cannot index with an empty filter")
 	}
 
-	indexeableFields := coll.GetIndexedFields()
+	indexeableFields := coll.GetActiveIndexedFields()
 	if len(indexeableFields) == 0 {
 		return nil, errors.InvalidArgument("No indexable fields")
 	}
 
 	encoder := func(indexParts ...interface{}) (keys.Key, error) {
-		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.Indexes.SecondaryIndex.Name, "kvs"), nil
+		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.SecondaryIndexName(), "kvs"), nil
 	}
 
 	buildIndexParts := func(fieldName string, datatype schema.FieldType, value interface{}) []interface{} {

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -85,7 +85,7 @@ func BuildSecondaryIndexKeys(coll *schema.DefaultCollection, queryFilters []filt
 	}
 
 	encoder := func(indexParts ...interface{}) (keys.Key, error) {
-		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.SecondaryIndexName(), "kvs"), nil
+		return newKeyWithPrimaryKey(indexParts, coll.EncodedTableIndexName, coll.SecondaryIndexKeyword(), "kvs"), nil
 	}
 
 	buildIndexParts := func(fieldName string, datatype schema.FieldType, value interface{}) []interface{} {

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -105,14 +105,14 @@ func NewSecondaryIndexer(coll *schema.DefaultCollection) *SecondaryIndexer {
 }
 
 func (q *SecondaryIndexer) scanIndex(ctx context.Context, tx transaction.Tx) (kv.Iterator, error) {
-	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
-	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
+	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexKeyword(), KVSubspace)
+	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexKeyword(), KVSubspace, 0xFF)
 	return tx.ReadRange(ctx, start, end, false)
 }
 
 func (q *SecondaryIndexer) IndexSize(ctx context.Context, tx transaction.Tx) (int64, error) {
-	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
-	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
+	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexKeyword(), KVSubspace)
+	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexKeyword(), KVSubspace, 0xFF)
 	return tx.RangeSize(ctx, q.coll.EncodedTableIndexName, lKey, rKey)
 }
 
@@ -318,7 +318,7 @@ func (q *SecondaryIndexer) buildTSRows(tableData *internal.TableData) ([]IndexRo
 
 func (q *SecondaryIndexer) buildIndexKey(row IndexRow, primaryKey []interface{}) keys.Key {
 	version := getFieldVersion(row.name, q.coll)
-	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
+	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.SecondaryIndexKeyword(), KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
 }
 
 func (q *SecondaryIndexer) createKeysAndIndexInfo(primaryKey []interface{}, rows []IndexRow) ([]keys.Key, map[string]int64, map[string]int64) {

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -105,14 +105,14 @@ func NewSecondaryIndexer(coll *schema.DefaultCollection) *SecondaryIndexer {
 }
 
 func (q *SecondaryIndexer) scanIndex(ctx context.Context, tx transaction.Tx) (kv.Iterator, error) {
-	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
-	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
+	start := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
+	end := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
 	return tx.ReadRange(ctx, start, end, false)
 }
 
 func (q *SecondaryIndexer) IndexSize(ctx context.Context, tx transaction.Tx) (int64, error) {
-	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace)
-	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, 0xFF)
+	lKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace)
+	rKey := keys.NewKey(q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, 0xFF)
 	return tx.RangeSize(ctx, q.coll.EncodedTableIndexName, lKey, rKey)
 }
 
@@ -318,7 +318,7 @@ func (q *SecondaryIndexer) buildTSRows(tableData *internal.TableData) ([]IndexRo
 
 func (q *SecondaryIndexer) buildIndexKey(row IndexRow, primaryKey []interface{}) keys.Key {
 	version := getFieldVersion(row.name, q.coll)
-	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.Indexes.SecondaryIndex.Name, KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
+	return newKeyWithPrimaryKey(primaryKey, q.coll.EncodedTableIndexName, q.coll.SecondaryIndexName(), KVSubspace, row.Name(), version, row.value.AsInterface(), row.pos)
 }
 
 func (q *SecondaryIndexer) createKeysAndIndexInfo(primaryKey []interface{}, rows []IndexRow) ([]keys.Key, map[string]int64, map[string]int64) {

--- a/store/search/search.go
+++ b/store/search/search.go
@@ -90,7 +90,7 @@ func (n *NoopStore) AllCollections(context.Context) (map[string]*tsApi.Collectio
 }
 
 func (n *NoopStore) DescribeCollection(context.Context, string) (*tsApi.CollectionResponse, error) {
-	return nil, nil
+	return &tsApi.CollectionResponse{}, nil
 }
 func (n *NoopStore) CreateCollection(context.Context, *tsApi.CollectionSchema) error { return nil }
 func (n *NoopStore) UpdateCollection(context.Context, string, *tsApi.CollectionUpdateSchema) error {


### PR DESCRIPTION
## Describe your changes

Manage the state of secondary indexes in the collections metadata. Secondary indexes can be in 4 states:
    1. UNKNOWN = Have not fetched the index metadata yet so the state is unknown
	2. NOT_INDEXED = field is not indexed
	3. INDEX_WRITE_MODE = index is being built in the background and cannot be used for queries
	4. INDEX_ACTIVE = index can be used for queries

This allows Tigris to only use active and up to date indexes for querying.

There is also code clean up to differentiate between the primary key and the secondary index. The primary key index is kept in its own metadata subspace.

## How best to test these changes
All tests should pass

## Issue ticket number and link
closes #912 
