### PR TITLE
fix: Billing start date to be the same day at 00:00 UTC

### DIFF
--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -75,7 +75,7 @@ func (m *Metronome) AddPlan(ctx context.Context, metronomeId string, planId stri
 	payload := map[string]any{
 		"plan_id": planId,
 		// plans can only start at UTC midnight, so we either +1 or -1 from current day
-		"starting_on": nextMidnight().Format(TimeFormat),
+		"starting_on": pastMidnight().Format(TimeFormat),
 	}
 
 	req, err := m.createRequest(ctx, fmt.Sprintf("/customers/%s/plans/add", metronomeId), payload)
@@ -124,8 +124,8 @@ func (m *Metronome) executeRequest(ctx context.Context, req *http.Request) ([]by
 	return respBytes, nil
 }
 
-func nextMidnight() time.Time {
+func pastMidnight() time.Time {
 	now := time.Now().UTC()
 	yyyy, mm, dd := now.Date()
-	return time.Date(yyyy, mm, dd+1, 0, 0, 0, 0, time.UTC)
+	return time.Date(yyyy, mm, dd, 0, 0, 0, 0, time.UTC)
 }

--- a/server/services/v1/billing/metronome_test.go
+++ b/server/services/v1/billing/metronome_test.go
@@ -79,7 +79,7 @@ func TestMetronome_AddDefaultPlan(t *testing.T) {
 	t.Run("create new time", func(t *testing.T) {
 		metronomeId := "nsId_123"
 		yyyy, mm, dd := time.Now().UTC().Date()
-		expectedDate := time.Date(yyyy, mm, dd+1, 0, 0, 0, 0, time.UTC).Format(TimeFormat)
+		expectedDate := time.Date(yyyy, mm, dd, 0, 0, 0, 0, time.UTC).Format(TimeFormat)
 
 		gock.New(cfg.URL).
 			Post(fmt.Sprintf("customers/%s/plans/add", metronomeId)).


### PR DESCRIPTION
## Describe your changes
- If billing start day is next day, today's usage won't be accounted for

## How best to test these changes
- Unit tests
