### PR TITLE
fix: check metadata before reading collection metadata

### DIFF
--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -479,7 +479,7 @@ func (s *apiService) DescribeCollection(ctx context.Context, r *api.DescribeColl
 	runner := s.runnerFactory.GetCollectionQueryRunner(accessToken)
 	runner.SetDescribeCollectionReq(r)
 
-	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{})
+	resp, err := s.sessions.Execute(ctx, runner, database.ReqOptions{InstantVerTracking: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes
The describe collection wasn't reacting to collection index changes because it was not checking the metadata has changed. 

## How best to test these changes

## Issue ticket number and link
