### PR TITLE
Fix panic in GetDatabaseBranches

### DIFF
--- a/.github/workflows/test-docker-local-image.yaml
+++ b/.github/workflows/test-docker-local-image.yaml
@@ -20,10 +20,10 @@ jobs:
           submodules: true
 
       - name: Build local image
-        run: DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.local -t tigrisdata/tigris-local-test .
+        run: make docker-local
 
       - name: Run local image
-        run: docker run -d -p 8081:8081 tigrisdata/tigris-local-test
+        run: docker run -d -p 8081:8081 tigris_local
 
       - name: Run CLI tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,7 @@ dump_integration_coverage:
 	sleep 15
 	/usr/local/go/bin/go tool covdata textfmt -i=/tmp/tigris_coverdata/ -o coverage1.out # from tigris_server
 	/usr/local/go/bin/go tool covdata textfmt -i=/tmp/tigris_coverdata2/ -o coverage2.out # from tigris_server2
+
+# Build local all-in-one package
+docker-local:
+	DOCKER_BUILDKIT=1 docker build -t tigris_local -f docker/Dockerfile.local .

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1499,13 +1499,15 @@ func (p *Project) Id() uint32 {
 
 // GetDatabaseWithBranches returns main database and all the corresponding database branches.
 func (p *Project) GetDatabaseWithBranches() []*Database {
-	databases := make([]*Database, len(p.databaseBranches)+1)
-	databases[0] = p.database
+	if p.database == nil {
+		return nil
+	}
 
-	i := 1
+	databases := make([]*Database, 0, len(p.databaseBranches)+1)
+	databases = append(databases, p.database)
+
 	for _, database := range p.databaseBranches {
-		databases[i] = database
-		i++
+		databases = append(databases, database)
 	}
 
 	return databases

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -268,6 +268,9 @@ func TestTenantManager_DatabaseBranches(t *testing.T) {
 	err = tenant.CreateProject(ctx, tx, tenantProj2, nil)
 	require.NoError(t, err)
 
+	databases := (&Project{}).GetDatabaseWithBranches()
+	require.Len(t, databases, 0)
+
 	require.NoError(t, tenant.reload(ctx, tx, nil, nil))
 
 	require.NoError(t, tenant.CreateBranch(ctx, tx, tenantProj1, NewDatabaseNameWithBranch(tenantProj1, "branch1")))
@@ -302,7 +305,7 @@ func TestTenantManager_DatabaseBranches(t *testing.T) {
 	require.True(t, branch3.IsBranch())
 	require.Equal(t, tenantProj1+BranchNameSeparator+"branch3", branch3.Name())
 
-	databases := proj1.GetDatabaseWithBranches()
+	databases = proj1.GetDatabaseWithBranches()
 	require.Len(t, databases, 4)
 	require.Equal(t, proj1.database, databases[0])
 


### PR DESCRIPTION
* Fix panic on race condition when GetDatabaseBranches is called before Project is fully initialized in tenant.reload. (it only fixes the panic, doesn't fix underlying race)
* Add ability to build local docker image. It's useful to test local changes where multiple local instances need to be started.
