### PR TITLE
feat: Delete namespace implementation

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -55,6 +55,7 @@ const (
 	ManagementMethodPrefix    = "/tigrisdata.management.v1.Management/"
 	CreateNamespaceMethodName = ManagementMethodPrefix + "CreateNamespace"
 	ListNamespaceMethodName   = ManagementMethodPrefix + "ListNamespaces"
+	DeleteNamespaceMethodName = ManagementMethodPrefix + "DeleteNamespace"
 
 	AuthMethodPrefix         = "/tigrisdata.auth.v1.Auth/"
 	GetAccessTokenMethodName = AuthMethodPrefix + "GetAccessToken"

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -86,6 +86,7 @@ type AuthConfig struct {
 	TokenClockSkewDurationSec  int                   `mapstructure:"token_clock_skew_duration_sec" yaml:"token_clock_skew_duration_sec" json:"token_clock_skew_duration_sec"`
 	Gotrue                     Gotrue                `mapstructure:"gotrue" yaml:"gotrue" json:"gotrue"`
 	NamespaceLocalization      NamespaceLocalization `mapstructure:"namespace_localization" yaml:"namespace_localization" json:"namespace_localization"`
+	EnableNamespaceDeletion    bool                  `mapstructure:"enable_namespace_deletion" yaml:"enable_namespace_deletion" json:"enable_namespace_deletion"`
 }
 
 type ClusterConfig struct {
@@ -270,7 +271,8 @@ var DefaultConfig = Config{
 			ClientIdLength:     30,
 			ClientSecretLength: 50,
 		},
-		NamespaceLocalization: NamespaceLocalization{Enabled: false},
+		NamespaceLocalization:   NamespaceLocalization{Enabled: false},
+		EnableNamespaceDeletion: false,
 	},
 	Billing: Billing{
 		Metronome: Metronome{

--- a/server/metadata/dictionary.go
+++ b/server/metadata/dictionary.go
@@ -172,6 +172,21 @@ func (r *reservedSubspace) reload(ctx context.Context, tx transaction.Tx) error 
 	return it.Err()
 }
 
+func (r *reservedSubspace) unReserveNamespace(ctx context.Context, tx transaction.Tx, namespaceId string) error {
+	if len(namespaceId) == 0 {
+		return errors.InvalidArgument("namespaceId is empty")
+	}
+
+	key := keys.NewKey(r.ReservedSubspaceName(), namespaceKey, namespaceId, keyEnd)
+
+	err := tx.Delete(ctx, key)
+
+	log.Debug().Err(err).Str("key", key.String()).Str("value", namespaceId).
+		Msg("un-reserving namespace")
+
+	return err
+}
+
 func (r *reservedSubspace) reserveNamespace(ctx context.Context, tx transaction.Tx, namespaceId string,
 	namespaceMetadata NamespaceMetadata,
 ) error {
@@ -309,6 +324,11 @@ func (k *Dictionary) ReserveNamespace(ctx context.Context, tx transaction.Tx, na
 	namespaceMetadata NamespaceMetadata,
 ) error {
 	return k.reservedSb.reserveNamespace(ctx, tx, namespaceId, namespaceMetadata)
+}
+
+// UnReserveNamespace deletes the namespace.
+func (k *Dictionary) UnReserveNamespace(ctx context.Context, tx transaction.Tx, namespaceId string) error {
+	return k.reservedSb.unReserveNamespace(ctx, tx, namespaceId)
 }
 
 func (k *Dictionary) GetNamespaces(ctx context.Context, tx transaction.Tx,

--- a/server/request/request.go
+++ b/server/request/request.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	adminMethods = container.NewHashSet(api.CreateNamespaceMethodName, api.ListNamespaceMethodName)
+	adminMethods = container.NewHashSet(api.CreateNamespaceMethodName, api.ListNamespaceMethodName, api.DeleteNamespaceMethodName)
 	tenantGetter metadata.TenantGetter
 )
 

--- a/server/request/request_test.go
+++ b/server/request/request_test.go
@@ -71,6 +71,7 @@ func TestRequestMetadata(t *testing.T) {
 	t.Run("isAdmin test", func(t *testing.T) {
 		require.True(t, IsAdminApi("/tigrisdata.management.v1.Management/CreateNamespace"))
 		require.True(t, IsAdminApi("/tigrisdata.management.v1.Management/ListNamespaces"))
+		require.True(t, IsAdminApi("/tigrisdata.management.v1.Management/DeleteNamespace"))
 		require.False(t, IsAdminApi("/.HealthAPI/Health"))
 		require.False(t, IsAdminApi("some-random"))
 	})

--- a/server/services/v1/namespace_metadata_provider.go
+++ b/server/services/v1/namespace_metadata_provider.go
@@ -29,6 +29,7 @@ type NamespaceMetadataProvider interface {
 	GetNamespaceMetadata(ctx context.Context, req *api.GetNamespaceMetadataRequest) (*api.GetNamespaceMetadataResponse, error)
 	InsertNamespaceMetadata(ctx context.Context, req *api.InsertNamespaceMetadataRequest) (*api.InsertNamespaceMetadataResponse, error)
 	UpdateNamespaceMetadata(ctx context.Context, req *api.UpdateNamespaceMetadataRequest) (*api.UpdateNamespaceMetadataResponse, error)
+	DeleteNamespace(ctx context.Context, tx transaction.Tx, namespaceId uint32) error
 }
 
 type DefaultNamespaceMetadataProvider struct {
@@ -57,6 +58,10 @@ func (a *DefaultNamespaceMetadataProvider) GetNamespaceMetadata(ctx context.Cont
 		NamespaceId: namespaceId,
 		Value:       val,
 	}, nil
+}
+
+func (a *DefaultNamespaceMetadataProvider) DeleteNamespace(ctx context.Context, tx transaction.Tx, namespaceId uint32) error {
+	return a.namespaceStore.DeleteNamespace(ctx, tx, namespaceId)
 }
 
 func (a *DefaultNamespaceMetadataProvider) InsertNamespaceMetadata(ctx context.Context, req *api.InsertNamespaceMetadataRequest) (*api.InsertNamespaceMetadataResponse, error) {


### PR DESCRIPTION
## Describe your changes
Allow cluster admins to delete namespace. This is required for internal clean up and this needs to be followed up with a restart of server for now as the memory state needs to be updated across all the nodes.

## How best to test these changes

## Issue ticket number and link
