### PR TITLE
fix: `recordTimerDuration` not started for metronome metrics

### DIFF
--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -338,7 +338,7 @@ func (m *Measurement) RecordDuration(scope tally.Scope, tags map[string]string) 
 	case SearchRespTime, SearchErrorRespTime:
 		timerEnabled = cfg.Search.Timer.TimerEnabled
 		histogramEnabled = cfg.Search.Timer.HistogramEnabled
-	case MetronomeLatency:
+	case MetronomeCreateAccount, MetronomeAddPlan, MetronomeIngest, MetronomeGetInvoice, MetronomeListInvoices:
 		timerEnabled = true
 	}
 	if scope != nil && timerEnabled {

--- a/server/metrics/metronome.go
+++ b/server/metrics/metronome.go
@@ -14,24 +14,42 @@
 
 package metrics
 
-import "github.com/uber-go/tally"
+import (
+	"strconv"
+
+	"github.com/uber-go/tally"
+)
 
 var (
-	MetronomeResponseCode tally.Scope
-	MetronomeLatency      tally.Scope
-	MetronomeErrors       tally.Scope
-	MetronomeEvents       tally.Scope
+	MetronomeCreateAccount tally.Scope
+	MetronomeAddPlan       tally.Scope
+	MetronomeIngest        tally.Scope
+	MetronomeListInvoices  tally.Scope
+	MetronomeGetInvoice    tally.Scope
 )
 
 func initializeMetronomeScopes() {
-	MetronomeResponseCode = MetronomeMetrics.SubScope("response_code")
-	MetronomeLatency = MetronomeMetrics.SubScope("latency")
-	MetronomeErrors = MetronomeMetrics.SubScope("errors")
-	MetronomeEvents = MetronomeMetrics.SubScope("events")
+	MetronomeCreateAccount = MetronomeMetrics.SubScope("create_account")
+	MetronomeAddPlan = MetronomeMetrics.SubScope("add_plan")
+	MetronomeIngest = MetronomeMetrics.SubScope("ingest")
+	MetronomeListInvoices = MetronomeMetrics.SubScope("list_invoices")
+	MetronomeGetInvoice = MetronomeMetrics.SubScope("get_invoice")
 }
 
-func GetMetronomeTags(operation string) map[string]string {
+func GetResponseCodeTags(code int) map[string]string {
 	return map[string]string{
-		"operation": operation,
+		"response_code": strconv.Itoa(code),
+	}
+}
+
+func GetErrorCodeTags(err error) map[string]string {
+	return map[string]string{
+		"error_value": err.Error(),
+	}
+}
+
+func GetIngestEventTags(eventType string) map[string]string {
+	return map[string]string{
+		"event_type": eventType,
 	}
 }

--- a/server/metrics/metronome_test.go
+++ b/server/metrics/metronome_test.go
@@ -21,8 +21,8 @@ import (
 func TestMetronomeMetrics(t *testing.T) {
 	InitializeMetrics()
 	t.Run("Increment metronome counter", func(t *testing.T) {
-		tags := GetMetronomeTags("createAccount")
-		MetronomeResponseCode.Tagged(tags).Counter("200").Inc(1)
-		MetronomeErrors.Tagged(tags).Counter("timeout").Inc(1)
+		tags := GetResponseCodeTags(500)
+		MetronomeListInvoices.Tagged(tags).Counter("request").Inc(1)
+		MetronomeGetInvoice.Tagged(tags).Counter("error").Inc(1)
 	})
 }

--- a/server/services/v1/billing/metronome_test.go
+++ b/server/services/v1/billing/metronome_test.go
@@ -710,8 +710,9 @@ func TestMetronome_buildInvoice(t *testing.T) {
 }
 
 func initializeMetricsForTest() {
-	metrics.MetronomeResponseCode = tally.NewTestScope("resp", map[string]string{})
-	metrics.MetronomeErrors = tally.NewTestScope("errors", map[string]string{})
-	metrics.MetronomeLatency = tally.NewTestScope("latency", map[string]string{})
-	metrics.MetronomeEvents = tally.NewTestScope("latency", map[string]string{})
+	metrics.MetronomeCreateAccount = tally.NewTestScope("create_account", map[string]string{})
+	metrics.MetronomeAddPlan = tally.NewTestScope("add_plan", map[string]string{})
+	metrics.MetronomeIngest = tally.NewTestScope("ingest", map[string]string{})
+	metrics.MetronomeListInvoices = tally.NewTestScope("list_invoices", map[string]string{})
+	metrics.MetronomeGetInvoice = tally.NewTestScope("get_invoice", map[string]string{})
 }


### PR DESCRIPTION
## Describe your changes
- restructuring metronome metrics for efficient querying
- fixing `recordTimerDuration` bug where tracing was not started before recording duration

## How best to test these changes
- Unit tests

## Issue ticket number and link
