### PR TITLE
feat: Allow disabling namespace creation at cluster level

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -87,6 +87,7 @@ type AuthConfig struct {
 	Gotrue                     Gotrue                `mapstructure:"gotrue" yaml:"gotrue" json:"gotrue"`
 	NamespaceLocalization      NamespaceLocalization `mapstructure:"namespace_localization" yaml:"namespace_localization" json:"namespace_localization"`
 	EnableNamespaceDeletion    bool                  `mapstructure:"enable_namespace_deletion" yaml:"enable_namespace_deletion" json:"enable_namespace_deletion"`
+	EnableNamespaceCreation    bool                  `mapstructure:"enable_namespace_creation" yaml:"enable_namespace_creation" json:"enable_namespace_creation"`
 }
 
 type ClusterConfig struct {
@@ -273,6 +274,7 @@ var DefaultConfig = Config{
 		},
 		NamespaceLocalization:   NamespaceLocalization{Enabled: false},
 		EnableNamespaceDeletion: false,
+		EnableNamespaceCreation: true,
 	},
 	Billing: Billing{
 		Metronome: Metronome{

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -81,6 +81,10 @@ func newManagementService(authProvider auth.Provider, txMgr *transaction.Manager
 }
 
 func (m *managementService) CreateNamespace(ctx context.Context, req *api.CreateNamespaceRequest) (*api.CreateNamespaceResponse, error) {
+	if !config.DefaultConfig.Auth.EnableNamespaceCreation {
+		return nil, errors.Unimplemented("Namespace creation is disabled on this cluster")
+	}
+	
 	if req.GetName() == "" {
 		return nil, errors.InvalidArgument("Empty namespace name is not allowed")
 	}


### PR DESCRIPTION
## Describe your changes
In the multi-region setup, not all cluster will need to expose management interface to create namespace. This PR allows users to configure cluster to disable namespace creation API.

## How best to test these changes

## Issue ticket number and link
