### PR TITLE
feat: Return matched token for nested fields in case of array of objects

### DIFF
--- a/server/search/hits.go
+++ b/server/search/hits.go
@@ -22,6 +22,10 @@ import (
 	tsApi "github.com/tigrisdata/typesense-go/typesense/api"
 )
 
+const (
+	matchedTokensKey = "matched_tokens"
+)
+
 type Hits struct {
 	hits  []*Hit
 	index int
@@ -86,21 +90,9 @@ func NewSearchHit(tsHit *tsApi.SearchResultHit) *Hit {
 	var fields []*api.MatchField
 	if tsHit.Highlight != nil {
 		// check first in highlight
-		for name := range *tsHit.Highlight {
-			fields = append(fields, &api.MatchField{
-				Name: name,
-			})
-		}
+		fromHighlight(*tsHit.Highlight, &fields)
 	} else if tsHit.Highlights != nil {
-		for _, f := range *tsHit.Highlights {
-			name := ""
-			if f.Field != nil {
-				name = *f.Field
-			}
-			fields = append(fields, &api.MatchField{
-				Name: name,
-			})
-		}
+		fromHighlights(*tsHit.Highlights, &fields)
 	}
 
 	return &Hit{
@@ -111,4 +103,84 @@ func NewSearchHit(tsHit *tsApi.SearchResultHit) *Hit {
 			VectorDistance: tsHit.VectorDistance,
 		},
 	}
+}
+
+func fromHighlights(highlights []tsApi.SearchHighlight, fields *[]*api.MatchField) {
+	for _, f := range highlights {
+		name := ""
+		if f.Field != nil {
+			name = *f.Field
+		}
+		*fields = append(*fields, &api.MatchField{
+			Name: name,
+		})
+	}
+}
+
+func fromHighlight(highlight map[string]interface{}, fields *[]*api.MatchField) {
+	// check first in highlight
+	for name, value := range highlight {
+		if mp, ok := value.(map[string]any); ok {
+			// any non array match should just fall in this "if"
+			if isMatchedToken(mp) {
+				*fields = append(*fields, &api.MatchField{
+					Name: name,
+				})
+			}
+			continue
+		}
+
+		if mArr, ok := value.([]any); ok {
+			for _, each := range mArr {
+				if mp, ok := each.(map[string]any); ok {
+					matchedToken := isMatchedToken(mp)
+					if matchedToken {
+						// simple array
+						*fields = append(*fields, &api.MatchField{
+							Name: name,
+						})
+						break
+					}
+
+					// now this means we can have an array of objects, we iterate one level
+					// to build matched fields
+					buildMatchedForArrObjects(name, mp, fields)
+				}
+			}
+		}
+	}
+}
+func buildMatchedForArrObjects(parent string, obj map[string]any, fields *[]*api.MatchField) {
+	for k, v := range obj {
+		if mpNested, ok := v.(map[string]any); ok {
+			// nested element in an array of object is not an array
+			if isMatchedToken(mpNested) {
+				*fields = append(*fields, &api.MatchField{
+					Name: parent + "." + k,
+				})
+			}
+		} else if mpNestedArr, ok := v.([]any); ok {
+			// nested element in an array of object is an array
+			for _, eachNestedArr := range mpNestedArr {
+				if eachNested, ok := eachNestedArr.(map[string]any); ok {
+					if isMatchedToken(eachNested) {
+						*fields = append(*fields, &api.MatchField{
+							Name: parent + "." + k,
+						})
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func isMatchedToken(mp map[string]any) bool {
+	if matched, found := mp[matchedTokensKey]; found {
+		if matchedSlice, ok := matched.([]any); ok {
+			return len(matchedSlice) > 0
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Describe your changes
We were returning only the parent name(array of objects) in case the search matches that field. This diff will return an exact nested field that matches in the case of an array of objects. The convention will be the same `parent.nested`

## How best to test these changes

## Issue ticket number and link
