### PR TITLE
fix: more accurate count of secondary indexes

### DIFF
--- a/server/metrics/global_status.go
+++ b/server/metrics/global_status.go
@@ -152,15 +152,21 @@ func (r *RequestStatus) AddDDLUpdateUnit() {
 	log.Debug().Msg("Add ddl update unit")
 }
 
-func (r *RequestStatus) OnlyCountKeyLength(fdbKey []byte) bool {
+func (r *RequestStatus) IsKeySecondaryIndex(fdbKey []byte) bool {
+	if bytes.Contains(fdbKey, []byte("skey")) {
+		log.Debug().Bytes("fdbKey", fdbKey).Msg("Is secondary index")
+		return true
+	}
+	return false
+}
+
+func (r *RequestStatus) IsSecondaryIndexFieldIgnored(fdbKey []byte) bool {
 	for _, ignoredField := range ignoredFieldsForWrites {
-		// Do not count if it is an ignored secondary index or not a secondary index
-		if bytes.Contains(fdbKey, []byte("skey")) && !bytes.Contains(fdbKey, ignoredField) {
-			log.Debug().Bytes("field", fdbKey).Msg("Ignoring field")
+		if bytes.Contains(fdbKey, ignoredField) {
+			log.Debug().Bytes("fdbKey", fdbKey).Msg("Ignoring secondary index field")
 			return true
 		}
 	}
-	log.Debug().Bytes("field", fdbKey).Msg("Not ignoring field")
 	return false
 }
 

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
 	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/errors"

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -190,7 +190,9 @@ func (q *SecondaryIndexer) Update(ctx context.Context, tx transaction.Tx, newTd 
 
 	for _, indexKey := range updateSet.removeKeys {
 		if reqStatus != nil && reqStatusExists {
-			reqStatus.AddWriteBytes(int64(len(indexKey.SerializeToBytes())))
+			if !reqStatus.IsSecondaryIndexFieldIgnored(indexKey.SerializeToBytes()) {
+				reqStatus.AddWriteBytes(int64(len(indexKey.SerializeToBytes())))
+			}
 		}
 		if err := tx.Delete(ctx, indexKey); err != nil {
 			return err
@@ -199,7 +201,9 @@ func (q *SecondaryIndexer) Update(ctx context.Context, tx transaction.Tx, newTd 
 
 	for _, indexKey := range updateSet.addKeys {
 		if reqStatus != nil && reqStatusExists {
-			reqStatus.AddWriteBytes(int64(len(indexKey.SerializeToBytes())))
+			if !reqStatus.IsSecondaryIndexFieldIgnored(indexKey.SerializeToBytes()) {
+				reqStatus.AddWriteBytes(int64(len(indexKey.SerializeToBytes())))
+			}
 		}
 		if err := tx.Replace(ctx, indexKey, internal.EmptyData, false); err != nil {
 			return err

--- a/store/kv/measure.go
+++ b/store/kv/measure.go
@@ -235,10 +235,8 @@ func (m *TxImplWithMetrics) Replace(ctx context.Context, table []byte, key Key, 
 	}
 	if requestStatus != nil {
 		fdbKey := getFDBKey(table, key)
-		if requestStatus.OnlyCountKeyLength(fdbKey) {
-			// Does not count _tigris_created_at and _tigris_updated_at
-			requestStatus.AddWriteBytes(int64(len(fdbKey)))
-		} else {
+		if !requestStatus.IsKeySecondaryIndex(fdbKey) {
+			// The secondary index keys are counted in query runner
 			requestStatus.AddWriteBytes(int64(len(data.RawData)))
 		}
 	}


### PR DESCRIPTION
## Describe your changes

In the previous implementation, ignored secondary indexes were counted and non-ignored secondary indexes were double counted, because the count happened both in the kv layer and in query runner for updates. I removed the write counts from the kv layer.

## How best to test these changes

Run the tests, tested it locally with ycsb data.

## Issue ticket number and link
#918 