### PR TITLE
feat: bulk secondary index builder

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -31,6 +31,8 @@ const (
 	DeleteMethodName  = apiMethodPrefix + "Delete"
 	ReadMethodName    = apiMethodPrefix + "Read"
 
+	IndexCollection = apiMethodPrefix + "IndexCollection"
+
 	SearchMethodName = apiMethodPrefix + "Search"
 
 	SubscribeMethodName = apiMethodPrefix + "Subscribe"

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -241,6 +241,16 @@ func (d *DefaultCollection) GetActiveIndexedFields() []*QueryableField {
 	return indexed
 }
 
+func (d *DefaultCollection) GetWriteModeIndexes() []*QueryableField {
+	var indexed []*QueryableField
+	for _, q := range d.QueryableFields {
+		if q.Indexed && !d.SecondaryIndexes.IsWriteModeIndex(q.FieldName) {
+			indexed = append(indexed, q)
+		}
+	}
+	return indexed
+}
+
 func (d *DefaultCollection) GetIndexedFields() []*QueryableField {
 	var indexed []*QueryableField
 	for _, q := range d.QueryableFields {

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -291,9 +291,17 @@ type Indexes struct {
 }
 
 func (i *Indexes) IsActiveIndex(name string) bool {
+	return i.indexesHasStateState(name, INDEX_ACTIVE)
+}
+
+func (i *Indexes) IsWriteModeIndex(name string) bool {
+	return i.indexesHasStateState(name, INDEX_WRITE_MODE)
+}
+
+func (i *Indexes) indexesHasStateState(name string, state IndexState) bool {
 	for _, idx := range i.All {
 		if idx.Name == name {
-			return idx.State == INDEX_ACTIVE
+			return idx.State == state
 		}
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -50,8 +50,14 @@ func main() {
 }
 
 func mainWithCode() int {
+	l := ulog.LogConfig{
+		Level:      "info",
+		SampleRate: 0.01,
+		Format:     "console",
+	}
 	config.LoadConfig(&config.DefaultConfig)
-	ulog.Configure(config.DefaultConfig.Log)
+	// ulog.Configure(config.DefaultConfig.Log)
+	ulog.Configure(l)
 
 	log.Info().Msgf("Environment: '%v'", config.GetEnvironment())
 	log.Info().Msgf("Number of CPUs: %v", runtime.NumCPU())

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1359,6 +1359,23 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 	return nil
 }
 
+// Update the indexes for a collection.
+func (tenant *Tenant) UpdateCollectionIndexes(ctx context.Context, tx transaction.Tx, db *Database, collectionName string, indexes []*schema.Index) error {
+	tenant.Lock()
+	defer tenant.Unlock()
+
+	cHolder, ok := db.collections[collectionName]
+	if !ok {
+		return errors.NotFound("collection doesn't exists '%s'", collectionName)
+	}
+	_, err := tenant.metaStore.Collection().Update(ctx, tx, tenant.namespace.Id(), db.id, collectionName, cHolder.id, indexes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DropCollection is to drop a collection and its associated indexes. It removes the "created" entry from the encoding
 // subspace and adds a "dropped" entry for the same collection key.
 func (tenant *Tenant) DropCollection(ctx context.Context, tx transaction.Tx, db *Database, collectionName string) error {

--- a/server/middleware/timeout.go
+++ b/server/middleware/timeout.go
@@ -25,8 +25,9 @@ import (
 )
 
 var (
-	DefaultTimeout = 10 * time.Second
-	MaximumTimeout = 30 * time.Second
+	DefaultTimeout     = 10 * time.Second
+	MaximumTimeout     = 30 * time.Second
+	LongRunningTimeout = 1 * time.Hour
 )
 
 // timeoutUnaryServerInterceptor returns a new unary server interceptor
@@ -38,9 +39,13 @@ func timeoutUnaryServerInterceptor(timeout time.Duration) grpc.UnaryServerInterc
 		ctx, cancel = setDeadlineUsingHeader(ctx)
 
 		d, ok := ctx.Deadline()
-		if ok && time.Until(d) > MaximumTimeout {
+		if ok && info.FullMethod != api.IndexCollection && time.Until(d) > MaximumTimeout {
 			timeout = MaximumTimeout
 			ok = false
+		}
+
+		if !ok && info.FullMethod == api.IndexCollection {
+			timeout = LongRunningTimeout
 		}
 
 		if !ok {

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -245,6 +245,21 @@ func (s *apiService) Import(ctx context.Context, r *api.ImportRequest) (*api.Imp
 	}, nil
 }
 
+func (s *apiService) IndexCollection(ctx context.Context, r *api.IndexCollectionRequest) (*api.IndexCollectionResponse, error) {
+	qm := metrics.WriteQueryMetrics{}
+	accessToken, _ := request.GetAccessToken(ctx)
+
+	resp, err := s.sessions.ReadOnlyExecute(ctx, s.runnerFactory.GetIndexRunner(r, &qm, accessToken), database.ReqOptions{
+		MetadataChange:     true,
+		InstantVerTracking: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Response.(*api.IndexCollectionResponse), nil
+}
+
 func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.ReplaceResponse, error) {
 	qm := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -245,7 +245,7 @@ func (s *apiService) Import(ctx context.Context, r *api.ImportRequest) (*api.Imp
 	}, nil
 }
 
-func (s *apiService) IndexCollection(ctx context.Context, r *api.IndexCollectionRequest) (*api.IndexCollectionResponse, error) {
+func (s *apiService) BuildCollectionIndex(ctx context.Context, r *api.BuildCollectionIndexRequest) (*api.BuildCollectionIndexResponse, error) {
 	qm := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)
 
@@ -257,7 +257,7 @@ func (s *apiService) IndexCollection(ctx context.Context, r *api.IndexCollection
 		return nil, err
 	}
 
-	return resp.Response.(*api.IndexCollectionResponse), nil
+	return resp.Response.(*api.BuildCollectionIndexResponse), nil
 }
 
 func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.ReplaceResponse, error) {

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	jsoniter "github.com/json-iterator/go"
+	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
@@ -319,4 +320,23 @@ func (runner *BaseQueryRunner) getSecondaryWriterIterator(ctx context.Context, t
 		return nil, err
 	}
 	return NewSecondaryIndexReader(ctx, tx, coll, filter.NewWrappedFilter(filters), queryPlan)
+}
+
+func (runner *BaseQueryRunner) indexToCollectionIndex(all []*schema.Index) []*api.CollectionIndex {
+	indexes := make([]*api.CollectionIndex, len(all))
+	for i, index := range all {
+		fields := make([]*api.Field, len(index.Fields))
+		for j, field := range index.Fields {
+			fields[j] = &api.Field{
+				Name: field.FieldName,
+			}
+		}
+		indexes[i] = &api.CollectionIndex{
+			Name:   index.Name,
+			State:  index.StateString(),
+			Fields: fields,
+		}
+	}
+
+	return indexes
 }

--- a/server/services/v1/database/collection_runner.go
+++ b/server/services/v1/database/collection_runner.go
@@ -195,28 +195,13 @@ func (runner *CollectionQueryRunner) describe(ctx context.Context, tx transactio
 		}
 	}
 
-	indexes := make([]*api.CollectionIndex, len(coll.SecondaryIndexes.All))
-	for i, index := range coll.SecondaryIndexes.All {
-		fields := make([]*api.Field, len(index.Fields))
-		for j, field := range index.Fields {
-			fields[j] = &api.Field{
-				Name: field.FieldName,
-			}
-		}
-		indexes[i] = &api.CollectionIndex{
-			Name:   index.Name,
-			State:  index.StateString(),
-			Fields: fields,
-		}
-	}
-
 	return Response{
 		Response: &api.DescribeCollectionResponse{
 			Collection: coll.Name,
 			Metadata:   &api.CollectionMetadata{},
 			Schema:     sch,
 			Size:       size,
-			Indexes:    indexes,
+			Indexes:    runner.indexToCollectionIndex(coll.SecondaryIndexes.All),
 		},
 	}, ctx, nil
 }

--- a/server/services/v1/database/indexer_runner.go
+++ b/server/services/v1/database/indexer_runner.go
@@ -28,7 +28,7 @@ import (
 type IndexerRunner struct {
 	*BaseQueryRunner
 
-	req          *api.IndexCollectionRequest
+	req          *api.BuildCollectionIndexRequest
 	queryMetrics *metrics.WriteQueryMetrics
 }
 
@@ -72,11 +72,11 @@ func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tena
 		return Response{}, ctx, err
 	}
 
-	runner.queryMetrics.SetWriteType("replace")
+	runner.queryMetrics.SetWriteType("build_index")
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
 	return Response{
-		Response: &api.IndexCollectionResponse{
+		Response: &api.BuildCollectionIndexResponse{
 			Indexes: runner.indexToCollectionIndex(coll.SecondaryIndexes.All),
 		},
 	}, ctx, nil

--- a/server/services/v1/database/indexer_runner.go
+++ b/server/services/v1/database/indexer_runner.go
@@ -1,0 +1,83 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/metrics"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+type IndexerRunner struct {
+	*BaseQueryRunner
+
+	req          *api.IndexCollectionRequest
+	queryMetrics *metrics.WriteQueryMetrics
+}
+
+func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tenant) (Response, context.Context, error) {
+	tx, err := runner.txMgr.StartTx(ctx)
+	if err != nil {
+		return Response{}, ctx, err
+	}
+
+	db, coll, err := runner.getDBAndCollection(ctx, tx, tenant,
+		runner.req.GetProject(), runner.req.GetCollection(), runner.req.GetBranch())
+	if err != nil {
+		return Response{}, ctx, err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return Response{}, ctx, err
+	}
+
+	indexer := NewSecondaryIndexer(coll)
+
+	if err = indexer.BuildCollection(ctx, runner.txMgr); err != nil {
+		log.Err(err).Msgf("Failed to index collection \"%s\" for db \"%s\"", coll.Name, db.DbName())
+		return Response{}, ctx, err
+	}
+
+	for _, index := range coll.SecondaryIndexes.All {
+		index.State = schema.INDEX_ACTIVE
+	}
+
+	tx, err = runner.txMgr.StartTx(ctx)
+	if err != nil {
+		return Response{}, ctx, err
+	}
+
+	if err = tenant.UpdateCollectionIndexes(ctx, tx, db, coll.Name, coll.SecondaryIndexes.All); ulog.E(err) {
+		return Response{}, ctx, err
+	}
+
+	if err = tx.Commit(ctx); ulog.E(err) {
+		return Response{}, ctx, err
+	}
+
+	runner.queryMetrics.SetWriteType("replace")
+	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
+
+	return Response{
+		Response: &api.IndexCollectionResponse{
+			Indexes: runner.indexToCollectionIndex(coll.SecondaryIndexes.All),
+		},
+	}, ctx, nil
+}

--- a/server/services/v1/database/query_runner_factory.go
+++ b/server/services/v1/database/query_runner_factory.go
@@ -127,7 +127,7 @@ func (f *QueryRunnerFactory) GetBranchQueryRunner(accessToken *types.AccessToken
 	}
 }
 
-func (f *QueryRunnerFactory) GetIndexRunner(req *api.IndexCollectionRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *IndexerRunner {
+func (f *QueryRunnerFactory) GetIndexRunner(req *api.BuildCollectionIndexRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *IndexerRunner {
 	return &IndexerRunner{
 		req:             req,
 		queryMetrics:    queryMetrics,

--- a/server/services/v1/database/query_runner_factory.go
+++ b/server/services/v1/database/query_runner_factory.go
@@ -126,3 +126,11 @@ func (f *QueryRunnerFactory) GetBranchQueryRunner(accessToken *types.AccessToken
 		BaseQueryRunner: NewBaseQueryRunner(f.encoder, f.cdcMgr, f.txMgr, f.searchStore, accessToken),
 	}
 }
+
+func (f *QueryRunnerFactory) GetIndexRunner(req *api.IndexCollectionRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *IndexerRunner {
+	return &IndexerRunner{
+		req:             req,
+		queryMetrics:    queryMetrics,
+		BaseQueryRunner: NewBaseQueryRunner(f.encoder, f.cdcMgr, f.txMgr, f.searchStore, accessToken),
+	}
+}

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -4890,6 +4890,10 @@ func insertDocuments(t *testing.T, db string, collection string, documents []Doc
 	}
 }
 
+func buildCollectionIndexes(t *testing.T, db string, collection string) *httpexpect.Response {
+	return expect(t).POST(getDocumentURL(db, collection, "index")).Expect().Status(http.StatusOK)
+}
+
 func updateByFilter(t *testing.T, db string, collection string, filter Map, fields Map, collation Map) *httpexpect.Response {
 	payload := make(Map)
 	for key, value := range filter {

--- a/test/v1/server/secondary_index_test.go
+++ b/test/v1/server/secondary_index_test.go
@@ -689,7 +689,7 @@ func TestQuery_BuildIndex(t *testing.T) {
 
 	createCollection(t, db, coll, testBuildIndexSchema).Status(http.StatusOK)
 	str := buildCollectionIndexes(t, db, coll).Body().Raw()
-	resp := &api.IndexCollectionResponse{}
+	resp := &api.BuildCollectionIndexResponse{}
 	err := jsoniter.Unmarshal([]byte(str), resp)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Describe your changes
Adds an endpoint that will read all documents in a collection and add them to the secondary index. The bulk indexer will read in batches. If an error occurs it will try to decrease the number of documents read in a batch and try again.

## How best to test these changes
All tests should pass. C

## Issue ticket number and link
closes #1005 
