### PR TITLE
fix: Bump up search client with highlight object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fullstorydev/grpchan v1.1.1
 	github.com/gertd/go-pluralize v0.2.1
+	github.com/getkin/kin-openapi v0.115.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/cors v1.2.1
 	github.com/go-redis/redis/v8 v8.11.5
@@ -41,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/tigrisdata/metronome-go-client v0.1.0
 	github.com/tigrisdata/tigris-client-go v1.0.0-beta.25
-	github.com/tigrisdata/typesense-go v0.6.2-beta.6
+	github.com/tigrisdata/typesense-go v0.6.2-beta.7
 	github.com/uber-go/tally v3.5.3+incompatible
 	github.com/ugorji/go/codec v1.2.11
 	github.com/valyala/bytebufferpool v1.0.0
@@ -83,7 +84,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 // indirect
-	github.com/getkin/kin-openapi v0.115.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/tigrisdata/metronome-go-client v0.1.0 h1:EEsNCUakxhKbM0xZ+GSnUcCFngBy
 github.com/tigrisdata/metronome-go-client v0.1.0/go.mod h1:R5eSI50uoj2e2Qi0dpa51vf3RV92YZKNtRIWyG/DOno=
 github.com/tigrisdata/tigris-client-go v1.0.0-beta.25 h1:ifJlt67uoyprSJYWaOvd1aTkOL/FxpEBXcxv7n8ASOs=
 github.com/tigrisdata/tigris-client-go v1.0.0-beta.25/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
-github.com/tigrisdata/typesense-go v0.6.2-beta.6 h1:9XuSvGN0BZDPXV9dEquH6PuwmwYlhAX6w+h+9T1ngRo=
-github.com/tigrisdata/typesense-go v0.6.2-beta.6/go.mod h1:z/JGTvrZjYHqDxKB2fGHTbt47bXyVM4lo5Nzk5vNBD4=
+github.com/tigrisdata/typesense-go v0.6.2-beta.7 h1:uJex8/oHL+m5Rcw8SBt8s6lsEXNIu9Gp0RJLtK0RHtw=
+github.com/tigrisdata/typesense-go v0.6.2-beta.7/go.mod h1:z/JGTvrZjYHqDxKB2fGHTbt47bXyVM4lo5Nzk5vNBD4=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=

--- a/server/search/hits.go
+++ b/server/search/hits.go
@@ -84,7 +84,14 @@ func NewSearchHit(tsHit *tsApi.SearchResultHit) *Hit {
 	}
 
 	var fields []*api.MatchField
-	if tsHit.Highlights != nil {
+	if tsHit.Highlight != nil {
+		// check first in highlight
+		for name := range *tsHit.Highlight {
+			fields = append(fields, &api.MatchField{
+				Name: name,
+			})
+		}
+	} else if tsHit.Highlights != nil  {
 		for _, f := range *tsHit.Highlights {
 			name := ""
 			if f.Field != nil {


### PR DESCRIPTION
## Describe your changes
In case the match is for the nested object, then it is part of "Highlight" so we need to bump up the client to have that. The matched response looks like this,
```
{
  "result": {
    "hits": [
      {
        "data": {
          "object": {
            "field": "foo"
          },
          "id": "3de5d938-83eb-40e6-9732-ddb05ebe9752",
          "top_level_string": "foo"
        },
        "metadata": {
          "created_at": "2023-04-07T00:42:27.144444Z",
          "match": {
            "fields": [
              {
                "name": "object.field"
              },
              {
                "name": "top_level_string"
              }
            ],
            "score": "578730123365711994"
          }
        }
      }
    ],
    "facets": {},
    "meta": {
      "found": 127,
      "total_pages": 127,
      "page": {
        "current": 1,
        "size": 1
      },
      "matched_fields": [
        "top_level_string",
        "object.field"
      ]
    },
    "group": null
  }
}
```

## How best to test these changes

## Issue ticket number and link
