### PR TITLE
Use proto for document metadata encoding

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -37,18 +37,18 @@ func DecodeStreamData(b []byte) (*StreamData, error) {
 	if len(b) == 0 {
 		return nil, errors.Internal("unable to decode event data is empty")
 	}
-	dataType := DataType(b[0])
-	dec := codec.NewDecoderBytes(b[1:], &bh)
 
-	if dataType == StreamDataType {
-		var v *StreamData
-		if err := dec.Decode(&v); err != nil {
-			return nil, err
-		}
-		return v, nil
+	if b[0] != StreamDataType {
+		return nil, errors.Internal("unable to decode '%v'", b[0])
 	}
 
-	return nil, errors.Internal("unable to decode '%v'", dataType)
+	var v *StreamData
+	dec := codec.NewDecoderBytes(b[1:], &bh)
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }
 
 func NewCacheData(data []byte) *CacheData {
@@ -66,16 +66,16 @@ func DecodeCacheData(b []byte) (*CacheData, error) {
 	if len(b) == 0 {
 		return nil, errors.Internal("unable to decode event data is empty")
 	}
-	dataType := DataType(b[0])
-	dec := codec.NewDecoderBytes(b[1:], &bh)
 
-	if dataType == CacheDataType {
-		var v *CacheData
-		if err := dec.Decode(&v); err != nil {
-			return nil, err
-		}
-		return v, nil
+	if b[0] != CacheDataType {
+		return nil, errors.Internal("unable to decode '%v'", b[0])
 	}
 
-	return nil, errors.Internal("unable to decode '%v'", dataType)
+	var v *CacheData
+	dec := codec.NewDecoderBytes(b[1:], &bh)
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }

--- a/internal/data_test.go
+++ b/internal/data_test.go
@@ -15,10 +15,12 @@
 package internal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestEncode_Decode(t *testing.T) {
@@ -30,22 +32,159 @@ func TestEncode_Decode(t *testing.T) {
 
 		data, err := Decode(encoded)
 		require.NoError(t, err)
-		require.Equal(t, d, data)
+		require.True(t, proto.Equal(d, data))
 	})
 	t.Run("not_implemented", func(t *testing.T) {
 		data, err := Decode([]byte(`{"a": 1, "b": "foo"}`))
 		require.Equal(t, errors.Internal("unable to decode '123'"), err)
 		require.Nil(t, data)
 	})
+
+	t.Run("empty", func(t *testing.T) {
+		v := &TableData{
+			RawData: []byte(`{"a": 1, "b": "foo"}`),
+		}
+
+		encoded, err := Encode(v)
+		require.NoError(t, err)
+		require.NotNil(t, encoded)
+
+		data, err := Decode(encoded)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(v, data))
+	})
+
+	t.Run("decode_binc", func(t *testing.T) {
+		d := NewTableData([]byte(`{"a": 1, "b": "foo"}`))
+		encoded, err := encodeInternal(d, TableDataType)
+		require.NoError(t, err)
+		require.NotNil(t, encoded)
+
+		data, err := Decode(encoded)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(d, data))
+	})
+
+	t.Run("decode_proto", func(t *testing.T) {
+		d := NewTableData([]byte(`{"a": 1, "b": "foo"}`))
+		encoded, err := encodeInternalProto(d)
+		require.NoError(t, err)
+		require.NotNil(t, encoded)
+
+		data, err := Decode(encoded)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(d, data))
+	})
+
+	t.Run("default_is_proto", func(t *testing.T) {
+		v := &TableData{
+			RawData: []byte(`{"a": 1, "b": "foo"}`),
+		}
+
+		encoded, err := Encode(v)
+		require.NoError(t, err)
+		require.NotNil(t, encoded)
+		require.Equal(t, TableDataProtoType, encoded[0])
+	})
+
+	t.Run("stable_constants", func(t *testing.T) {
+		require.Equal(t, byte(1), TableDataType)
+		require.Equal(t, byte(2), CacheDataType)
+		require.Equal(t, byte(3), StreamDataType)
+		require.Equal(t, byte(4), TableDataProtoType)
+	})
 }
 
-func Benchmark_MsgPack(b *testing.B) {
+func Benchmark_Encode(b *testing.B) {
+	tm1 := NewTimestamp()
+	tm2 := NewTimestamp()
+
+	bb := int32(7)
 	v := &TableData{
-		RawData: []byte(`"K1": "vK1", "K2": 1, "D1": "vD1", "random", "this is a long string, with many characters"}`),
+		Ver:         23045,
+		Encoding:    3789,
+		CreatedAt:   tm1,
+		UpdatedAt:   tm2,
+		RawData:     []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
+		TotalChunks: &bb,
 	}
-	for n := 0; n < b.N; n++ {
-		enc, err := Encode(v)
-		require.NoError(b, err)
-		require.NotNil(b, enc)
+
+	b.Run("ugorji_binc", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			enc, err := encodeInternal(v, TableDataType)
+			if err != nil {
+				panic(err)
+			}
+			_ = enc
+		}
+	})
+
+	b.Run("proto", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			enc, err := encodeInternalProto(v)
+			if err != nil {
+				panic(err)
+			}
+			_ = enc
+		}
+	})
+	/*
+		enc, err := encodeInternalProto(v)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(os.Stderr, "Size: %v\n", len(enc))
+	*/
+}
+
+func Benchmark_Decode(b *testing.B) {
+	tm1 := NewTimestamp()
+	tm2 := NewTimestamp()
+
+	bb := int32(7)
+	v := &TableData{
+		Ver:         23045,
+		Encoding:    3789,
+		CreatedAt:   tm1,
+		UpdatedAt:   tm2,
+		RawData:     []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
+		TotalChunks: &bb,
 	}
+	enc, err := encodeInternal(v, TableDataType)
+	if err != nil {
+		panic(err)
+	}
+	b.Run("ugorji_binc", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			td, err := decodeInternal(enc[1:])
+			if err != nil {
+				panic(err)
+			}
+			_ = td
+		}
+	})
+	//	td, _ := decodeInternal(enc[1:])
+	//	fmt.Fprintf(os.Stderr, "td: %+v\n", td)
+
+	enc, err = encodeInternalProto(v)
+	if err != nil {
+		panic(err)
+	}
+	b.Run("proto", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			enc, err := decodeInternalProto(enc[1:])
+			if err != nil {
+				panic(err)
+			}
+			_ = enc
+		}
+	})
+
+	/*
+		td, err := decodeInternalProto(enc[1:])
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(os.Stderr, "td: %+v\n", td)
+	*/
 }

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -84,7 +84,7 @@ func (m *managementService) CreateNamespace(ctx context.Context, req *api.Create
 	if !config.DefaultConfig.Auth.EnableNamespaceCreation {
 		return nil, errors.Unimplemented("Namespace creation is disabled on this cluster")
 	}
-	
+
 	if req.GetName() == "" {
 		return nil, errors.InvalidArgument("Empty namespace name is not allowed")
 	}


### PR DESCRIPTION
This makes encoding ~3 times faster.
Decoding is made O(1), so no special metadata-only decoding API is needed.

This is forward incompatible change.