### PR TITLE
feat: APIs to push billing metrics to metronome

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-api-client-go v1.16.0
-	github.com/adilansari/metronome-go-client v0.1.3
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
 	github.com/auth0/go-auth0 v0.9.3
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0
@@ -40,6 +39,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	github.com/tigrisdata/metronome-go-client v0.1.0
 	github.com/tigrisdata/tigris-client-go v1.0.0-beta.25
 	github.com/tigrisdata/typesense-go v0.6.2-beta.6
 	github.com/uber-go/tally v3.5.3+incompatible

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-api-client-go v1.16.0
+	github.com/adilansari/metronome-go-client v0.1.3
 	github.com/apple/foundationdb/bindings/go v0.0.0-20220521054011-a88e049b28d8
 	github.com/auth0/go-auth0 v0.9.3
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0
@@ -16,7 +17,6 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fullstorydev/grpchan v1.1.1
 	github.com/gertd/go-pluralize v0.2.1
-	github.com/getkin/kin-openapi v0.115.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/cors v1.2.1
 	github.com/go-redis/redis/v8 v8.11.5
@@ -83,6 +83,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 // indirect
+	github.com/getkin/kin-openapi v0.115.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/rehttp v1.1.0 h1:JFZ7OeK+hbJpTxhNB0NDZT47AuXqCU0Smxfjtph7/Rs=
 github.com/PuerkitoBio/rehttp v1.1.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/adilansari/metronome-go-client v0.1.3 h1:oBPn+40RJXnUA0FnpW7dT0W5OnFj+bZ4UCpHuYh5foc=
+github.com/adilansari/metronome-go-client v0.1.3/go.mod h1:4B23bW3bCMTDTggkiRzP2yQe1+6dqzHXqu/GmWM56M4=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/rehttp v1.1.0 h1:JFZ7OeK+hbJpTxhNB0NDZT47AuXqCU0Smxfjtph7/Rs=
 github.com/PuerkitoBio/rehttp v1.1.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/adilansari/metronome-go-client v0.1.3 h1:oBPn+40RJXnUA0FnpW7dT0W5OnFj+bZ4UCpHuYh5foc=
-github.com/adilansari/metronome-go-client v0.1.3/go.mod h1:4B23bW3bCMTDTggkiRzP2yQe1+6dqzHXqu/GmWM56M4=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -527,6 +525,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tigrisdata/metronome-go-client v0.1.0 h1:EEsNCUakxhKbM0xZ+GSnUcCFngBycCBYOyGAmrbJRm4=
+github.com/tigrisdata/metronome-go-client v0.1.0/go.mod h1:R5eSI50uoj2e2Qi0dpa51vf3RV92YZKNtRIWyG/DOno=
 github.com/tigrisdata/tigris-client-go v1.0.0-beta.25 h1:ifJlt67uoyprSJYWaOvd1aTkOL/FxpEBXcxv7n8ASOs=
 github.com/tigrisdata/tigris-client-go v1.0.0-beta.25/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
 github.com/tigrisdata/typesense-go v0.6.2-beta.6 h1:9XuSvGN0BZDPXV9dEquH6PuwmwYlhAX6w+h+9T1ngRo=

--- a/lib/uuid/uuid.go
+++ b/lib/uuid/uuid.go
@@ -16,7 +16,7 @@ package uuid
 
 import uuid2 "github.com/google/uuid"
 
-var NullUUID = uuid2.UUID{}
+var NullUUID = uuid2.Nil
 
 func NewUUIDAsString() string {
 	return uuid2.New().String()

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/auth0/go-jwt-middleware/v2/validator"
+
 	"github.com/tigrisdata/tigris/util/log"
 )
 
@@ -263,10 +264,11 @@ var DefaultConfig = Config{
 	},
 	Billing: Billing{
 		Metronome: Metronome{
-			Enabled:     false,
-			URL:         "https://api.metronome.com/v1",
-			ApiKey:      "replace_me",
-			DefaultPlan: "placeholderPlan",
+			Enabled: false,
+			URL:     "https://api.metronome.com/v1",
+			ApiKey:  "replace_me",
+			// random placeholder UUID and not an actual plan
+			DefaultPlan: "47eda90f-d2e8-4184-8955-cb3a6467782b",
 		},
 	},
 	Cdc: CdcConfig{

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/auth0/go-jwt-middleware/v2/validator"
-
 	"github.com/tigrisdata/tigris/util/log"
 )
 

--- a/server/services/v1/billing/event.go
+++ b/server/services/v1/billing/event.go
@@ -1,0 +1,135 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package billing
+
+import (
+	"time"
+
+	biller "github.com/adilansari/metronome-go-client"
+)
+
+type UsageEvent struct {
+	biller.Event
+}
+
+func NewUsageEventBuilder() *UsageEventBuilder {
+	return &UsageEventBuilder{}
+}
+
+type UsageEventBuilder struct {
+	namespaceId   string
+	transactionId string
+	timestamp     string
+	databaseUnits *int64
+	searchUnits   *int64
+}
+
+func (ub *UsageEventBuilder) WithNamespaceId(id string) *UsageEventBuilder {
+	ub.namespaceId = id
+	return ub
+}
+func (ub *UsageEventBuilder) WithTransactionId(id string) *UsageEventBuilder {
+	ub.transactionId = id
+	return ub
+}
+func (ub *UsageEventBuilder) WithTimestamp(ts time.Time) *UsageEventBuilder {
+	ub.timestamp = ts.Format(TimeFormat)
+	return ub
+}
+func (ub *UsageEventBuilder) WithDatabaseUnits(value int64) *UsageEventBuilder {
+	ub.databaseUnits = &value
+	return ub
+}
+func (ub *UsageEventBuilder) WithSearchUnits(value int64) *UsageEventBuilder {
+	ub.searchUnits = &value
+	return ub
+}
+
+func (ub *UsageEventBuilder) Build() *UsageEvent {
+	billingMetric := &UsageEvent{}
+	billingMetric.EventType = "usage"
+	billingMetric.CustomerId = ub.namespaceId
+	billingMetric.TransactionId = ub.transactionId
+	billingMetric.Timestamp = ub.timestamp
+	props := make(map[string]interface{})
+
+	// the key names must match the registered billing metrics in metronome
+	if ub.searchUnits != nil {
+		props["search_units"] = *ub.searchUnits
+	}
+
+	if ub.databaseUnits != nil {
+		props["database_units"] = *ub.databaseUnits
+	}
+	billingMetric.Properties = &props
+	return billingMetric
+}
+
+type StorageEvent struct {
+	biller.Event
+}
+
+func NewStorageEventBuilder() *StorageEventBuilder {
+	return &StorageEventBuilder{}
+}
+
+type StorageEventBuilder struct {
+	namespaceId   string
+	transactionId string
+	timestamp     string
+	databaseBytes *int64
+	indexBytes    *int64
+}
+
+func (sb *StorageEventBuilder) WithNamespaceId(id string) *StorageEventBuilder {
+	sb.namespaceId = id
+	return sb
+}
+func (sb *StorageEventBuilder) WithTransactionId(id string) *StorageEventBuilder {
+	sb.transactionId = id
+	return sb
+}
+func (sb *StorageEventBuilder) WithTimestamp(ts time.Time) *StorageEventBuilder {
+	sb.timestamp = ts.Format(TimeFormat)
+	return sb
+}
+func (sb *StorageEventBuilder) WithDatabaseBytes(value int64) *StorageEventBuilder {
+	sb.databaseBytes = &value
+	return sb
+}
+func (sb *StorageEventBuilder) WithIndexBytes(value int64) *StorageEventBuilder {
+	sb.indexBytes = &value
+	return sb
+}
+
+func (sb *StorageEventBuilder) Build() *StorageEvent {
+	billingMetric := &StorageEvent{}
+	billingMetric.EventType = "storage"
+	billingMetric.CustomerId = sb.namespaceId
+	billingMetric.TransactionId = sb.transactionId
+	billingMetric.Timestamp = sb.timestamp
+	props := make(map[string]interface{})
+
+	// the key names must match the registered billing metrics in metronome
+	if sb.indexBytes != nil {
+		props["index_bytes"] = *sb.indexBytes
+	}
+
+	if sb.databaseBytes != nil {
+		props["database_bytes"] = *sb.databaseBytes
+	}
+	billingMetric.Properties = &props
+	return billingMetric
+}

--- a/server/services/v1/billing/event.go
+++ b/server/services/v1/billing/event.go
@@ -17,7 +17,7 @@ package billing
 import (
 	"time"
 
-	biller "github.com/adilansari/metronome-go-client"
+	biller "github.com/tigrisdata/metronome-go-client"
 )
 
 type UsageEvent struct {

--- a/server/services/v1/billing/event_test.go
+++ b/server/services/v1/billing/event_test.go
@@ -1,0 +1,151 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package billing
+
+import (
+	"testing"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageEvent(t *testing.T) {
+	t.Run("with single property", func(t *testing.T) {
+		billingEvent := NewStorageEventBuilder().WithDatabaseBytes(24).WithNamespaceId("cid").Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "")
+		require.Equal(t, actual["event_type"], "storage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"database_bytes": float64(24),
+		})
+	})
+
+	t.Run("with 0 values", func(t *testing.T) {
+		billingEvent := NewStorageEventBuilder().WithDatabaseBytes(0).WithIndexBytes(0).Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "")
+		require.Equal(t, actual["event_type"], "storage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"index_bytes":    float64(0),
+			"database_bytes": float64(0),
+		})
+	})
+
+	t.Run("complete object", func(t *testing.T) {
+		billingEvent := NewStorageEventBuilder().
+			WithNamespaceId("c1").
+			WithTransactionId("t1").
+			WithTimestamp(time.Date(2023, 2, 21, 8, 53, 41, 0, time.UTC)).
+			WithIndexBytes(12).
+			WithDatabaseBytes(345).
+			Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "2023-02-21T08:53:41Z")
+		require.Equal(t, actual["event_type"], "storage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"index_bytes":    float64(12),
+			"database_bytes": float64(345),
+		})
+	})
+}
+
+func TestUsageEvent(t *testing.T) {
+	t.Run("with single property", func(t *testing.T) {
+		billingEvent := NewUsageEventBuilder().WithDatabaseUnits(55).WithNamespaceId("cid").Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "")
+		require.Equal(t, actual["event_type"], "usage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"database_units": float64(55),
+		})
+	})
+
+	t.Run("with 0 values", func(t *testing.T) {
+		billingEvent := NewUsageEventBuilder().WithDatabaseUnits(0).WithSearchUnits(0).Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "")
+		require.Equal(t, actual["event_type"], "usage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"database_units": float64(0),
+			"search_units":   float64(0),
+		})
+	})
+
+	t.Run("complete object", func(t *testing.T) {
+		billingEvent := NewUsageEventBuilder().
+			WithNamespaceId("c1").
+			WithTransactionId("t1").
+			WithTimestamp(time.Date(2023, 2, 21, 8, 53, 41, 0, time.UTC)).
+			WithDatabaseUnits(123).
+			WithSearchUnits(542).
+			Build()
+
+		jsonEvent, err := jsoniter.Marshal(billingEvent)
+		require.NoError(t, err)
+		var actual map[string]interface{}
+		err = jsoniter.Unmarshal(jsonEvent, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, actual["customer_id"], billingEvent.CustomerId)
+		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
+		require.Equal(t, actual["timestamp"], "2023-02-21T08:53:41Z")
+		require.Equal(t, actual["event_type"], "usage")
+		require.Equal(t, actual["properties"], map[string]any{
+			"database_units": float64(123),
+			"search_units":   float64(542),
+		})
+	})
+}

--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -19,9 +19,9 @@ import (
 	"net/http"
 	"time"
 
-	biller "github.com/tigrisdata/metronome-go-client"
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/google/uuid"
+	biller "github.com/tigrisdata/metronome-go-client"
 
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/config"

--- a/server/services/v1/billing/metronome_test.go
+++ b/server/services/v1/billing/metronome_test.go
@@ -20,22 +20,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tigrisdata/tigris/server/config"
 )
 
 func TestMetronome_CreateAccount(t *testing.T) {
 	defer gock.Off()
 	cfg := config.DefaultConfig.Billing.Metronome
-	metronome := &Metronome{Config: cfg}
+	metronome, err := NewMetronomeProvider(cfg)
+	require.NoError(t, err)
 	ctx := context.TODO()
 
 	t.Run("creating account succeeds in metronome", func(t *testing.T) {
 		namespaceId := "nsId_123"
 		tenantName := "foo tenant"
 		gock.New(cfg.URL).
-			Post("customers").
+			Post("/customers").
 			MatchHeader("Authorization", cfg.ApiKey).
 			MatchHeader("Content-Type", "application/json").
 			MatchType("json").
@@ -46,13 +49,14 @@ func TestMetronome_CreateAccount(t *testing.T) {
 			Reply(200).
 			JSON(map[string]interface{}{
 				"data": map[string]string{
-					"id": "metronome123",
+					"id": "16d145ec-d18e-11ed-afa1-0242ac120002",
 				},
 			})
 
 		createdId, err := metronome.CreateAccount(ctx, namespaceId, tenantName)
 		require.NoError(t, err)
-		require.Equal(t, "metronome123", createdId)
+		require.Equal(t, "16d145ec-d18e-11ed-afa1-0242ac120002", createdId.String())
+		require.True(t, gock.IsDone())
 	})
 
 	t.Run("Invalid API key", func(t *testing.T) {
@@ -63,26 +67,40 @@ func TestMetronome_CreateAccount(t *testing.T) {
 			})
 
 		createdId, err := metronome.CreateAccount(ctx, "nsId1", "foo_tenant")
-		require.ErrorContains(t, err, "401 Unauthorized")
+		require.ErrorContains(t, err, "Unauthorized")
 		require.Empty(t, createdId)
+		require.True(t, gock.IsDone())
 	})
 
-	require.True(t, gock.IsDone())
+	t.Run("account already exists", func(t *testing.T) {
+		gock.New(cfg.URL).
+			Post("/customers").
+			Reply(409).
+			JSON(map[string]string{
+				"message": "ingest alias conflict",
+			})
+
+		createdId, err := metronome.CreateAccount(ctx, "nsId1", "foo_tenant")
+		require.ErrorContains(t, err, "ingest alias conflict")
+		require.Empty(t, createdId)
+		require.True(t, gock.IsDone())
+	})
 }
 
 func TestMetronome_AddDefaultPlan(t *testing.T) {
 	defer gock.Off()
 	cfg := config.DefaultConfig.Billing.Metronome
-	metronome := &Metronome{Config: cfg}
+	metronome, err := NewMetronomeProvider(cfg)
+	require.NoError(t, err)
 	ctx := context.TODO()
 
 	t.Run("create new time", func(t *testing.T) {
-		metronomeId := "nsId_123"
+		metronomeId := uuid.New()
 		yyyy, mm, dd := time.Now().UTC().Date()
 		expectedDate := time.Date(yyyy, mm, dd, 0, 0, 0, 0, time.UTC).Format(TimeFormat)
 
 		gock.New(cfg.URL).
-			Post(fmt.Sprintf("customers/%s/plans/add", metronomeId)).
+			Post(fmt.Sprintf("/customers/%s/plans/add", metronomeId)).
 			MatchHeader("Authorization", cfg.ApiKey).
 			MatchHeader("Content-Type", "application/json").
 			MatchType("json").
@@ -93,20 +111,21 @@ func TestMetronome_AddDefaultPlan(t *testing.T) {
 			Reply(200).
 			JSON(map[string]interface{}{
 				"data": map[string]string{
-					"id": "plan123",
+					"id": "47eda90f-d2e8-4184-8955-cb3a64677821",
 				},
 			})
 
 		added, err := metronome.AddDefaultPlan(ctx, metronomeId)
 		require.NoError(t, err)
 		require.True(t, added)
+		require.True(t, gock.IsDone())
 	})
 
 	t.Run("bad request when no plan exists", func(t *testing.T) {
-		metronomeId := "nsId_123"
+		metronomeId := uuid.New()
 
 		gock.New(cfg.URL).
-			Post(fmt.Sprintf("customers/%s/plans/add", metronomeId)).
+			Post(fmt.Sprintf("/customers/%s/plans/add", metronomeId)).
 			Reply(400).
 			JSON(map[string]string{
 				"message": "No such plan",
@@ -115,7 +134,214 @@ func TestMetronome_AddDefaultPlan(t *testing.T) {
 		added, err := metronome.AddDefaultPlan(ctx, metronomeId)
 		require.ErrorContains(t, err, "No such plan")
 		require.False(t, added)
+		require.True(t, gock.IsDone())
+	})
+}
+
+func TestMetronome_PushStorageEvents(t *testing.T) {
+	defer gock.Off()
+	cfg := config.DefaultConfig.Billing.Metronome
+	metronome, err := NewMetronomeProvider(cfg)
+	require.NoError(t, err)
+	ctx := context.TODO()
+
+	t.Run("Skips invalid events", func(t *testing.T) {
+		namespaceId := "ns123"
+		events := []*StorageEvent{
+			NewStorageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				WithIndexBytes(256000).
+				WithDatabaseBytes(920_000_000).
+				Build(),
+			NewStorageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12355").
+				WithTimestamp(time.Date(2023, 2, 2, 0, 0, 0, 0, time.UTC)).
+				WithIndexBytes(8_750_000_000).
+				Build(),
+			nil,
+			NewStorageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12355").
+				WithTimestamp(time.Date(2023, 2, 2, 0, 0, 0, 0, time.UTC)).
+				Build(),
+		}
+
+		gock.New(cfg.URL).
+			Post("/ingest").
+			MatchHeader("Authorization", cfg.ApiKey).
+			MatchHeader("Content-Type", "application/json").
+			MatchType("json").
+			JSON([]map[string]interface{}{
+				{
+					"customer_id":    namespaceId,
+					"transaction_id": "t12354",
+					"timestamp":      "2023-01-01T00:00:00Z",
+					"event_type":     "storage",
+					"properties": map[string]interface{}{
+						"database_bytes": 920_000_000,
+						"index_bytes":    256000,
+					},
+				},
+				{
+					"customer_id":    namespaceId,
+					"transaction_id": "t12355",
+					"timestamp":      "2023-02-02T00:00:00Z",
+					"event_type":     "storage",
+					"properties": map[string]interface{}{
+						"index_bytes": 8_750_000_000,
+					},
+				}}).
+			Reply(200).
+			JSON(nil)
+
+		err := metronome.PushStorageEvents(ctx, events)
+		require.NoError(t, err)
+		require.True(t, gock.IsDone())
 	})
 
-	require.True(t, gock.IsDone())
+	t.Run("bad request", func(t *testing.T) {
+		gock.New(cfg.URL).
+			Post("/ingest").
+			Reply(400).
+			JSON(map[string]string{
+				"message": "Bad request",
+			})
+
+		err := metronome.PushStorageEvents(ctx, []*StorageEvent{
+			NewStorageEventBuilder().
+				WithNamespaceId("someId").
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				WithIndexBytes(256000).
+				WithDatabaseBytes(920_000_000).
+				Build(),
+		})
+		require.ErrorContains(t, err, "Bad request")
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("empty events", func(t *testing.T) {
+		gock.New(cfg.URL).
+			Post("/ingest").
+			Reply(200).
+			JSON(nil)
+
+		// no properties
+		err := metronome.PushStorageEvents(ctx, []*StorageEvent{
+			NewStorageEventBuilder().
+				WithNamespaceId("someId").
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				Build(),
+		})
+		require.NoError(t, err)
+		require.False(t, gock.IsDone())
+	})
+}
+
+func TestMetronome_PushUsageEvents(t *testing.T) {
+	defer gock.Off()
+	cfg := config.DefaultConfig.Billing.Metronome
+	metronome, err := NewMetronomeProvider(cfg)
+	require.NoError(t, err)
+	ctx := context.TODO()
+
+	t.Run("Skips invalid events", func(t *testing.T) {
+		namespaceId := "ns123"
+		events := []*UsageEvent{
+			NewUsageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				WithSearchUnits(256).
+				WithDatabaseUnits(920).
+				Build(),
+			NewUsageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12355").
+				WithTimestamp(time.Date(2023, 2, 2, 0, 0, 0, 0, time.UTC)).
+				WithSearchUnits(8_750).
+				Build(),
+			nil,
+			NewUsageEventBuilder().
+				WithNamespaceId(namespaceId).
+				WithTransactionId("t12355").
+				WithTimestamp(time.Date(2023, 2, 2, 0, 0, 0, 0, time.UTC)).
+				Build(),
+		}
+
+		gock.New(cfg.URL).
+			Post("/ingest").
+			MatchHeader("Authorization", cfg.ApiKey).
+			MatchHeader("Content-Type", "application/json").
+			MatchType("json").
+			JSON([]map[string]interface{}{
+				{
+					"customer_id":    namespaceId,
+					"transaction_id": "t12354",
+					"timestamp":      "2023-01-01T00:00:00Z",
+					"event_type":     "usage",
+					"properties": map[string]interface{}{
+						"database_units": 920,
+						"search_units":   256,
+					},
+				},
+				{
+					"customer_id":    namespaceId,
+					"transaction_id": "t12355",
+					"timestamp":      "2023-02-02T00:00:00Z",
+					"event_type":     "usage",
+					"properties": map[string]interface{}{
+						"search_units": 8_750,
+					},
+				}}).
+			Reply(200).
+			JSON(nil)
+
+		err := metronome.PushUsageEvents(ctx, events)
+		require.NoError(t, err)
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		gock.New(cfg.URL).
+			Post("/ingest").
+			Reply(400).
+			JSON(map[string]string{
+				"message": "Bad request",
+			})
+
+		err := metronome.PushUsageEvents(ctx, []*UsageEvent{
+			NewUsageEventBuilder().
+				WithNamespaceId("someId").
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				WithSearchUnits(256).
+				WithDatabaseUnits(920).
+				Build(),
+		})
+		require.ErrorContains(t, err, "Bad request")
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("empty events", func(t *testing.T) {
+		gock.New(cfg.URL).
+			Post("/ingest").
+			Reply(200).
+			JSON(nil)
+
+		// no properties
+		err := metronome.PushUsageEvents(ctx, []*UsageEvent{
+			NewUsageEventBuilder().
+				WithNamespaceId("someId").
+				WithTransactionId("t12354").
+				WithTimestamp(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)).
+				Build(),
+		})
+		require.NoError(t, err)
+		require.False(t, gock.IsDone())
+	})
 }

--- a/server/services/v1/billing/noop.go
+++ b/server/services/v1/billing/noop.go
@@ -17,19 +17,21 @@ package billing
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/tigrisdata/tigris/errors"
 )
 
 type noop struct{}
 
-func (n *noop) CreateAccount(_ context.Context, _ string, _ string) (string, error) {
-	return "", errors.Unimplemented("billing not enabled on this server")
+func (n *noop) CreateAccount(_ context.Context, _ string, _ string) (MetronomeId, error) {
+	return uuid.Nil, errors.Unimplemented("billing not enabled on this server")
 }
 
-func (n *noop) AddDefaultPlan(ctx context.Context, id string) (bool, error) {
-	return n.AddPlan(ctx, id, "")
+func (n *noop) AddDefaultPlan(ctx context.Context, accountId MetronomeId) (bool, error) {
+	return n.AddPlan(ctx, accountId, uuid.New())
 }
 
-func (*noop) AddPlan(ctx context.Context, metronomeId string, planId string) (bool, error) {
+func (*noop) AddPlan(_ context.Context, _ MetronomeId, _ uuid.UUID) (bool, error) {
 	return false, errors.Unimplemented("billing not enabled on this server")
 }

--- a/server/services/v1/billing/provider.go
+++ b/server/services/v1/billing/provider.go
@@ -17,18 +17,24 @@ package billing
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/tigrisdata/tigris/server/config"
+	ulog "github.com/tigrisdata/tigris/util/log"
 )
 
 type Provider interface {
-	CreateAccount(ctx context.Context, namespaceId string, name string) (string, error)
-	AddDefaultPlan(ctx context.Context, metronomeId string) (bool, error)
-	AddPlan(ctx context.Context, metronomeId string, planId string) (bool, error)
+	CreateAccount(ctx context.Context, namespaceId string, name string) (MetronomeId, error)
+	AddDefaultPlan(ctx context.Context, accountId MetronomeId) (bool, error)
+	AddPlan(ctx context.Context, accountId MetronomeId, planId uuid.UUID) (bool, error)
 }
 
 func NewProvider() Provider {
 	if config.DefaultConfig.Billing.Metronome.Enabled {
-		return &Metronome{Config: config.DefaultConfig.Billing.Metronome}
+		svc, err := NewMetronomeProvider(config.DefaultConfig.Billing.Metronome)
+		if !ulog.E(err) {
+			return svc
+		}
 	}
 	return &noop{}
 }

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
@@ -116,7 +115,7 @@ func (m *managementService) CreateNamespace(ctx context.Context, req *api.Create
 	// Create a Billing account, if it fails metrics reporter will retry in a separate flow
 	// does not block namespace creation
 	billingId, err := m.BillingProvider.CreateAccount(ctx, id, req.GetName())
-	if !ulog.E(err) && billingId != uuid.Nil {
+	if !ulog.E(err) && billingId != uuid2.NullUUID {
 		// account creation succeeds, update namespace metadata
 		meta.Accounts.AddMetronome(billingId.String())
 		// add tenant to default plan

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -22,19 +22,21 @@ import (
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/errors"
-	"github.com/tigrisdata/tigris/lib/uuid"
+	uuid2 "github.com/tigrisdata/tigris/lib/uuid"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/services/v1/auth"
 	"github.com/tigrisdata/tigris/server/services/v1/billing"
 	"github.com/tigrisdata/tigris/server/transaction"
 	ulog "github.com/tigrisdata/tigris/util/log"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -85,7 +87,7 @@ func (m *managementService) CreateNamespace(ctx context.Context, req *api.Create
 	}
 	id := req.GetId()
 	if req.GetId() == "" {
-		id = uuid.New().String()
+		id = uuid2.New().String()
 	}
 
 	tx, err := m.Manager.StartTx(ctx)
@@ -114,9 +116,9 @@ func (m *managementService) CreateNamespace(ctx context.Context, req *api.Create
 	// Create a Billing account, if it fails metrics reporter will retry in a separate flow
 	// does not block namespace creation
 	billingId, err := m.BillingProvider.CreateAccount(ctx, id, req.GetName())
-	if !ulog.E(err) && len(billingId) > 0 {
+	if !ulog.E(err) && billingId != uuid.Nil {
 		// account creation succeeds, update namespace metadata
-		meta.Accounts.AddMetronome(billingId)
+		meta.Accounts.AddMetronome(billingId.String())
 		// add tenant to default plan
 		added, err := m.BillingProvider.AddDefaultPlan(ctx, billingId)
 


### PR DESCRIPTION
## Describe your changes
- Metronome was being used with raw http requests, this change replaces it to use a openapi generated client.
- Interface to publish **usage** and **storage** events to Metronome, it is not hooked to any production workflow yet.

## How best to test these changes
- Unit tests

## Issue ticket number and link
TIG-1204