### PR TITLE
fix: For search index, move encoding/etc search errors on document level

### DIFF
--- a/api/server/v1/search.go
+++ b/api/server/v1/search.go
@@ -32,7 +32,7 @@ func (x *GetDocumentResponse) MarshalJSON() ([]byte, error) {
 
 func (x *DocStatus) MarshalJSON() ([]byte, error) {
 	resp := struct {
-		ID    string `json:"id,omitempty"`
+		ID    string `json:"id"`
 		Error *Error `json:"error"`
 	}{
 		ID:    x.Id,

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fullstorydev/grpchan v1.1.1
 	github.com/gertd/go-pluralize v0.2.1
+	github.com/getkin/kin-openapi v0.115.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/cors v1.2.1
 	github.com/go-redis/redis/v8 v8.11.5
@@ -85,7 +86,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 // indirect
-	github.com/getkin/kin-openapi v0.115.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -66,13 +66,13 @@ type TableScanPlan struct {
 
 // QueryPlan is returned by KeyBuilder that contains the keys and type of query against fdb.
 type QueryPlan struct {
-	QueryType           QueryPlanType
-	FieldName           string
-	DataType            schema.FieldType
-	Keys                []keys.Key
-	Ascending           bool
-	IndexType           IndexType
-	From                keys.Key
+	QueryType QueryPlanType
+	FieldName string
+	DataType  schema.FieldType
+	Keys      []keys.Key
+	Ascending bool
+	IndexType IndexType
+	From      keys.Key
 }
 
 func NewQueryPlan(queryType QueryPlanType, fieldName string, dataType schema.FieldType, keys []keys.Key, indexType IndexType) QueryPlan {
@@ -476,12 +476,12 @@ func QueryPlanFromSort(sortFields *[]tsort.SortField, indexableFields []*schema.
 	}
 
 	plan := &QueryPlan{
-		FieldName:           field.FieldName,
-		QueryType:           FULLRANGE,
-		DataType:            field.DataType,
-		Ascending:           (*sortFields)[0].Ascending,
-		Keys:                []keys.Key{min, max},
-		IndexType:           indexType,
+		FieldName: field.FieldName,
+		QueryType: FULLRANGE,
+		DataType:  field.DataType,
+		Ascending: (*sortFields)[0].Ascending,
+		Keys:      []keys.Key{min, max},
+		IndexType: indexType,
 	}
 
 	return plan, nil

--- a/server/services/v1/billing/event_test.go
+++ b/server/services/v1/billing/event_test.go
@@ -106,7 +106,6 @@ func TestStorageEvent(t *testing.T) {
 		require.Equal(t, actual["timestamp"], "2023-02-21T08:53:41Z")
 		require.Equal(t, actual["event_type"], "storage")
 		require.Equal(t, actual["properties"], map[string]any{})
-
 	})
 }
 

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -143,7 +143,7 @@ func (r *UsageReporter) pushStorage() error {
 			dbBytes += secondaryIndexStats.StoredBytes
 		}
 
-		//todo: add search index sizes
+		// todo: add search index sizes
 		event := NewStorageEventBuilder().
 			WithNamespaceId(nsMeta.StrId).
 			WithTimestamp(time.Now()).

--- a/server/services/v1/billing/reporter_test.go
+++ b/server/services/v1/billing/reporter_test.go
@@ -145,7 +145,6 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 		require.Equal(t, 0, tenantMgr.refreshNamespaceCalls)
 		// no calls should be made to metronome provider
 		require.Empty(t, mockProvider.Calls)
-
 	})
 
 	t.Run("fails to create metronome account", func(t *testing.T) {

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -216,7 +216,8 @@ func (it *SecondaryIndexReaderImpl) Next(row *Row) bool {
 func (it *SecondaryIndexReaderImpl) Interrupted() error { return it.err }
 
 // For local debugging and testing.
-// nolint:unused
+//
+//nolint:unused
 func (it *SecondaryIndexReaderImpl) dbgPrintIndex() {
 	if config.GetEnvironment() != config.EnvLocal {
 		return

--- a/server/services/v1/search/base_runner.go
+++ b/server/services/v1/search/base_runner.go
@@ -1,0 +1,182 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"bytes"
+	"context"
+
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/server/types"
+	"github.com/tigrisdata/tigris/store/kv"
+	"github.com/tigrisdata/tigris/store/search"
+	"github.com/tigrisdata/tigris/util"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+type baseRunner struct {
+	store       search.Store
+	encoder     metadata.Encoder
+	accessToken *types.AccessToken
+	txMgr       *transaction.Manager
+}
+
+func newBaseRunner(store search.Store, encoder metadata.Encoder, txMgr *transaction.Manager, accessToken *types.AccessToken) *baseRunner {
+	return &baseRunner{
+		store:       store,
+		encoder:     encoder,
+		accessToken: accessToken,
+		txMgr:       txMgr,
+	}
+}
+
+func (runner *baseRunner) getIndex(tenant *metadata.Tenant, projName string, indexName string) (*schema.SearchIndex, error) {
+	project, err := tenant.GetProject(projName)
+	if err != nil {
+		return nil, err
+	}
+
+	index, found := project.GetSearch().GetIndex(indexName)
+	if !found {
+		// this allows to trigger version check to reload if index already exists
+		return nil, metadata.NewSearchIndexNotFoundErr(indexName)
+	}
+
+	return index, nil
+}
+
+func (runner *baseRunner) encodeDocuments(index *schema.SearchIndex, documents [][]byte, buffer *bytes.Buffer, isUpdate bool) ([]string, [][]byte, []error, int) {
+	var (
+		validDocs      = 0
+		ts             = internal.NewTimestamp()
+		transformer    = newWriteTransformer(index, ts, isUpdate)
+		docIds         = make([]string, len(documents))
+		docErrors      = make([]error, len(documents))
+		serializedDocs = make([][]byte, len(documents))
+	)
+
+	for i, raw := range documents {
+		doc, err := util.JSONToMap(raw)
+		if err != nil {
+			docErrors[i] = err
+			continue
+		}
+
+		// get or generate id
+		if docIds[i], docErrors[i] = transformer.getOrGenerateId(raw, doc); docErrors[i] != nil {
+			continue
+		}
+
+		// perform any validation on this document
+		if docErrors[i] = index.Validate(doc); docErrors[i] != nil {
+			continue
+		}
+
+		// transform to search
+		if doc, docErrors[i] = transformer.toSearch(docIds[i], doc); docErrors[i] != nil {
+			continue
+		}
+
+		// serialize it
+		if serializedDocs[i], docErrors[i] = util.MapToJSON(doc); docErrors[i] != nil {
+			continue
+		}
+
+		buffer.Write(serializedDocs[i])
+		buffer.WriteByte('\n')
+		validDocs++
+	}
+
+	return docIds, serializedDocs, docErrors, validDocs
+}
+
+func (runner *baseRunner) execInStorage(ctx context.Context, tableName string, ids []string, fn func(index int, tx transaction.Tx, key keys.Key) error) error {
+	if !config.DefaultConfig.Search.StorageEnabled {
+		return nil
+	}
+
+	tx, err := runner.txMgr.StartTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i, id := range ids {
+		if len(id) == 0 {
+			// this is only possible if user payload has issues
+			continue
+		}
+		var key keys.Key
+		if key, err = runner.encoder.EncodeFDBSearchKey(tableName, id); err != nil {
+			_ = tx.Rollback(ctx)
+			return err
+		}
+
+		if err = fn(i, tx, key); err != nil {
+			_ = tx.Rollback(ctx)
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (runner *baseRunner) readRow(ctx context.Context, tx transaction.Tx, key keys.Key) (*kv.KeyValue, bool, error) {
+	it, err := tx.Read(ctx, key, false)
+	if ulog.E(err) {
+		return nil, false, err
+	}
+
+	var value kv.KeyValue
+	if it.Next(&value) {
+		return &value, true, nil
+	}
+
+	return nil, false, it.Err()
+}
+
+// buildDocStatusResp is responsible for building doc status response that is returned by batch index APIs. This API
+// expects a batch of "ids", a batch of "errors" and then the "storeResp". All three have the same order as the input
+// documents. The batchErrors is set before sending requests to store which means first we check if that is set if yes
+// then we fill the response with that error otherwise that document was successfully sent to store so we need to check
+// whether store is processed it without any error.
+func (runner *baseRunner) buildDocStatusResp(ids []string, batchErrors []error, storeResp []search.IndexResp) []*api.DocStatus {
+	var (
+		respIdx int
+		status  = make([]*api.DocStatus, len(ids))
+	)
+	for i, id := range ids {
+		var apiErr *api.Error
+		if batchErrors[i] != nil {
+			apiErr = convertStoreErrToApiErr(id, 400, batchErrors[i].Error())
+		} else {
+			// otherwise we need to extract from the store response
+			apiErr = convertStoreErrToApiErr(id, storeResp[respIdx].Code, storeResp[respIdx].Error)
+			respIdx++
+		}
+
+		status[i] = &api.DocStatus{
+			Id:    id,
+			Error: apiErr,
+		}
+	}
+
+	return status
+}

--- a/server/services/v1/search/errors.go
+++ b/server/services/v1/search/errors.go
@@ -76,6 +76,11 @@ func convertStoreErrToApiErr(id string, code int, msg string) *api.Error {
 			Code:    http.StatusConflict,
 			Message: fmt.Sprintf("A document with id '%s' already exists.", id),
 		}
+	case http.StatusBadRequest:
+		return &api.Error{
+			Code:    http.StatusBadRequest,
+			Message: msg,
+		}
 	default:
 		return &api.Error{
 			Code:    api.Code(code),

--- a/server/services/v1/search/indexer_test.go
+++ b/server/services/v1/search/indexer_test.go
@@ -107,11 +107,12 @@ func TestMutateSearchDocument(t *testing.T) {
 		require.NoError(t, err)
 
 		wt := newWriteTransformer(index, internal.NewTimestamp(), false)
-		id, transformed, err := wt.toSearch(c.doc, mp)
+		id, err := wt.getOrGenerateId(c.doc, mp)
 		if len(c.expError) > 0 {
 			require.ErrorContains(t, err, c.expError)
 			continue
 		}
+		transformed, err := wt.toSearch(id, mp)
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 


### PR DESCRIPTION
## Describe your changes

For search indexes, when there is a batch index documents requests, instead of failing the entire batch, this diff will move individual document-related errors to the document level i.e. 
  - If there is a missing id in a document (in case 'id' is explicitly set in the schema)
  - In case of validation fails for the document

## How best to test these changes

## Issue ticket number and link
