### PR TITLE
fix: Filtering with timestamp

### DIFF
--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
-
 	"strconv"
+	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/google/uuid"
@@ -195,7 +194,6 @@ func (m *Metronome) pushBillingEvents(ctx context.Context, events []biller.Event
 				return nil, err
 			}
 			return resp.HTTPResponse, err
-
 		})
 		if err != nil {
 			return err

--- a/server/services/v1/database/row_reader.go
+++ b/server/services/v1/database/row_reader.go
@@ -160,15 +160,11 @@ func (it *FilterIterator) Next(row *Row) bool {
 }
 
 func (it *FilterIterator) advanceToMatchingRow(row *Row) bool {
-	// Convert the created_at and updated_at to a json blob
-	// this allows them to be processed by our filter and check if the query
-	// matches those fields
-	ts, err := row.Data.TimestampsToJSON()
-	if err == nil && it.filter.Matches(ts) {
-		return true
+	dataWithTS, err := row.Data.DataWithTimeStamps()
+	if err != nil {
+		return false
 	}
-
-	return it.filter.Matches(row.Data.RawData)
+	return it.filter.Matches(dataWithTS)
 }
 
 type DatabaseReader struct {

--- a/test/v1/server/secondary_index_test.go
+++ b/test/v1/server/secondary_index_test.go
@@ -314,8 +314,8 @@ func TestQuery_Range(t *testing.T) {
 			[]string{"null", "2015-12.22T17:42:34Z"},
 		},
 		{
-			Map{"_tigris_created_at": Map{"$gt": "2022-12.22T17:42:34Z"}},
-			[]int{1, 2, 3, 4, 30},
+			Map{"_tigris_created_at": Map{"$gt": "2022-12.22T17:42:34Z"}, "bool_value": true},
+			[]int{1, 4},
 			[]string{"2022-12.22T17:42:34Z", max},
 		},
 		{


### PR DESCRIPTION
## Describe your changes

When a filter had a `_tigris_created_at` check and another field check the filtering would always fail because we did two separate checks on the filter. This adds the timestamps to the raw data and then does a single filtering check.

## How best to test these changes
The current tests should pass

## Issue ticket number and link
