### PR TITLE
feat: Allow filtering for nested array of objects(one level) for standalone search index

### DIFF
--- a/cmd/consistency/workload/document.go
+++ b/cmd/consistency/workload/document.go
@@ -76,14 +76,14 @@ type Nested struct {
 	Domain    string   `json:"domain"  fake:"{domainname}"`
 	Sentence  string   `json:"sentence" fake:"{sentence:3}"`
 	Company   string   `json:"company"  fake:"{company}"`
-	Labels    []string `json:"labels"  fakesize:"200"`
+	Labels    []string `json:"labels"  fakesize:"2"`
 	Address   Address  `json:"address"`
 	NestedId  string   `json:"nested_id"  fake:"{uuid}"`
 }
 
 type DocumentV1 struct {
 	Id        int64     `json:"id"`
-	Cars      []string  `json:"cars" fake:"{carmaker}" fakesize:"10000"`
+	Cars      []string  `json:"cars" fake:"{carmaker}" fakesize:"2"`
 	CreatedAt time.Time `json:"created_at"  fake:"{date}"`
 	UpdatedAt time.Time `json:"updated_at"  fake:"{date}"`
 	Nested    *Nested   `json:"nested"`
@@ -99,6 +99,7 @@ func NewDocumentV1(id int64) *DocumentV1 {
 	if err := gofakeit.Struct(&document); err != nil {
 		log.Panic().Err(err).Msgf("failed in generating fake document")
 	}
+
 	document.Id = id
 	document.Nested = &nested
 

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -250,6 +250,14 @@ func (factory *Factory) ParseSelector(k []byte, v []byte, dataType jsonparser.Va
 	for _, f := range factory.fields {
 		if f.Name() == string(k) {
 			field = f
+			break
+		}
+
+		for _, nested := range f.AllowedNestedQFields {
+			if nested.Name() == string(k) {
+				field = nested
+				break
+			}
 		}
 	}
 	if field == nil {

--- a/schema/search.go
+++ b/schema/search.go
@@ -213,6 +213,11 @@ func (s *SearchIndex) GetQueryableField(name string) (*QueryableField, error) {
 		if qf.Name() == name {
 			return qf, nil
 		}
+		for _, nested := range qf.AllowedNestedQFields {
+			if nested.Name() == name {
+				return nested, nil
+			}
+		}
 	}
 	return nil, errors.InvalidArgument("Field `%s` is not present in collection", name)
 }

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -4298,13 +4298,14 @@ func TestFilteringOnArrays_Primitives(t *testing.T) {
 		nil,
 		inputDocument[2:3])
 
-	readExpError(t,
+	readAndValidate(t,
 		db,
 		collection,
 		Map{
 			"arr_obj.name": "classic",
 		},
-		http.StatusBadRequest,
+		nil,
+		inputDocument[0:1],
 	)
 }
 


### PR DESCRIPTION
## Describe your changes
This allows if an array of objects is indexed, then filtering can be done inside it like this,
```
{"filter": {"arr.nested_field": "foo"}}
```
## How best to test these changes

## Issue ticket number and link
