### PR TITLE
feat: Add count documents API

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -454,6 +454,41 @@ func (x *DeleteRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON on CountRequest avoids unmarshalling filter and instead this way we can write a custom struct to do
+// the unmarshalling and will be avoiding any extra allocation/copying.
+func (x *CountRequest) UnmarshalJSON(data []byte) error {
+	var mp map[string]jsoniter.RawMessage
+
+	if err := jsoniter.Unmarshal(data, &mp); err != nil {
+		return err
+	}
+
+	for key, value := range mp {
+		var v interface{}
+
+		switch key {
+		case "project":
+			v = &x.Project
+		case "collection":
+			v = &x.Collection
+		case "branch":
+			v = &x.Branch
+		case "filter":
+			// not decoding it here and let it decode during filter parsing
+			x.Filter = value
+			continue
+		default:
+			continue
+		}
+
+		if err := jsoniter.Unmarshal(value, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // UnmarshalJSON on CreateCollectionRequest avoids unmarshalling schema. The req handler deserializes the schema.
 func (x *CreateOrUpdateCollectionRequest) UnmarshalJSON(data []byte) error {
 	var mp map[string]jsoniter.RawMessage

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -328,6 +328,19 @@ func (s *apiService) Read(r *api.ReadRequest, stream api.Tigris_ReadServer) erro
 	return err
 }
 
+func (s *apiService) Count(ctx context.Context, r *api.CountRequest) (*api.CountResponse, error) {
+	queryMetrics := metrics.StreamingQueryMetrics{}
+	accessToken, _ := request.GetAccessToken(ctx)
+	resp, err := s.sessions.Execute(ctx, s.runnerFactory.GetCountQueryRunner(r, &queryMetrics, accessToken), database.ReqOptions{
+		TxCtx: api.GetTransaction(ctx),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Response.(*api.CountResponse), nil
+}
+
 func (s *apiService) Explain(ctx context.Context, r *api.ReadRequest) (*api.ExplainResponse, error) {
 	queryMetrics := metrics.WriteQueryMetrics{}
 	accessToken, _ := request.GetAccessToken(ctx)

--- a/server/services/v1/database/query_runner_factory.go
+++ b/server/services/v1/database/query_runner_factory.go
@@ -82,6 +82,14 @@ func (f *QueryRunnerFactory) GetDeleteQueryRunner(r *api.DeleteRequest, qm *metr
 	}
 }
 
+func (f *QueryRunnerFactory) GetCountQueryRunner(r *api.CountRequest, qm *metrics.StreamingQueryMetrics, accessToken *types.AccessToken) *CountQueryRunner {
+	return &CountQueryRunner{
+		BaseQueryRunner: NewBaseQueryRunner(f.encoder, f.cdcMgr, f.txMgr, f.searchStore, accessToken),
+		req:             r,
+		queryMetrics:    qm,
+	}
+}
+
 // GetStreamingQueryRunner returns StreamingQueryRunner.
 func (f *QueryRunnerFactory) GetStreamingQueryRunner(r *api.ReadRequest, streaming Streaming, qm *metrics.StreamingQueryMetrics, accessToken *types.AccessToken) *StreamingQueryRunner {
 	return &StreamingQueryRunner{


### PR DESCRIPTION
## Describe your changes
Return the counts of documents in a collection. Optionally accept a filter to return the count of documents that matches the filter. 
```
curl '127.0.0.1:8081/v1/projects/p1/database/collections/foo/documents/count' -XPOST
{"count":2}
```

## How best to test these changes

## Issue ticket number and link
