### PR TITLE
fix: Disabled realtime test

### DIFF
--- a/test/v1/server/realtime_test.go
+++ b/test/v1/server/realtime_test.go
@@ -48,6 +48,7 @@ func createChannel(t *testing.T, projectName string, channelName string) *httpex
 }
 
 func TestGetChannel(t *testing.T) {
+	t.Skip("Skip and enable when we add back the realtime offering")
 	project := setupTestsOnlyProject(t)
 	defer cleanupTests(t, project)
 
@@ -64,6 +65,7 @@ func TestGetChannel(t *testing.T) {
 }
 
 func TestMessages(t *testing.T) {
+	t.Skip("Skip and enable when we add back the realtime offering")
 	project := setupTestsOnlyProject(t)
 	defer cleanupTests(t, project)
 


### PR DESCRIPTION
## Describe your changes
Disabled realtime test for realtime  - fix and enable it back when we are ready for realtime. This is to improve CI health temporarily.

## How best to test these changes

## Issue ticket number and link
