### PR TITLE
feat: Support $regex, $contains, $not in filters(extending hybrid search functionality)

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -17,9 +17,8 @@ package main
 import (
 	"os"
 
-	"github.com/spf13/pflag"
-
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/pflag"
 	"github.com/tigrisdata/tigris/cmd/admin/cmd"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"

--- a/query/filter/comparison.go
+++ b/query/filter/comparison.go
@@ -15,28 +15,43 @@
 package filter
 
 import (
+	"bytes"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/value"
 )
 
 const (
-	EQ  = "$eq"
-	GT  = "$gt"
-	LT  = "$lt"
-	GTE = "$gte"
-	LTE = "$lte"
+	EQ       = "$eq"
+	GT       = "$gt"
+	LT       = "$lt"
+	GTE      = "$gte"
+	LTE      = "$lte"
+	NOT      = "$not"
+	REGEX    = "$regex"
+	CONTAINS = "$contains"
 )
+
+type Matcher interface {
+	// Type return the type of the value matcher, syntactic sugar for logging, etc
+	Type() string
+}
+
+type LikeMatcher interface {
+	Matcher
+
+	Matches(docValue any) bool
+}
 
 // ValueMatcher is an interface that has method like Matches.
 type ValueMatcher interface {
+	Matcher
+
 	// Matches returns true if the receiver has the value object that has the same value as input
 	Matches(input value.Value) bool
-
-	// Type return the type of the value matcher, syntactic sugar for logging, etc
-	Type() string
-
 	// GetValue returns the value on which the Matcher is operating
 	GetValue() value.Value
 }
@@ -64,6 +79,19 @@ func NewMatcher(key string, v value.Value) (ValueMatcher, error) {
 		return &LessThanEqMatcher{
 			Value: v,
 		}, nil
+	default:
+		return nil, errors.InvalidArgument("unsupported operand '%s'", key)
+	}
+}
+
+func NewLikeMatcher(key string, input string, collation *value.Collation) (LikeMatcher, error) {
+	switch key {
+	case REGEX:
+		return NewRegexMatcher(input, collation)
+	case CONTAINS:
+		return NewContainsMatcher(input, collation)
+	case NOT:
+		return NewNotMatcher(input, collation)
 	default:
 		return nil, errors.InvalidArgument("unsupported operand '%s'", key)
 	}
@@ -184,4 +212,139 @@ func (l *LessThanEqMatcher) Type() string {
 
 func (l *LessThanEqMatcher) String() string {
 	return fmt.Sprintf("{$lte:%v}", l.Value)
+}
+
+// RegexMatcher implements "$regex" operand.
+// When matching against text, the regexp returns a match that
+// begins as early as possible in the input (leftmost), and among those
+// it chooses the one that a backtracking search would have found first.
+// This so-called leftmost-first matching is the same semantics
+// that Perl, Python, and other implementations use.
+type RegexMatcher struct {
+	regex     *regexp.Regexp
+	collation *value.Collation
+}
+
+func NewRegexMatcher(value string, collation *value.Collation) (LikeMatcher, error) {
+	regexp, err := regexp.Compile(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegexMatcher{
+		regex:     regexp,
+		collation: collation,
+	}, nil
+}
+
+func (c *RegexMatcher) Matches(docValue any) bool {
+	switch dv := docValue.(type) {
+	case string:
+		return c.regex.MatchString(dv)
+	case []string:
+		for _, e := range dv {
+			if c.regex.MatchString(e) {
+				return true
+			}
+		}
+	case []byte:
+		return c.regex.Match(dv)
+	}
+	return false
+}
+
+func (c *RegexMatcher) Type() string {
+	return "$regex"
+}
+
+func (c *RegexMatcher) String() string {
+	return fmt.Sprintf("{regex:%v}", c.regex.String())
+}
+
+// ContainsMatcher implements "$contains" operand.
+type ContainsMatcher struct {
+	value     string
+	collation *value.Collation
+}
+
+func NewContainsMatcher(value string, collation *value.Collation) (LikeMatcher, error) {
+	return &ContainsMatcher{
+		value:     value,
+		collation: collation,
+	}, nil
+}
+
+func (c *ContainsMatcher) Matches(docValue any) bool {
+	switch dv := docValue.(type) {
+	case string:
+		return StringContains(dv, c.value, c.collation)
+	case []string:
+		for _, e := range dv {
+			if StringContains(e, c.value, c.collation) {
+				return true
+			}
+		}
+	case []byte:
+		if c.collation.IsCaseInsensitive() {
+			return bytes.Contains(bytes.ToLower(dv), bytes.ToLower([]byte(c.value)))
+		}
+		return bytes.Contains(dv, []byte(c.value))
+	}
+	return false
+}
+
+func (c *ContainsMatcher) Type() string {
+	return "$contains"
+}
+
+func (c *ContainsMatcher) String() string {
+	return fmt.Sprintf("{$contains:%v}", c.value)
+}
+
+// NotMatcher implements "$not" operand.
+type NotMatcher struct {
+	value     string
+	collation *value.Collation
+}
+
+func NewNotMatcher(value string, collation *value.Collation) (LikeMatcher, error) {
+	return &NotMatcher{
+		value:     value,
+		collation: collation,
+	}, nil
+}
+
+func (n *NotMatcher) Matches(docValue any) bool {
+	switch dv := docValue.(type) {
+	case string:
+		return !StringContains(dv, n.value, n.collation)
+	case []string:
+		for _, e := range dv {
+			if StringContains(e, n.value, n.collation) {
+				return false
+			}
+		}
+		return true
+	case []byte:
+		if n.collation.IsCaseInsensitive() {
+			return !bytes.Contains(bytes.ToLower(dv), bytes.ToLower([]byte(n.value)))
+		}
+		return !bytes.Contains(dv, []byte(n.value))
+	}
+	return false
+}
+
+func (n *NotMatcher) Type() string {
+	return "$not"
+}
+
+func (n *NotMatcher) String() string {
+	return fmt.Sprintf("{$not:%v}", n.value)
+}
+
+func StringContains(s string, substr string, collation *value.Collation) bool {
+	if collation.IsCaseInsensitive() {
+		return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+	}
+	return strings.Contains(s, substr)
 }

--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -129,9 +129,10 @@ func (k *KeyBuilder[F]) Build(filters []Filter, userDefinedKeys []F) ([]QueryPla
 	var singleLevel []*Selector
 	var allKeys []QueryPlan
 	for _, f := range filters {
-		if ss, ok := f.(*Selector); ok {
+		switch ss := f.(type) {
+		case *Selector:
 			singleLevel = append(singleLevel, ss)
-		} else {
+		case LogicalFilter:
 			queue = append(queue, f)
 		}
 	}

--- a/query/filter/like.go
+++ b/query/filter/like.go
@@ -1,0 +1,74 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+
+	"github.com/buger/jsonparser"
+	"github.com/tigrisdata/tigris/schema"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+// LikeFilter creates a filter that offers "like" semantics i.e. "regex"/"contains"/"not". It is not used to create
+// any key. It is always used to post-process the records.
+type LikeFilter struct {
+	Field   *schema.QueryableField
+	Matcher LikeMatcher
+}
+
+func NewLikeFilter(field *schema.QueryableField, matcher LikeMatcher) *LikeFilter {
+	return &LikeFilter{
+		Field:   field,
+		Matcher: matcher,
+	}
+}
+
+func (s *LikeFilter) MatchesDoc(doc map[string]any) bool {
+	v, ok := doc[s.Field.Name()]
+	if !ok {
+		return true
+	}
+
+	return s.Matcher.Matches(v)
+}
+
+// Matches returns true if the doc value matches this filter.
+func (s *LikeFilter) Matches(doc []byte) bool {
+	docValue, dtp, _, err := jsonparser.Get(doc, s.Field.KeyPath()...)
+	if dtp == jsonparser.NotExist {
+		return false
+	}
+	if ulog.E(err) {
+		return false
+	}
+	if dtp == jsonparser.Null {
+		docValue = nil
+	}
+
+	return s.Matcher.Matches(docValue)
+}
+
+func (s *LikeFilter) ToSearchFilter() string {
+	return ""
+}
+
+func (s *LikeFilter) IsSearchIndexed() bool {
+	return false
+}
+
+func (s *LikeFilter) String() string {
+	return fmt.Sprintf("{%v:%v}", s.Field.Name(), s.Matcher)
+}

--- a/query/filter/logical.go
+++ b/query/filter/logical.go
@@ -204,9 +204,10 @@ func (sz *searchSerializer) serialize(searchToken string, filters []Filter) []st
 	var selectors []*Selector
 	var logical []LogicalFilter
 	for _, f := range filters {
-		if s, ok := f.(*Selector); ok {
-			selectors = append(selectors, s)
-		} else {
+		switch conv := f.(type) {
+		case *Selector:
+			selectors = append(selectors, conv)
+		case LogicalFilter:
 			logical = append(logical, f.(LogicalFilter))
 		}
 	}

--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -37,9 +37,10 @@ import (
 //	{f:20} (default is "$eq" so we automatically append EqualityMatcher for this case in parser)
 //	{f:<Expr>}
 type Selector struct {
-	Field     *schema.QueryableField
-	Matcher   ValueMatcher
-	Collation *value.Collation
+	Field       *schema.QueryableField
+	Matcher     ValueMatcher
+	Collation   *value.Collation
+	LikeMatcher LikeMatcher
 }
 
 // NewSelector returns Selector object.
@@ -51,7 +52,7 @@ func NewSelector(field *schema.QueryableField, matcher ValueMatcher, collation *
 	}
 }
 
-func (s *Selector) MatchesDoc(doc map[string]interface{}) bool {
+func (s *Selector) MatchesDoc(doc map[string]any) bool {
 	v, ok := doc[s.Field.Name()]
 	if !ok {
 		return true

--- a/test/v1/server/search_test.go
+++ b/test/v1/server/search_test.go
@@ -904,7 +904,6 @@ func TestSearch(t *testing.T) {
 
 	compareDocs(t, docs[2], res.Result.Groups[0]["hits"].([]any)[0].(map[string]any)["data"].(map[string]any))
 	compareDocs(t, docs[0], res.Result.Groups[0]["hits"].([]any)[1].(map[string]any)["data"].(map[string]any))
-
 	compareDocs(t, docs[1], res.Result.Groups[1]["hits"].([]any)[0].(map[string]any)["data"].(map[string]any))
 }
 
@@ -937,7 +936,7 @@ func TestVectorSearch(t *testing.T) {
 			"vector":       []float64{0.1, 1.1, 0.93, 0.75},
 		}, {
 			"id":           "2",
-			"string_value": "big data",
+			"string_value": "big data platform",
 			"vector":       []float64{-0.23, -0.57, 1.12, 0.98},
 		}, {
 			"id":           "3",
@@ -978,6 +977,21 @@ func TestVectorSearch(t *testing.T) {
 
 	require.Equal(t, float64(0), res.Result.Hits[0]["metadata"]["match"].(map[string]any)["vector_distance"])
 	require.Equal(t, 0.22375428676605225, res.Result.Hits[1]["metadata"]["match"].(map[string]any)["vector_distance"])
+
+	res = getSearchResults(t, project, index, Map{"vector": Map{"vector": []float64{1.1, 2.22, 0.0875, 0.975}}, "filter": Map{"string_value": Map{"$contains": "platform"}}}, false)
+	require.Equal(t, 2, len(res.Result.Hits))
+
+	// contains will filter out other rows
+	compareDocs(t, docs[0], res.Result.Hits[0]["data"])
+	compareDocs(t, docs[1], res.Result.Hits[1]["data"])
+
+	res = getSearchResults(t, project, index, Map{"vector": Map{"vector": []float64{1.1, 2.22, 0.0875, 0.975}}, "filter": Map{"string_value": Map{"$not": "platform"}}}, false)
+	require.Equal(t, 2, len(res.Result.Hits))
+
+	// contains will filter out other rows
+	compareDocs(t, docs[2], res.Result.Hits[0]["data"])
+	compareDocs(t, docs[3], res.Result.Hits[1]["data"])
+
 }
 
 func TestComplexObjects(t *testing.T) {

--- a/value/collation.go
+++ b/value/collation.go
@@ -33,8 +33,8 @@ func NewCollation() *Collation {
 	return NewCollationFrom(nil)
 }
 
-// The collation sort key is used for with the secondary index.
-// We generate a sortkey when storing a string in the index and
+// NewSortKeyCollation is used for with the secondary index.
+// We generate a sort key when storing a string in the index and
 // also use it when comparing strings when filtering.
 func NewSortKeyCollation() *Collation {
 	return NewCollationFrom(&api.Collation{Case: "csk"})


### PR DESCRIPTION
## Describe your changes
Adding three more operands in the filters. 
- `$regex`: Provides regular expression capabilities for pattern-matching strings in queries.
- `$contains`: Contains reports whether the filter value is within the value stored in the field.
- `$not`: Not is the reverse of contains.

These operands can further filter database results or search index results. This is very useful for our hybrid search, where results are returned in the similarity order of vectors, and then using these operands, results can be narrowed.

Example Search Req:
```
{
  "vector": {
        "vec": [-0.12, -0.23, -0.56, -0.83]
   },
   "filter": {"StrValue": {"$contains": "hybrid"}}
}
```
## How best to test these changes

## Issue ticket number and link
