### PR TITLE
Collection statistics

### DIFF
--- a/internal/data.go
+++ b/internal/data.go
@@ -123,7 +123,13 @@ func (x *TableData) CloneWithAttributesOnly(newRawData []byte) *TableData {
 		UpdatedAt:   x.UpdatedAt,
 		TotalChunks: x.TotalChunks,
 		RawData:     newRawData,
+		RawSize:     x.RawSize,
 	}
+}
+
+// Size of the payload field.
+func (x *TableData) Size() int32 {
+	return int32(len(x.RawData))
 }
 
 func (x *TableData) IsChunkedData() bool {

--- a/internal/data.proto
+++ b/internal/data.proto
@@ -35,6 +35,8 @@ message TableData {
   // raw_data is the raw bytes stored, caller controls how they want to store these raw bytes in database.
   bytes raw_data = 5;
   optional int32 total_chunks = 6;
+  int32 raw_size = 7;
+  optional int32 search_fields_size = 8;
 }
 
 // StreamData is used to store a serialized data that has user data, some Tigris metadata in Cache Stream. Some options

--- a/internal/data_test.go
+++ b/internal/data_test.go
@@ -33,6 +33,7 @@ func TestEncode_Decode(t *testing.T) {
 		data, err := Decode(encoded)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(d, data))
+		require.Equal(t, int32(20), data.Size())
 	})
 	t.Run("not_implemented", func(t *testing.T) {
 		data, err := Decode([]byte(`{"a": 1, "b": "foo"}`))
@@ -52,6 +53,7 @@ func TestEncode_Decode(t *testing.T) {
 		data, err := Decode(encoded)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(v, data))
+		require.Equal(t, int32(20), data.Size())
 	})
 
 	t.Run("decode_binc", func(t *testing.T) {
@@ -63,6 +65,7 @@ func TestEncode_Decode(t *testing.T) {
 		data, err := Decode(encoded)
 		require.NoError(t, err)
 		require.True(t, proto.Equal(d, data))
+		require.Equal(t, int32(20), data.Size())
 	})
 
 	t.Run("decode_proto", func(t *testing.T) {
@@ -101,12 +104,14 @@ func Benchmark_Encode(b *testing.B) {
 
 	bb := int32(7)
 	v := &TableData{
-		Ver:         23045,
-		Encoding:    3789,
-		CreatedAt:   tm1,
-		UpdatedAt:   tm2,
-		RawData:     []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
-		TotalChunks: &bb,
+		Ver:              23045,
+		Encoding:         3789,
+		CreatedAt:        tm1,
+		UpdatedAt:        tm2,
+		RawData:          []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
+		TotalChunks:      &bb,
+		RawSize:          43524354,
+		SearchFieldsSize: &bb,
 	}
 
 	b.Run("ugorji_binc", func(b *testing.B) {
@@ -118,6 +123,8 @@ func Benchmark_Encode(b *testing.B) {
 			_ = enc
 		}
 	})
+	// enc, _ := encodeInternal(v, TableDataType)
+	// fmt.Fprintf(os.Stderr, "Size: %v\n", len(enc))
 
 	b.Run("proto", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -141,14 +148,16 @@ func Benchmark_Decode(b *testing.B) {
 	tm1 := NewTimestamp()
 	tm2 := NewTimestamp()
 
-	bb := int32(7)
+	b1 := int32(34524)
 	v := &TableData{
-		Ver:         23045,
-		Encoding:    3789,
-		CreatedAt:   tm1,
-		UpdatedAt:   tm2,
-		RawData:     []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
-		TotalChunks: &bb,
+		Ver:              23045,
+		Encoding:         3789,
+		CreatedAt:        tm1,
+		UpdatedAt:        tm2,
+		RawData:          []byte("[s" + strings.Repeat("a", 1024*1024) + "e]"),
+		TotalChunks:      &b1,
+		RawSize:          43524354,
+		SearchFieldsSize: &b1,
 	}
 	enc, err := encodeInternal(v, TableDataType)
 	if err != nil {

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -295,7 +295,7 @@ var DefaultConfig = Config{
 		EnableNamespaceDeletion: false,
 		EnableNamespaceCreation: true,
 		UserInvitations: Invitation{
-			ExpireAfterSec: 259200, //3days
+			ExpireAfterSec: 259200, // 3days
 		},
 	},
 	Billing: Billing{

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1536,31 +1536,75 @@ func (tenant *Tenant) String() string {
 	return fmt.Sprintf("id: %d, name: %s", tenant.namespace.Id(), tenant.namespace.StrId())
 }
 
-// Size returns approximate data size on disk for all the collections, databases for this tenant.
-func (tenant *Tenant) Size(ctx context.Context) (int64, error) {
+func (tenant *Tenant) listEncCollName(db *Database) [][]byte {
+	colls := make([][]byte, 0, len(db.collections))
+	for _, v := range db.collections {
+		name, _ := tenant.Encoder.EncodeTableName(tenant.namespace, db, v.collection)
+		colls = append(colls, name)
+	}
+
+	return colls
+}
+
+func (tenant *Tenant) sumCollsSize(ctx context.Context, colls [][]byte) (*kv.TableStats, error) {
+	var sumStats kv.TableStats
+
+	for _, coll := range colls {
+		stats, err := tenant.kvStore.GetTableStats(ctx, coll)
+		if err != nil {
+			return nil, err
+		}
+
+		sumStats.StoredBytes += stats.StoredBytes
+		sumStats.OnDiskSize += stats.OnDiskSize
+		sumStats.RowCount += stats.RowCount
+	}
+
+	return &sumStats, nil
+}
+
+// Size returns exact data size on disk for all the collections, databases for this tenant.
+func (tenant *Tenant) Size(ctx context.Context) (*kv.TableStats, error) {
+	colls := make([][]byte, 0)
+
 	tenant.Lock()
-	nsName, _ := tenant.Encoder.EncodeTableName(tenant.namespace, nil, nil)
+	for _, v := range tenant.projects {
+		if v.database != nil {
+			colls = append(colls, tenant.listEncCollName(v.database)...)
+		}
+
+		for _, br := range v.databaseBranches {
+			colls = append(colls, tenant.listEncCollName(br)...)
+		}
+	}
 	tenant.Unlock()
 
-	return tenant.kvStore.TableSize(ctx, nsName)
+	return tenant.sumCollsSize(ctx, colls)
 }
 
 // DatabaseSize returns approximate data size on disk for all the database for this tenant.
-func (tenant *Tenant) DatabaseSize(ctx context.Context, db *Database) (int64, error) {
+func (tenant *Tenant) DatabaseSize(ctx context.Context, db *Database) (*kv.TableStats, error) {
+	var colls [][]byte
+
 	tenant.Lock()
-	nsName, _ := tenant.Encoder.EncodeTableName(tenant.namespace, db, nil)
+	colls = tenant.listEncCollName(db)
 	tenant.Unlock()
 
-	return tenant.kvStore.TableSize(ctx, nsName)
+	return tenant.sumCollsSize(ctx, colls)
 }
 
 // CollectionSize returns approximate data size on disk for all the collections for the database provided by the caller.
-func (tenant *Tenant) CollectionSize(ctx context.Context, db *Database, coll *schema.DefaultCollection) (int64, error) {
+func (tenant *Tenant) CollectionSize(ctx context.Context, db *Database, coll *schema.DefaultCollection) (*kv.TableStats, error) {
 	tenant.Lock()
 	nsName, _ := tenant.Encoder.EncodeTableName(tenant.namespace, db, coll)
 	tenant.Unlock()
 
-	return tenant.kvStore.TableSize(ctx, nsName)
+	stats, err := tenant.kvStore.GetTableStats(ctx, nsName)
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
 }
 
 type Project struct {

--- a/server/metadata/version_test.go
+++ b/server/metadata/version_test.go
@@ -28,7 +28,7 @@ func TestMetaVersion(t *testing.T) {
 	fdbCfg, err := config.GetTestFDBConfig("../..")
 	require.NoError(t, err)
 
-	kv, err := kv.NewTxStore(fdbCfg)
+	kv, err := kv.NewBuilder().Build(fdbCfg)
 	require.NoError(t, err)
 
 	t.Run("read versions", func(t *testing.T) {

--- a/server/quota/quota_test.go
+++ b/server/quota/quota_test.go
@@ -162,7 +162,7 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("failed to init FDB config: %v", err))
 	}
 
-	kvStore, err = kv.NewTxStore(fdbCfg)
+	kvStore, err = kv.NewBuilder().WithStats().Build(fdbCfg)
 	if err != nil {
 		panic(fmt.Sprintf("failed to init FDB KV %v", err))
 	}

--- a/server/quota/storage.go
+++ b/server/quota/storage.go
@@ -131,7 +131,7 @@ func getDbSize(ctx context.Context, tenant *metadata.Tenant, db *metadata.Databa
 	if err != nil {
 		ulog.E(err)
 	}
-	return dbSize
+	return dbSize.StoredBytes
 }
 
 func getCollSize(ctx context.Context, tenant *metadata.Tenant, db *metadata.Database, coll *schema.DefaultCollection) int64 {
@@ -139,7 +139,7 @@ func getCollSize(ctx context.Context, tenant *metadata.Tenant, db *metadata.Data
 	if err != nil {
 		ulog.E(err)
 	}
-	return collSize
+	return collSize.StoredBytes
 }
 
 func (s *storage) getTenantSize(ctx context.Context, namespace string) int64 {
@@ -147,9 +147,13 @@ func (s *storage) getTenantSize(ctx context.Context, namespace string) int64 {
 	if ulog.E(err) {
 		return 0
 	}
+
 	size, err := tenant.Size(ctx)
-	ulog.E(err)
-	return size
+	if ulog.E(err) {
+		return 0
+	}
+
+	return size.StoredBytes
 }
 
 func (s *storage) updateMetricsForNamespace(ctx context.Context, namespace string) {

--- a/server/services/v1/database/collection_runner.go
+++ b/server/services/v1/database/collection_runner.go
@@ -183,7 +183,7 @@ func (runner *CollectionQueryRunner) describe(ctx context.Context, tx transactio
 		namespace = "unknown"
 	}
 
-	metrics.UpdateCollectionSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), coll.GetName(), size)
+	metrics.UpdateCollectionSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), coll.GetName(), size.StoredBytes)
 	// remove indexing version from the schema before returning the response
 	sch := schema.RemoveIndexingVersion(coll.Schema)
 
@@ -200,7 +200,7 @@ func (runner *CollectionQueryRunner) describe(ctx context.Context, tx transactio
 			Collection: coll.Name,
 			Metadata:   &api.CollectionMetadata{},
 			Schema:     sch,
-			Size:       size,
+			Size:       size.StoredBytes,
 			Indexes:    runner.indexToCollectionIndex(coll.SecondaryIndexes.All),
 		},
 	}, ctx, nil

--- a/server/services/v1/database/database_runner.go
+++ b/server/services/v1/database/database_runner.go
@@ -123,7 +123,7 @@ func (runner *ProjectQueryRunner) describe(ctx context.Context, tx transaction.T
 			return Response{}, ctx, err
 		}
 
-		metrics.UpdateCollectionSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), c.GetName(), size)
+		metrics.UpdateCollectionSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), c.GetName(), size.StoredBytes)
 
 		// remove indexing version from the schema before returning the response
 		sch := schema.RemoveIndexingVersion(c.Schema)
@@ -140,7 +140,7 @@ func (runner *ProjectQueryRunner) describe(ctx context.Context, tx transaction.T
 			Collection: c.GetName(),
 			Metadata:   &api.CollectionMetadata{},
 			Schema:     sch,
-			Size:       size,
+			Size:       size.StoredBytes,
 		}
 	}
 
@@ -149,13 +149,13 @@ func (runner *ProjectQueryRunner) describe(ctx context.Context, tx transaction.T
 		return Response{}, ctx, err
 	}
 
-	metrics.UpdateDbSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), size)
+	metrics.UpdateDbSizeMetrics(namespace, tenantName, db.DbName(), db.BranchName(), size.StoredBytes)
 
 	return Response{
 		Response: &api.DescribeDatabaseResponse{
 			Metadata:    &api.DatabaseMetadata{},
 			Collections: collections,
-			Size:        size,
+			Size:        size.StoredBytes,
 			Branches:    tenant.ListDatabaseBranches(runner.describeReq.GetProject()),
 		},
 	}, ctx, nil

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -260,6 +260,8 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		newData.SetVersion(coll.GetVersion())
 		// as we have merged the data, it is safe to call replace
 
+		szCtx := kv.CtxWithSize(ctx, row.Data.Size())
+
 		isUpdate := true
 		newKey := key
 		if primaryKeyMutation {
@@ -270,10 +272,15 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 			}
 
 			// deleteReq old key
-			if err = tx.Delete(ctx, key); ulog.E(err) {
+			if err = tx.Delete(szCtx, key); ulog.E(err) {
 				return Response{}, ctx, err
 			}
 			isUpdate = false
+
+			// clear size from the context, so as we subtracted the size
+			// in the delete above.
+			// if new key exist its value size will be subtracted in the replace below
+			szCtx = ctx
 
 			if config.DefaultConfig.SecondaryIndex.WriteEnabled {
 				if err := indexer.Delete(ctx, tx, row.Data, key.IndexParts()); ulog.E(err) {
@@ -288,7 +295,8 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 				return Response{}, ctx, err
 			}
 		}
-		if err = tx.Replace(ctx, newKey, newData, isUpdate); ulog.E(err) {
+
+		if err = tx.Replace(szCtx, newKey, newData, isUpdate); ulog.E(err) {
 			return Response{}, ctx, err
 		}
 	}
@@ -364,7 +372,7 @@ func (runner *DeleteQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 			return Response{}, ctx, err
 		}
 		if reqStatusFound {
-			reqStatus.AddWriteBytes(int64(len(row.Data.RawData)))
+			reqStatus.AddWriteBytes(int64(row.Data.Size()))
 		}
 
 		if config.DefaultConfig.SecondaryIndex.WriteEnabled {
@@ -373,6 +381,8 @@ func (runner *DeleteQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 				return Response{}, ctx, err
 			}
 		}
+
+		ctx = kv.CtxWithSize(ctx, row.Data.Size())
 
 		if err = tx.Delete(ctx, key); ulog.E(err) {
 			return Response{}, ctx, err
@@ -814,7 +824,7 @@ type ExplainQueryRunner struct {
 	req *api.ReadRequest
 }
 
-func (runner *ExplainQueryRunner) Run(ctx context.Context, tx transaction.Tx, tenant *metadata.Tenant) (Response, context.Context, error) {
+func (runner *ExplainQueryRunner) Run(ctx context.Context, _ transaction.Tx, tenant *metadata.Tenant) (Response, context.Context, error) {
 	db, err := runner.getDatabase(ctx, nil, tenant, runner.req.GetProject(), runner.req.GetBranch())
 	if err != nil {
 		return Response{}, ctx, err

--- a/server/services/v1/database/search_indexer.go
+++ b/server/services/v1/database/search_indexer.go
@@ -60,7 +60,8 @@ func (i *SearchIndexer) OnPostCommit(ctx context.Context, tenant *metadata.Tenan
 		}
 
 		collection := db.GetCollection(collName)
-		if collection == nil {
+		if collection == nil || event.Key == nil {
+			// event.Key == nil if event comes from drop table
 			continue
 		}
 

--- a/server/services/v1/database/secondary_index_measure.go
+++ b/server/services/v1/database/secondary_index_measure.go
@@ -71,9 +71,9 @@ func (m *secondaryIndexerWithMetrics) BuildCollection(ctx context.Context, txMgr
 	return
 }
 
-func (m *secondaryIndexerWithMetrics) ReadDocAndDelete(ctx context.Context, tx transaction.Tx, key keys.Key) (err error) {
+func (m *secondaryIndexerWithMetrics) ReadDocAndDelete(ctx context.Context, tx transaction.Tx, key keys.Key) (size int32, err error) {
 	m.measure(ctx, "ReadDocAndDelete", func(ctx context.Context) error {
-		err = m.q.ReadDocAndDelete(ctx, tx, key)
+		size, err = m.q.ReadDocAndDelete(ctx, tx, key)
 		return err
 	})
 	return

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -839,7 +839,7 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("failed to init FDB config: %v", err))
 	}
 
-	kvStore, err = kv.NewTxStore(fdbCfg)
+	kvStore, err = kv.NewBuilder().Build(fdbCfg)
 	if err != nil {
 		panic(fmt.Sprintf("failed to init FDB KV %v", err))
 	}

--- a/server/services/v1/management.go
+++ b/server/services/v1/management.go
@@ -307,7 +307,7 @@ func (m *managementService) getNameSpaceDetails(ctx context.Context, namespaceId
 					}
 					res[nsName][db.Name()][coll.Name] = map[string]string{
 						"schema": string(coll.Schema),
-						"size":   strconv.FormatInt(size, 10),
+						"size":   strconv.FormatInt(size.StoredBytes, 10),
 					}
 				}
 			}

--- a/server/services/v1/observability.go
+++ b/server/services/v1/observability.go
@@ -144,7 +144,7 @@ func (dd *Datadog) QueryQuotaUsage(ctx context.Context, _ *api.QuotaUsageRequest
 	return &api.QuotaUsageResponse{
 		ReadUnits:            ru,
 		WriteUnits:           wu,
-		StorageSize:          size,
+		StorageSize:          size.StoredBytes,
 		ReadUnitsThrottled:   rt,
 		WriteUnitsThrottled:  wt,
 		StorageSizeThrottled: st,

--- a/server/transaction/manager.go
+++ b/server/transaction/manager.go
@@ -279,10 +279,10 @@ func (s *TxSession) Get(ctx context.Context, key []byte, isSnapshot bool) (kv.Fu
 		return nil, err
 	}
 
-	return s.kTx.Get(ctx, key, isSnapshot)
+	return s.kTx.Get(ctx, key, isSnapshot), nil
 }
 
-func (s *TxSession) RangeSize(ctx context.Context, table []byte, lKey keys.Key, rKey keys.Key) (size int64, err error) {
+func (s *TxSession) RangeSize(ctx context.Context, _ []byte, lKey keys.Key, rKey keys.Key) (size int64, err error) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/store/kv/atomic.go
+++ b/store/kv/atomic.go
@@ -1,0 +1,125 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"math/rand"
+)
+
+const (
+	NumShards             = 128
+	AtomicSuffixSeparator = "__A__"
+)
+
+// shard is 128 static shards, which is randomly picked on AtomicAdd.
+// the adea is to spread the FDB range where the shard belongs to
+// prevent bottlenecks.
+// This array can be extended.
+// On shrink or shard name change the persisted atomic values will be lost.
+var shards = [NumShards]string{
+	"v27t99NE", "P1NW61m2", "6jDXBKFu", "kGlzr2YZ", "8N31iXRR", "41NCAyEC", "ZJ90gTMg", "WIsa8zCq",
+	"CLGKcl5i", "4ZHWtEAe", "3iGtcUpy", "ppYwe1Fi", "TteDP1bw", "dAcG3AI5", "pjvzomB1", "I6XeWQtn",
+	"gE4DRqoK", "4jM4TLnE", "gQeTa2Ec", "rWWF3VZB", "YBM6ZB4E", "cJoxa0PW", "4zXkxmDQ", "WgdP4lOO",
+	"92SPlusc", "6NTcBua7", "BIA6fWqY", "gGJ15hZl", "UEn2VCBk", "d02XVPU2", "wg7GraYU", "Yy92rvaM",
+	"ZRcI7b3A", "hJh9aDzw", "KihwT4uy", "IEZc8Ic9", "Z3LqgCq0", "KOh9gCFF", "XN4vuSdD", "lppjSm39",
+	"zvbS9RU8", "Ci6WaGxE", "VDCe1ibQ", "vHCI95EV", "Q71oCbx0", "20Syn9nj", "sjIV7g5i", "ekc1uMV7",
+	"yYY6WxTz", "ASUM9e92", "TNGarTZ1", "bAKHsd33", "ea3ASCCj", "biIHW7rR", "0khDWXcr", "55mHHuIW",
+	"CsBb5sQ8", "NL0sT4eG", "GsVpHY9r", "PFBDiJh1", "bftO0a6b", "pJSSa8tQ", "wK4dE1Q9", "hMS8tvZ1",
+	"NO8JlTXF", "lbCJ4iON", "0LhbRdAs", "0MIPe4io", "lI2SaPkc", "NfNhD0W5", "tDAI0ceM", "aZcm7YD0",
+	"3Qies3KR", "0lRQv54p", "wB16FMTA", "aH0FtNPi", "DI8rzxLa", "s0iRRhXF", "krAFA2UH", "RpMe37pr",
+	"IKC6aRKe", "A9guqMUq", "v7nMGu7n", "bSKx6v1Y", "1bweYimp", "LG5PYwGF", "04Cqnpq9", "wGvPK3xB",
+	"uaFn14Kr", "qsLOZD92", "T2E77luL", "AJM5bpBF", "b6mXdEun", "yRa8Fymz", "HvFZn23A", "2WRTn04W",
+	"I6No0Mul", "D0aDhAo7", "Npop1exp", "dZ7Y2Y21", "eI4RaafH", "2CssCr3u", "Qd26If0b", "8ANvmMP0",
+	"OFcVe9NQ", "s8gQAXxO", "5Ro1b6FV", "fXDjw5S6", "mucDn1wF", "9R2vQO08", "l9Q0wrbT", "3CMNRxlH",
+	"PBrW8Vbc", "3v5OjTCI", "Thk72J6h", "usONXhh5", "lxz0ATU7", "7WJAbBsK", "snql1Fi7", "fuP2GdMh",
+	"edp3m6Qb", "Q7J43hw7", "90gn2rZY", "r0nLAtu5", "Q5bnj2VI", "QmenpTx0", "6gImYfts", "kr1TE8OD",
+}
+
+type ShardedAtomics interface {
+	AtomicAddTx(ctx context.Context, tx Tx, table []byte, key Key, value int64) error
+	AtomicReadTx(ctx context.Context, tx Tx, table []byte, key Key) (int64, error)
+	AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error
+	AtomicRead(ctx context.Context, table []byte, key Key) (int64, error)
+}
+
+type shardedAtomics struct {
+	kv        TxStore
+	numShards int
+}
+
+func NewShardedAtomics(kv TxStore) ShardedAtomics {
+	return &shardedAtomics{
+		numShards: NumShards,
+		kv:        kv,
+	}
+}
+
+// AtomicAddTx applies increment to random shard in the transaction.
+func (s *shardedAtomics) AtomicAddTx(ctx context.Context, tx Tx, table []byte, key Key, inc int64) error {
+	n := rand.Intn(s.numShards) //nolint:gosec
+
+	key = append(key, AtomicSuffixSeparator)
+	key = append(key, shards[n])
+
+	return tx.AtomicAdd(ctx, table, key, inc)
+}
+
+// AtomicReadTx calculates the value by summing all the shards in the transaction.
+func (s *shardedAtomics) AtomicReadTx(ctx context.Context, tx Tx, table []byte, key Key) (int64, error) {
+	it, err := tx.AtomicReadPrefix(ctx, table, key, true)
+	if err != nil {
+		return 0, err
+	}
+
+	var sum int64
+
+	var kv FdbBaseKeyValue[int64]
+	for it.Next(&kv) {
+		sum += kv.Data
+	}
+
+	if it.Err() != nil {
+		return 0, it.Err()
+	}
+
+	return sum, nil
+}
+
+// AtomicAdd applies increment to random shard in the transaction.
+func (s *shardedAtomics) AtomicAdd(ctx context.Context, table []byte, key Key, inc int64) error {
+	tx, err := s.kv.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := s.AtomicAddTx(ctx, tx, table, key, inc); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// AtomicRead calculates the value by summing all the shards in the transaction.
+func (s *shardedAtomics) AtomicRead(ctx context.Context, table []byte, key Key) (int64, error) {
+	tx, err := s.kv.BeginTx(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	return s.AtomicReadTx(ctx, tx, table, key)
+}

--- a/store/kv/atomic_test.go
+++ b/store/kv/atomic_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+func TestShardedAtomics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cfg, err := config.GetTestFDBConfig("../..")
+	require.NoError(t, err)
+
+	bkv, err := newFoundationDB(cfg)
+	require.NoError(t, err)
+
+	kv := NewTxStore(bkv)
+
+	sa := NewShardedAtomics(kv)
+
+	testTable := []byte(`atomic_test_table`)
+	testKey := BuildKey("atomic_test_key")
+
+	err = bkv.Delete(ctx, testTable, testKey)
+	require.NoError(t, err)
+
+	err = sa.AtomicAdd(ctx, testTable, testKey, 10)
+	require.NoError(t, err)
+
+	err = sa.AtomicAdd(ctx, testTable, testKey, 100)
+	require.NoError(t, err)
+
+	err = sa.AtomicAdd(ctx, testTable, testKey, -20)
+	require.NoError(t, err)
+
+	val, err := sa.AtomicRead(ctx, testTable, testKey)
+	require.NoError(t, err)
+	assert.Equal(t, int64(90), val)
+
+	testKey.AddPart("composite").AddPart(123)
+
+	err = bkv.Delete(ctx, testTable, testKey)
+	require.NoError(t, err)
+
+	err = sa.AtomicAdd(ctx, testTable, testKey, 100000)
+	require.NoError(t, err)
+
+	err = sa.AtomicAdd(ctx, testTable, testKey, -2000)
+	require.NoError(t, err)
+
+	val, err = sa.AtomicRead(ctx, testTable, testKey)
+	require.NoError(t, err)
+	assert.Equal(t, int64(98000), val)
+}

--- a/store/kv/base.go
+++ b/store/kv/base.go
@@ -16,7 +16,11 @@ package kv
 
 import (
 	"context"
+
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )
+
+type Future = fdb.FutureByteSlice
 
 type baseKeyValue struct {
 	Key    Key
@@ -28,10 +32,11 @@ type baseKV interface {
 	Insert(ctx context.Context, table []byte, key Key, data []byte) error
 	Replace(ctx context.Context, table []byte, key Key, data []byte, isUpdate bool) error
 	Delete(ctx context.Context, table []byte, key Key) error
-	Read(ctx context.Context, table []byte, key Key) (baseIterator, error)
+	Read(ctx context.Context, table []byte, key Key, isSnapshot bool) (baseIterator, error)
 	ReadRange(ctx context.Context, table []byte, lkey Key, rkey Key, isSnapshot bool) (baseIterator, error)
+	SetVersionstampedKey(_ context.Context, key []byte, value []byte) error
 	SetVersionstampedValue(ctx context.Context, key []byte, value []byte) error
-	Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error)
+	Get(ctx context.Context, key []byte, isSnapshot bool) Future
 	AtomicAdd(ctx context.Context, table []byte, key Key, value int64) error
 	AtomicRead(ctx context.Context, table []byte, key Key) (int64, error)
 	AtomicReadRange(ctx context.Context, table []byte, lkey Key, rkey Key, isSnapshot bool) (AtomicIterator, error)
@@ -54,4 +59,5 @@ type baseKVStore interface {
 	BeginTx(ctx context.Context) (baseTx, error)
 	CreateTable(ctx context.Context, name []byte) error
 	DropTable(ctx context.Context, name []byte) error
+	TableSize(ctx context.Context, name []byte) (int64, error)
 }

--- a/store/kv/chunk_test.go
+++ b/store/kv/chunk_test.go
@@ -37,8 +37,7 @@ func TestChunkStore(t *testing.T) {
 	require.NoError(t, kv.DropTable(ctx, table))
 	require.NoError(t, kv.CreateTable(ctx, table))
 
-	store, err := NewTxStore(cfg)
-	require.NoError(t, err)
+	store := NewTxStore(kv)
 
 	chunkStore := NewChunkStore(store)
 

--- a/store/kv/errors.go
+++ b/store/kv/errors.go
@@ -32,6 +32,7 @@ const (
 	ErrCodeTransactionNotCommitted StoreErrCode = 0x05
 	ErrCodeValueSizeExceeded       StoreErrCode = 0x06
 	ErrCodeTransactionSizeExceeded StoreErrCode = 0x07
+	ErrCodeNotFound                StoreErrCode = 0x08
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 	ErrTransactionNotCommitted = NewStoreError(1021, ErrCodeTransactionNotCommitted, "transaction may or may not have committed")
 	ErrValueSizeExceeded       = NewStoreError(2103, ErrCodeValueSizeExceeded, "document exceeds limit")
 	ErrTransactionSizeExceeded = NewStoreError(2101, ErrCodeTransactionSizeExceeded, "transaction exceeds limit")
+	ErrNotFound                = NewStoreError(0, ErrCodeNotFound, "not found")
 )
 
 type StoreError struct {

--- a/store/kv/kv_test.go
+++ b/store/kv/kv_test.go
@@ -332,7 +332,7 @@ func testKVBasic(t *testing.T, kv baseKVStore) {
 	}
 
 	// read individual record
-	it, err := kv.Read(ctx, table, BuildKey("p1", 2))
+	it, err := kv.Read(ctx, table, BuildKey("p1", 2), false)
 	require.NoError(t, err)
 
 	v := readAll(t, it)
@@ -342,7 +342,7 @@ func testKVBasic(t *testing.T, kv baseKVStore) {
 	err = kv.Replace(ctx, table, BuildKey("p1", 2), []byte("value2+2"), false)
 	require.NoError(t, err)
 
-	it, err = kv.Read(ctx, table, BuildKey("p1", 2))
+	it, err = kv.Read(ctx, table, BuildKey("p1", 2), false)
 	require.NoError(t, err)
 
 	v = readAll(t, it)
@@ -359,7 +359,7 @@ func testKVBasic(t *testing.T, kv baseKVStore) {
 	}, v)
 
 	// prefix read
-	it, err = kv.Read(ctx, table, BuildKey("p1"))
+	it, err = kv.Read(ctx, table, BuildKey("p1"), false)
 	require.NoError(t, err)
 
 	v = readAll(t, it)
@@ -413,7 +413,7 @@ func testFullScan(t *testing.T, kv baseKVStore) {
 	}
 
 	// prefix read
-	it, err := kv.Read(ctx, table, nil)
+	it, err := kv.Read(ctx, table, nil, false)
 	require.NoError(t, err)
 
 	v := readAll(t, it)
@@ -483,7 +483,7 @@ func testKVInsert(t *testing.T, kv baseKVStore) {
 				}
 			}
 			for _, i := range v.result {
-				it, err := kv.Read(context.Background(), table, i.Key)
+				it, err := kv.Read(context.Background(), table, i.Key, false)
 				require.NoError(t, err)
 				var res baseKeyValue
 				require.True(t, it.Next(&res))
@@ -557,7 +557,7 @@ func testFDBKVIterator(t *testing.T, kv baseKVStore) {
 		require.NoError(t, err)
 	}
 
-	it, err := kv.Read(ctx, table, nil)
+	it, err := kv.Read(ctx, table, nil, false)
 	require.NoError(t, err)
 
 	ic, ok := it.(*fdbIteratorTxCloser)
@@ -669,11 +669,10 @@ func TestKVFDB(t *testing.T) {
 	cfg, err := config.GetTestFDBConfig("../..")
 	require.NoError(t, err)
 
-	kvStore, err := NewTxStore(cfg)
-	require.NoError(t, err)
-
 	kv, err := newFoundationDB(cfg)
 	require.NoError(t, err)
+
+	kvStore := NewTxStore(kv)
 
 	t.Run("TestKVFBench", func(t *testing.T) {
 		benchKV(t, kv)
@@ -723,6 +722,6 @@ func TestGetCtxTimeout(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	ulog.Configure(ulog.LogConfig{Level: "disabled"})
+	ulog.Configure(ulog.LogConfig{Level: "disabled", Format: "console"})
 	os.Exit(m.Run())
 }

--- a/store/kv/noop_store.go
+++ b/store/kv/noop_store.go
@@ -50,6 +50,10 @@ func (n *NoopKVStore) DropTable(_ context.Context, _ []byte) error          { re
 func (n *NoopKVStore) GetInternalDatabase() (interface{}, error)            { return nil, nil }
 func (n *NoopKVStore) TableSize(_ context.Context, _ []byte) (int64, error) { return 0, nil }
 
+func (n *NoopKVStore) GetTableStats(ctx context.Context, table []byte) (*TableStats, error) {
+	return &TableStats{}, nil
+}
+
 type NoopKV struct{}
 
 func (n *NoopKV) Insert(ctx context.Context, table []byte, key Key, data *internal.TableData) error {
@@ -88,8 +92,16 @@ func (n *NoopKV) AtomicReadRange(ctx context.Context, table []byte, lkey Key, rk
 	return &NoopFDBTypeIterator{}, nil
 }
 
-func (n *NoopKV) Get(ctx context.Context, key []byte, isSnapshot bool) (Future, error) {
-	return nil, nil
+func (n *NoopKV) AtomicReadPrefix(ctx context.Context, table []byte, key Key, isSnapshot bool) (AtomicIterator, error) {
+	return &NoopFDBTypeIterator{}, nil
+}
+
+func (n *NoopKV) Get(ctx context.Context, key []byte, isSnapshot bool) Future {
+	return nil
+}
+
+func (n *NoopKV) GetMetadata(ctx context.Context, table []byte, key Key) (*internal.TableData, error) {
+	return &internal.TableData{}, nil
 }
 
 func (n *NoopKV) RangeSize(ctx context.Context, table []byte, lkey Key, rkey Key) (int64, error) {

--- a/store/kv/stats.go
+++ b/store/kv/stats.go
@@ -1,0 +1,210 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/tigrisdata/tigris/internal"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+const (
+	StatsSizeKey     = "size"
+	StatsRowCountKey = "count"
+
+	StatsSearchFieldsKey = "search_size"
+)
+
+var StatsTable = []byte("stats")
+
+type (
+	CtxValueSize  struct{}
+	CtxSearchSize struct{}
+)
+
+type StatsTxStore struct {
+	TxStore
+	sa ShardedAtomics
+}
+
+func NewStatsStore(store TxStore) TxStore {
+	return &StatsTxStore{TxStore: store, sa: NewShardedAtomics(store)}
+}
+
+func (store *StatsTxStore) BeginTx(ctx context.Context) (Tx, error) {
+	btx, err := store.TxStore.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StatsTx{
+		Tx: btx,
+		sa: store.sa,
+	}, nil
+}
+
+func (store *StatsTxStore) DropTable(ctx context.Context, name []byte) error {
+	tx, err := store.TxStore.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err = tx.Delete(ctx, name, nil); err != nil {
+		return err
+	}
+
+	if err = tx.Delete(ctx, StatsTable, BuildKey(name)); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (store *StatsTxStore) GetTableStats(ctx context.Context, table []byte) (*TableStats, error) {
+	stats, err := store.TxStore.GetTableStats(ctx, table)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := store.TxStore.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	stats.RowCount, err = store.sa.AtomicReadTx(ctx, tx, StatsTable, BuildKey(table, StatsRowCountKey))
+	if err != nil {
+		return nil, err
+	}
+
+	stats.StoredBytes, err = store.sa.AtomicReadTx(ctx, tx, StatsTable, BuildKey(table, StatsSizeKey))
+	if err != nil {
+		return nil, err
+	}
+
+	stats.SearchFieldsSize, err = store.sa.AtomicReadTx(ctx, tx, StatsTable, BuildKey(table, StatsSearchFieldsKey))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Temporary. Used to restore statistics for existing collections.
+	// TODO: Can be removed for all new installations or after it run at least once
+	// TODO: for every existing collection.
+	if stats.RowCount == 0 && stats.StoredBytes == 0 {
+		stats.StoredBytes = stats.OnDiskSize
+		err = store.sa.AtomicAdd(ctx, StatsTable, BuildKey(table, StatsSizeKey), stats.OnDiskSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return stats, nil
+}
+
+type StatsTx struct {
+	Tx
+	sa ShardedAtomics
+}
+
+func (tx *StatsTx) Insert(ctx context.Context, table []byte, key Key, data *internal.TableData) error {
+	data.RawSize = data.Size()
+
+	if err := tx.Tx.Insert(ctx, table, key, data); err != nil {
+		return err
+	}
+
+	if err := tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsRowCountKey), 1); err != nil {
+		return err
+	}
+
+	return tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsSizeKey), int64(data.RawSize))
+}
+
+func (tx *StatsTx) Replace(ctx context.Context, table []byte, key Key, data *internal.TableData, isUpdate bool) error {
+	data.RawSize = data.Size()
+
+	prevSize := GetSizeFromCtx(ctx)
+	// do not read from disk if value is known and set in the data parameter
+	if prevSize == 0 {
+		prev, err := tx.GetMetadata(ctx, table, key)
+		switch {
+		case err == nil:
+			prevSize = prev.RawSize
+		case err == ErrNotFound:
+			// adding new row
+			if err := tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsRowCountKey), 1); err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+	}
+
+	if err := tx.Tx.Replace(ctx, table, key, data, isUpdate); err != nil {
+		return err
+	}
+
+	return tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsSizeKey), int64(data.RawSize-prevSize))
+}
+
+func (tx *StatsTx) Delete(ctx context.Context, table []byte, key Key) error {
+	prevSize := GetSizeFromCtx(ctx)
+	if prevSize == 0 {
+		prev, err := tx.GetMetadata(ctx, table, key)
+		switch {
+		case err == nil:
+			prevSize = prev.RawSize
+		case err == ErrNotFound:
+			return tx.Tx.Delete(ctx, table, key) // try prefix delete
+		default:
+			return err
+		}
+	}
+
+	if err := tx.Tx.Delete(ctx, table, key); err != nil {
+		return err
+	}
+
+	if err := tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsRowCountKey), -1); err != nil {
+		return err
+	}
+
+	return tx.sa.AtomicAddTx(ctx, tx, StatsTable, BuildKey(table, StatsSizeKey), int64(-prevSize))
+}
+
+func GetSizeFromCtx(ctx context.Context) int32 {
+	if v := ctx.Value(CtxValueSize{}); v != nil {
+		if vv, ok := v.(int32); ok {
+			return vv
+		}
+
+		if vv, ok := v.(int); ok {
+			return int32(vv)
+		}
+
+		_ = ulog.CE("unexpected ctx value %v", reflect.TypeOf(v))
+	}
+
+	return 0
+}
+
+func CtxWithSize(ctx context.Context, size int32) context.Context {
+	return context.WithValue(ctx, CtxValueSize{}, size)
+}

--- a/store/kv/stats_test.go
+++ b/store/kv/stats_test.go
@@ -1,0 +1,130 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
+)
+
+func checkStats(t *testing.T, ctx context.Context, table []byte, store TxStore, sb int64, rc int64) {
+	stats, err := store.GetTableStats(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, sb, stats.StoredBytes)
+	require.Equal(t, rc, stats.RowCount)
+}
+
+func tx(t *testing.T, ctx context.Context, s TxStore, fn func(tx Tx)) {
+	tx, err := s.BeginTx(ctx)
+	require.NoError(t, err)
+
+	fn(tx)
+
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+}
+
+func TestStatsStore(t *testing.T) {
+	cfg, err := config.GetTestFDBConfig("../..")
+	require.NoError(t, err)
+
+	kv, err := newFoundationDB(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Second)
+	defer cancel()
+
+	store := NewTxStore(kv)
+
+	statsStore := NewStatsStore(store)
+
+	table := []byte("t1")
+	require.NoError(t, statsStore.DropTable(ctx, table))
+	require.NoError(t, kv.CreateTable(ctx, table))
+
+	checkStats(t, ctx, table, statsStore, 0, 0)
+
+	payload23 := strings.Repeat("a", 23)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		// insert data 23 bytes long
+		err = tx.Insert(ctx, table, BuildKey("p1_", 1), &internal.TableData{RawData: []byte(payload23)})
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 23, 1)
+
+	payload37 := strings.Repeat("a", 37)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		// increase size to 37
+		err = tx.Replace(ctx, table, BuildKey("p1_", 1), &internal.TableData{RawData: []byte(payload37)}, false)
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 37, 1)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		// decrease size back to 23
+		err = tx.Replace(ctx, table, BuildKey("p1_", 1), &internal.TableData{RawData: []byte(payload23)}, false)
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 23, 1)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		// insert another row. 37 bytes long
+		err = tx.Replace(ctx, table, BuildKey("p2_", 1), &internal.TableData{RawData: []byte(payload37)}, false)
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 60, 2)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		err = tx.Delete(ctx, table, BuildKey("pnon_existing", 1))
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 60, 2)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		err = tx.Delete(ctx, table, BuildKey("p2_", 1))
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 23, 1)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		// existing value size is passed in the context
+		// results is 23-5+23
+		err = tx.Replace(context.WithValue(ctx, CtxValueSize{}, 5), table, BuildKey("p1_", 1), &internal.TableData{RawData: []byte(payload23)}, false)
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 41, 1)
+
+	tx(t, ctx, statsStore, func(tx Tx) {
+		err = tx.Delete(context.WithValue(ctx, CtxValueSize{}, 5), table, BuildKey("p2_", 1))
+		require.NoError(t, err)
+	})
+
+	checkStats(t, ctx, table, statsStore, 36, 0)
+}

--- a/test/v1/server/integration_test.go
+++ b/test/v1/server/integration_test.go
@@ -310,10 +310,10 @@ func createTestCollection(t *testing.T, database string, collection string, sche
 	createCollection(t, database, collection, schema).Status(http.StatusOK)
 }
 
-func describeCollection(t *testing.T, database string, collection string, schema map[string]interface{}) *httpexpect.Response {
+func describeCollection(t *testing.T, database string, collection string, body map[string]interface{}) *httpexpect.Response {
 	e := expect(t)
 	return e.POST(getCollectionURL(database, collection, "describe")).
-		WithJSON(schema).
+		WithJSON(body).
 		Expect()
 }
 


### PR DESCRIPTION
This replaces collection size calculation using FDB range size estimation,
by exact transactional accounting using atomics.

  * Sharded atomics with 128 static shards
  * Statistics KV layer, puts statistics to "stats" KV table with key equal to user "table" + statistic name (size or row count)
  * For existing tables overwrites size with on disk FDB size.
  * Size can be passed in ctx to stats layer to avoid read modify write. (so as we already reading the value in most of the places)
  * Collection, DB and namespace size API now returns an object with statistics instead of int64.
  * Valid statistics fields: StoredBytes, OnDiskSize, RowCount

TODO: Inline search fields statistics is not calculated.