### PR TITLE
fix: Use empty collation if not set

### DIFF
--- a/query/filter/comparison.go
+++ b/query/filter/comparison.go
@@ -85,6 +85,10 @@ func NewMatcher(key string, v value.Value) (ValueMatcher, error) {
 }
 
 func NewLikeMatcher(key string, input string, collation *value.Collation) (LikeMatcher, error) {
+	if collation == nil {
+		collation = value.EmptyCollation
+	}
+
 	switch key {
 	case REGEX:
 		return NewRegexMatcher(input, collation)

--- a/value/collation.go
+++ b/value/collation.go
@@ -29,6 +29,8 @@ type Collation struct {
 	apiCollation *api.Collation
 }
 
+var EmptyCollation = NewCollation()
+
 func NewCollation() *Collation {
 	return NewCollationFrom(nil)
 }


### PR DESCRIPTION
## Describe your changes
Use empty collation if not set

## How best to test these changes

## Issue ticket number and link
