### PR TITLE
refactor: Optimize by loading schemas for search only during the start of the server

### DIFF
--- a/schema/queryable.go
+++ b/schema/queryable.go
@@ -102,6 +102,8 @@ func (builder *QueryableFieldsBuilder) NewQueryableField(name string, f *Field, 
 	packThis := false
 	if f.DataType == ArrayType || f.DataType == ObjectType {
 		for _, fieldInSearch := range fieldsInSearch {
+			// Queryable field only use the "fieldInSearch" schema to understand if any field needs packing i.e. the
+			// schema in search is string but the data type is an array or an object.
 			if fieldInSearch.Name == name {
 				searchType = fieldInSearch.Type
 				if searchType == FieldNames[StringType] {

--- a/server/metadata/tenant_tracker.go
+++ b/server/metadata/tenant_tracker.go
@@ -54,6 +54,7 @@ type CacheTracker struct {
 	txMgr          *transaction.Manager
 	versionH       *VersionHandler
 	tenantVersions map[string]Version
+	tenantMgr      *TenantManager
 }
 
 // NewCacheTracker creates and returns the cache tracker. It uses tenant manager state to populate in-memory
@@ -68,6 +69,7 @@ func NewCacheTracker(tenantMgr *TenantManager, txMgr *transaction.Manager) *Cach
 		txMgr:          txMgr,
 		tenantVersions: tenantVersionMap,
 		versionH:       tenantMgr.versionH,
+		tenantMgr:      tenantMgr,
 	}
 }
 
@@ -200,7 +202,7 @@ func (cacheTracker *CacheTracker) stopTracking(ctx context.Context, tenant *Tena
 		return err
 	}
 
-	if err = tenant.Reload(ctx, tx, version); err != nil {
+	if err = tenant.Reload(ctx, tx, version, cacheTracker.tenantMgr.searchSchemasSnapshot); err != nil {
 		return err
 	}
 

--- a/server/quota/quota_test.go
+++ b/server/quota/quota_test.go
@@ -70,7 +70,7 @@ func TestQuota(t *testing.T) {
 	factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 	require.NoError(t, err)
 
-	err = tenant.Reload(ctx, tx, []byte("aaa"))
+	err = tenant.Reload(ctx, tx, []byte("aaa"), nil)
 	require.NoError(t, err)
 
 	proj1, err := tenant.GetProject(projName)

--- a/server/quota/storage_test.go
+++ b/server/quota/storage_test.go
@@ -61,7 +61,7 @@ func TestStorageQuota(t *testing.T) {
 	factory, err := schema.NewFactoryBuilder(true).Build("test_collection", jsSchema)
 	require.NoError(t, err)
 
-	err = tenant.Reload(ctx, tx, []byte("aaa"))
+	err = tenant.Reload(ctx, tx, []byte("aaa"), nil)
 	require.NoError(t, err)
 
 	proj1, err := tenant.GetProject(projName)

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -75,18 +75,13 @@ func newApiService(kv kv.TxStore, searchStore search.Store, tenantMgr *metadata.
 		authProvider: authProvider,
 	}
 
-	collectionsInSearch, err := u.searchStore.AllCollections(context.TODO())
-	if err != nil {
-		log.Fatal().Err(err).Msgf("error starting server: loading schemas from search failed")
-	}
-
 	ctx := context.TODO()
 	tx, err := u.txMgr.StartTx(ctx)
 	if ulog.E(err) {
 		log.Fatal().Err(err).Msgf("error starting server: starting transaction failed")
 	}
 
-	if err := tenantMgr.Reload(ctx, tx, collectionsInSearch); ulog.E(err) {
+	if err := tenantMgr.Reload(ctx, tx); ulog.E(err) {
 		// ToDo: no need to panic, probably handle through async thread.
 		log.Fatal().Err(err).Msgf("error starting server: reloading tenants failed")
 	}

--- a/server/services/v1/realtime/device_session.go
+++ b/server/services/v1/realtime/device_session.go
@@ -73,7 +73,7 @@ func (s *Sessions) CreateDeviceSession(ctx context.Context, conn *websocket.Conn
 		if version, err = s.versionH.Read(ctx, tx, false); err != nil {
 			return nil, err
 		}
-		if err = tenant.Reload(ctx, tx, version); err != nil {
+		if err = tenant.Reload(ctx, tx, version, nil); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
## Describe your changes
One of the use cases of using the previous version of the search schema is to know if a field needs to be masked. This is only relevant for very old collections, so moving this logic to load all the schemas during startup only.

## How best to test these changes

## Issue ticket number and link
