### PR TITLE
fix: For array of date-time, convert it to string array for search instead of integer array

### DIFF
--- a/schema/fields.go
+++ b/schema/fields.go
@@ -241,10 +241,9 @@ func toSearchFieldType(fieldType FieldType, subType FieldType) string {
 			return FieldNames[subType] + "[]"
 		case Int32Type, Int64Type:
 			return FieldNames[subType] + "[]"
-		case StringType, ByteType, UUIDType:
+		case StringType, ByteType, UUIDType, DateTimeType:
+			// for array, we don't need to convert to int64
 			return FieldNames[StringType] + "[]"
-		case DateTimeType:
-			return FieldNames[Int64Type] + "[]"
 		case DoubleType:
 			return searchDoubleType + "[]"
 		case ObjectType:

--- a/schema/queryable_test.go
+++ b/schema/queryable_test.go
@@ -22,8 +22,14 @@ import (
 
 func TestBuildQueryableFields(t *testing.T) {
 	fields := []*Field{
-		{FieldName: "A", DataType: Int64Type},
-		{FieldName: "B", DataType: StringType},
+		{FieldName: "A1", DataType: Int32Type},
+		{FieldName: "A2", DataType: Int64Type},
+		{FieldName: "A3", DataType: DoubleType},
+		{FieldName: "A4", DataType: BoolType},
+		{FieldName: "B1", DataType: StringType},
+		{FieldName: "B2", DataType: UUIDType},
+		{FieldName: "B3", DataType: DateTimeType},
+		{FieldName: "B4", DataType: ByteType},
 		{FieldName: "C", DataType: ObjectType, Fields: []*Field{
 			{FieldName: "E", DataType: Int64Type},
 			{FieldName: "F", DataType: StringType},
@@ -35,11 +41,23 @@ func TestBuildQueryableFields(t *testing.T) {
 			},
 		}},
 		{FieldName: "D", DataType: ObjectType},
+		{FieldName: "E", DataType: ArrayType},
+		{FieldName: "F", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: Int32Type}}},
+		{FieldName: "F1", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: Int64Type}}},
+		{FieldName: "F2", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: DoubleType}}},
+		{FieldName: "F3", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: BoolType}}},
+		{FieldName: "F4", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: StringType}}},
+		{FieldName: "F5", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: UUIDType}}},
+		{FieldName: "F6", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: DateTimeType}}},
+		{FieldName: "F7", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: ArrayType}}},
+		{FieldName: "F8", DataType: ArrayType, Fields: []*Field{{FieldName: "A", DataType: ObjectType}}},
 	}
 
 	queryable := NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil)
-	expFields := []string{"A", "B", "C.E", "C.F", "C.G.H", "C.G.I", "D", "_tigris_created_at", "_tigris_updated_at"}
+	expTypes := []string{"int32", "int64", "float", "bool", "string", "string", "int64", "string", "int64", "string", "string", "object", "object", "string", "int32[]", "int64[]", "float[]", "bool[]", "string[]", "string[]", "string[]", "string", "object[]", "int64", "int64"}
+	expFields := []string{"A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4", "C.E", "C.F", "C.G.H", "C.G.I", "D", "E", "F", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "_tigris_created_at", "_tigris_updated_at"}
 	for i, q := range queryable {
 		require.Equal(t, expFields[i], q.FieldName)
+		require.Equal(t, expTypes[i], q.SearchType)
 	}
 }


### PR DESCRIPTION
## Describe your changes
We convert date-time to int64 to support time-series filtering, but it won't be useful for the date-time array. This diff will simply convert date-time arrays to string arrays for storing in search.

## How best to test these changes

## Issue ticket number and link
