### PR TITLE
feat: Add support for automatically converting string to int64 based on schema

### DIFF
--- a/schema/collection_test.go
+++ b/schema/collection_test.go
@@ -406,13 +406,15 @@ func TestCollection_Int64(t *testing.T) {
 	require.NoError(t, err)
 	coll, err := NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(coll.int64FieldsPath))
-	_, ok := coll.int64FieldsPath["id"]
+
+	int64Paths := coll.int64FieldsPath.get()
+	require.Equal(t, 4, len(int64Paths))
+	_, ok := int64Paths["id"]
 	require.True(t, ok)
-	_, ok = coll.int64FieldsPath["nested_object.obj.intField"]
+	_, ok = int64Paths["nested_object.obj.intField"]
 	require.True(t, ok)
-	_, ok = coll.int64FieldsPath["array_items.id"]
+	_, ok = int64Paths["array_items.id"]
 	require.True(t, ok)
-	_, ok = coll.int64FieldsPath["array_simple_items"]
+	_, ok = int64Paths["array_simple_items"]
 	require.True(t, ok)
 }

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -288,7 +288,7 @@ func ValidateFieldAttributes(isSearch bool, field *Field) error {
 			return errors.InvalidArgument("setting primary key is not supported on search index '%s'", field.Name())
 		}
 
-		if field.FieldName == SearchId || field.IsSearchId() {
+		if field.IsSearchId() {
 			if field.DataType != StringType && field.DataType != UUIDType {
 				return errors.InvalidArgument("Cannot have field '%s' as 'id'. Only string type is supported as 'id' field", field.FieldName)
 			}

--- a/server/search/hits.go
+++ b/server/search/hits.go
@@ -91,7 +91,7 @@ func NewSearchHit(tsHit *tsApi.SearchResultHit) *Hit {
 				Name: name,
 			})
 		}
-	} else if tsHit.Highlights != nil  {
+	} else if tsHit.Highlights != nil {
 		for _, f := range *tsHit.Highlights {
 			name := ""
 			if f.Field != nil {

--- a/server/services/v1/common/converter.go
+++ b/server/services/v1/common/converter.go
@@ -1,0 +1,106 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/schema"
+)
+
+type fieldAccessor func(name string) *schema.Field
+
+type StringToInt64Converter struct {
+	converted     bool
+	fieldAccessor fieldAccessor
+}
+
+func NewStringToInt64Converter(fieldAccessor fieldAccessor) *StringToInt64Converter {
+	return &StringToInt64Converter{
+		fieldAccessor: fieldAccessor,
+	}
+}
+
+func (converter *StringToInt64Converter) Convert(doc map[string]any, paths map[string]struct{}) (bool, error) {
+	for key := range paths {
+		keys := strings.Split(key, ".")
+		value, ok := doc[keys[0]]
+		if !ok {
+			continue
+		}
+
+		field := converter.fieldAccessor(keys[0])
+		if field == nil {
+			continue
+		}
+
+		if err := converter.traverse(doc, value, keys[1:], field); err != nil {
+			return false, err
+		}
+	}
+
+	return converter.converted, nil
+}
+
+func (converter *StringToInt64Converter) traverse(parentMap map[string]any, value any, keys []string, parentField *schema.Field) error {
+	var err error
+	if parentField.Type() == schema.Int64Type {
+		if conv, ok := value.(string); ok {
+			if parentMap[parentField.FieldName], err = strconv.ParseInt(conv, 10, 64); err != nil {
+				return errors.InvalidArgument("json schema validation failed for field '%s' reason "+
+					"'expected integer, but got string'", parentField.FieldName)
+			}
+
+			converter.converted = true
+			return nil
+		}
+		return nil
+	}
+
+	switch converted := value.(type) {
+	case map[string]any:
+		value, ok := converted[keys[0]]
+		if !ok {
+			return nil
+		}
+
+		return converter.traverse(converted, value, keys[1:], parentField.GetNestedField(keys[0]))
+	case []any:
+		// array should have a single nested field either as object or primitive type
+		field := parentField.Fields[0]
+		if field.DataType == schema.ObjectType {
+			// is object or simple type
+			for _, va := range converted {
+				if err := converter.traverse(va.(map[string]any), va, keys, field); err != nil {
+					return err
+				}
+			}
+		} else if field.DataType == schema.Int64Type {
+			for idx := range converted {
+				if conv, ok := converted[idx].(string); ok {
+					if converted[idx], err = strconv.ParseInt(conv, 10, 64); err != nil {
+						return errors.InvalidArgument("json schema validation failed for field '%s' "+
+							"reason 'expected integer, but got string'", field.FieldName)
+					}
+					converter.converted = true
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/services/v1/common/converter_test.go
+++ b/server/services/v1/common/converter_test.go
@@ -12,199 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package common
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
-	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/util"
 )
 
-func TestMutateSetDefaults(t *testing.T) {
-	reqSchema := []byte(`{
-		"title": "t1",
-		"properties": {
-			"id": {
-				"type": "integer"
-			},
-			"double_f": {
-				"type": "number",
-				"default": 1.5
-			},
-			"created": {
-				"type": "string",
-				"format": "date-time",
-				"createdAt": true
-			},
-			"updated": {
-				"type": "string",
-				"format": "date-time",
-				"updatedAt": true
-			},
-			"arr": {
-				"type": "array",
-				"items": {
-					"type": "integer"
-				},
-				"default": [10,20,30]
-			}
-		},
-		"primary_key": ["id"]
-	}`)
-
-	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
-	require.NoError(t, err)
-	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
-	require.NoError(t, err)
-	p := newInsertPayloadMutator(coll, time.Now().UTC().String())
-
-	cases := []struct {
-		input   []byte
-		mutated bool
-		output  []byte
-	}{
-		{
-			// created will be populated
-			[]byte(`{"double_f":2,"arr":[1,2]}`),
-			true,
-			[]byte(fmt.Sprintf(`{"double_f":2,"arr":[1,2],"created":"%s"}`, p.(*insertPayloadMutator).createdAt)),
-		},
-		{
-			// double_f will be populated
-			[]byte(`{"arr":[1,2]}`),
-			true,
-			[]byte(fmt.Sprintf(`{"double_f":1.5,"arr":[1,2],"created":"%s"}`, p.(*insertPayloadMutator).createdAt)),
-		},
-		{
-			// arr will be populated
-			[]byte(`{"double_f":1.8}`),
-			true,
-			[]byte(fmt.Sprintf(`{"double_f":1.8,"arr":[10,20,30],"created":"%s"}`, p.(*insertPayloadMutator).createdAt)),
-		},
-	}
-	for _, c := range cases {
-		doc, err := util.JSONToMap(c.input)
-		require.NoError(t, err)
-
-		require.NoError(t, p.setDefaultsInIncomingPayload(doc))
-		require.Equal(t, c.mutated, p.isMutated())
-		actualJS, err := util.MapToJSON(doc)
-		require.NoError(t, err)
-		require.JSONEq(t, string(c.output), string(actualJS))
-	}
-}
-
-func TestMutateSetDefaultsComplexSchema(t *testing.T) {
-	reqSchema := []byte(`{
-		"title": "t1",
-		"properties": {
-			"id": {
-				"type": "integer"
-			},
-			"int32": {
-				"type": "integer",
-				"default": 1
-			},
-			"str": {
-				"type": "string",
-				"default": "a"
-			},
-			"obj_a": {
-				"type": "object"
-			},
-			"obj_n": {
-				"type": "object",
-				"properties": {
-					"uid": { "type": "string", "default": "abc" },
-					"obj": {
-						"type": "object",
-						"properties": {
-							"int64_any": { "type": "integer", "default": 2 },
-							"str_f": { "type": "string"}
-						}
-					}
-				}
-			},
-			"arr_o": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"id": {
-							"type": "integer",
-							 "default": 3
-						},
-						"str_f": {
-							"type": "string"
-						}
-					}
-				}
-			},
-			"arr_s": {
-				"type": "array",
-				"items": {
-					"type": "integer"
-				}
-			}
-		},
-		"primary_key": ["id"]
-	}`)
-
-	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
-	require.NoError(t, err)
-	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
-	require.NoError(t, err)
-
-	cases := []struct {
-		input   []byte
-		mutated bool
-		output  []byte
-	}{
-		{
-			// no defaults, doc has all the value pre-populated
-			[]byte(`{"obj_n":{"obj":{"str_f":"test","int64_any":20},"uid":"a"},"arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}],"int32":10,"str":"aaa"}`),
-			false,
-			[]byte(`{"obj_n":{"obj":{"str_f":"test","int64_any":20},"uid":"a"},"arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}],"int32":10,"str":"aaa"}`),
-		},
-		{
-			// obj_n is missing
-			[]byte(`{"arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}]}`),
-			true,
-			[]byte(`{"obj_n":{"obj":{"int64_any":2},"uid":"abc"},"int32":1,"str":"a","arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}]}`),
-		},
-		{
-			// arr_o is missing
-			[]byte(`{"obj_n":{"obj":{"int64_any":20},"uid":"a"}}`),
-			true,
-			[]byte(`{"obj_n":{"obj":{"int64_any":20},"uid":"a"},"int32":1,"str":"a"}`),
-		},
-		{
-			[]byte(`{"id":1,"obj_a":{"s":"a"},"obj_n":{"obj":{"str_f":"test"}},"arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}],"arr_s":[1,2,3]}`),
-			true,
-			[]byte(`{"id":1,"obj_a":{"s":"a"},"obj_n":{"obj":{"str_f":"test","int64_any":2},"uid":"abc"},"arr_o":[{"str_f":"t0","id":1},{"str_f":"t1","id":2},{"str_f":"t2","id":3}],"arr_s":[1,2,3],"int32":1,"str":"a"}`),
-		},
-	}
-	for _, c := range cases {
-		doc, err := util.JSONToMap(c.input)
-		require.NoError(t, err)
-
-		p := newInsertPayloadMutator(coll, time.Now().UTC().String())
-		require.NoError(t, p.setDefaultsInIncomingPayload(doc))
-		require.Equal(t, c.mutated, p.isMutated())
-		actualJS, err := util.MapToJSON(doc)
-		require.NoError(t, err)
-		require.JSONEq(t, string(c.output), string(actualJS))
-	}
-}
-
-func TestMutatePayload(t *testing.T) {
-	reqSchema := []byte(`{
+func TestStringToInt64Converter_Convert(t *testing.T) {
+	reqCollectionSchema := []byte(`{
 		"title": "t1",
 		"properties": {
 			"id": {
@@ -249,11 +68,67 @@ func TestMutatePayload(t *testing.T) {
 		"primary_key": ["id"]
 	}`)
 
-	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
+	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqCollectionSchema)
 	require.NoError(t, err)
 	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
 	require.NoError(t, err)
 
+	testStringToInt64Converter(t, coll.GetField, coll.GetInt64FieldsPath())
+
+	reqIndexSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer"
+			},
+			"simple_object": {
+				"type": "object"
+			},
+			"nested_object": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"obj": {
+						"type": "object",
+						"properties": {
+							"intField": { "type": "integer" }
+						}
+					}
+				}
+			},
+			"array_items": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"item_name": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"array_simple_items": {
+				"type": "array",
+				"items": {
+					"type": "integer"
+				}
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	searchFactory, err := schema.NewFactoryBuilder(true).BuildSearch("t1", reqIndexSchema)
+	require.NoError(t, err)
+	index := schema.NewSearchIndex(1, "t1", searchFactory, nil)
+	require.NoError(t, err)
+
+	testStringToInt64Converter(t, index.GetField, index.GetInt64FieldsPath())
+}
+
+func testStringToInt64Converter(t *testing.T, accessor fieldAccessor, paths map[string]struct{}) {
 	cases := []struct {
 		input   []byte
 		mutated bool
@@ -272,12 +147,14 @@ func TestMutatePayload(t *testing.T) {
 			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
 		},
 		// all elements of array
+
 		{
 			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": "9223372036854775801"}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
 			true,
 			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":[9223372036854775800, 9223372036854775801, 9223372036854775802]}`),
 		},
 		// all elements of primitive array
+
 		{
 			[]byte(`{"name":"test","id":9223372036854775800,"brand":"random","nested_object":{"obj": {"intField": 9223372036854775800}},"array_items":[{"name": "test0", "id": 9223372036854775800}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": 9223372036854775802}],"array_simple_items":["9223372036854775800", "9223372036854775801", "9223372036854775802"]}`),
 			true,
@@ -306,76 +183,13 @@ func TestMutatePayload(t *testing.T) {
 		doc, err := util.JSONToMap(c.input)
 		require.NoError(t, err)
 
-		p := newInsertPayloadMutator(coll, time.Now().UTC().String())
-		require.NoError(t, p.stringToInt64(doc))
-		require.Equal(t, c.mutated, p.isMutated())
+		p := NewStringToInt64Converter(accessor)
+		converted, err := p.Convert(doc, paths)
+		require.NoError(t, err)
+		require.Equal(t, c.mutated, converted)
 
 		actualJS, err := util.MapToJSON(doc)
 		require.NoError(t, err)
 		require.JSONEq(t, string(c.output), string(actualJS))
-	}
-}
-
-func BenchmarkStringToInteger(b *testing.B) {
-	reqSchema := []byte(`{
-		"title": "t1",
-		"properties": {
-			"id": {
-				"type": "integer"
-			},
-			"simple_object": {
-				"type": "object"
-			},
-			"nested_object": {
-				"type": "object",
-				"properties": {
-					"name": { "type": "string" },
-					"obj": {
-						"type": "object",
-						"properties": {
-							"intField": { "type": "integer" }
-						}
-					}
-				}
-			},
-			"array_items": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"id": {
-							"type": "integer"
-						},
-						"item_name": {
-							"type": "string"
-						}
-					}
-				}
-			},
-			"array_simple_items": {
-				"type": "array",
-				"items": {
-					"type": "integer"
-				}
-			}
-		},
-		"primary_key": ["id"]
-	}`)
-
-	schFactory, err := schema.NewFactoryBuilder(true).Build("t1", reqSchema)
-	require.NoError(b, err)
-	coll, err := schema.NewDefaultCollection(1, 1, schFactory, nil, nil)
-	require.NoError(b, err)
-	require.Equal(b, 4, len(coll.GetQueryableFields()))
-
-	data := []byte(`{"name":"fiona handbag","id":9223372036854775800,"brand":"michael kors","nested_object":{"obj": {"intField": "9223372036854775800"}},"array_items":[{"name": "test0", "id": "9223372036854775800"}, {"name": "test1", "id": 9223372036854775801}, {"name": "test2", "id": "9223372036854775802"}],"array_simple_items":[9223372036854775800, "9223372036854775801", 9223372036854775802]}`)
-	var deserializedDoc map[string]interface{}
-	dec := jsoniter.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	require.NoError(b, err)
-
-	for i := 0; i < b.N; i++ {
-		p := newInsertPayloadMutator(coll, time.Now().UTC().String())
-		require.NoError(b, p.stringToInt64(deserializedDoc))
 	}
 }


### PR DESCRIPTION
For the search index user can have an `int64` field in the schema but can pass string values for these fields in the document during indexing. This will be converted to `int64` on the server side and stored as `int64`, meaning the value for this field will be returned as `int64` back to the user. 

## Describe your changes

## How best to test these changes

## Issue ticket number and link
