### PR TITLE
fix: EQ KeyBuilder ignoring EQ fields

### DIFF
--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -230,10 +230,11 @@ func (s *StrictEqKeyComposer[F]) Compose(selectors []*Selector, userDefinedKeys 
 	for _, k := range userDefinedKeys {
 		var repeatedFields []*Selector
 		for _, sel := range selectors {
-			if k.Name() == sel.Field.Name() {
-				repeatedFields = append(repeatedFields, sel)
-			}
-			if sel.Matcher.Type() != EQ {
+			if sel.Matcher.Type() == EQ {
+				if k.Name() == sel.Field.Name() {
+					repeatedFields = append(repeatedFields, sel)
+				}
+			} else if s.matchAll {
 				return nil, errors.InvalidArgument("filters only supporting $eq comparison, found '%s'", sel.Matcher.Type())
 			}
 		}

--- a/query/filter/key_builder_test.go
+++ b/query/filter/key_builder_test.go
@@ -218,6 +218,14 @@ func TestKeyBuilderSecondaryEq(t *testing.T) {
 			errors.InvalidArgument("$or filter is not yet supported for secondary index"),
 			nil,
 		},
+		{
+			// eq combined with another filter
+			[]*schema.QueryableField{{FieldName: "a", DataType: schema.Int64Type}, {FieldName: "b", DataType: schema.Int64Type}},
+			[]*schema.Field{{FieldName: "a", DataType: schema.Int64Type}, {FieldName: "b", DataType: schema.Int64Type}},
+			[]byte(`{"a": 10, "b": {"$gt": 1}}`),
+			nil,
+			[]QueryPlan{NewQueryPlan(EQUAL, "a", schema.Int64Type, []keys.Key{keys.NewKey(nil, int64(10))})},
+		},
 		// NOT SUPPORTED YET
 		// {
 		// 	// simple OR filter

--- a/test/v1/server/secondary_index_test.go
+++ b/test/v1/server/secondary_index_test.go
@@ -127,6 +127,7 @@ func TestQuery_EQ(t *testing.T) {
 		ids      []int
 		keyRange []string
 	}{
+
 		{
 			Map{"int_value": 10},
 			[]int{1},
@@ -156,6 +157,11 @@ func TestQuery_EQ(t *testing.T) {
 			},
 			[]int{2},
 			[]string{"false"},
+		},
+		{
+			Map{"int_value": 1, "double_value": Map{"$gte": 5}},
+			[]int{2},
+			[]string{"1"},
 		},
 		// {
 		// 	Map{
@@ -321,7 +327,7 @@ func TestQuery_Range(t *testing.T) {
 				},
 			},
 			[]int{1, 4},
-			[]string{"2022-12.22T17:42:34Z", max},
+			[]string{"true"},
 		},
 		{
 			Map{


### PR DESCRIPTION
## Describe your changes
This fixes the case where the EQ key composer
would ignore a filter that contains a `eq` and a non-eq field

## How best to test these changes
Tests should pass

## Issue ticket number and link
