### PR TITLE
fix: disable metronome reporting for default namespace

### DIFF
--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/metrics"
 	ulog "github.com/tigrisdata/tigris/util/log"
+	"github.com/tigrisdata/tigris/server/defaults"
 )
 
 type UsageReporter struct {
@@ -96,7 +97,7 @@ func (r *UsageReporter) pushUsage() error {
 			log.Error().Msgf("invalid namespace id %s", namespaceId)
 			continue
 		}
-		if len(nsMeta.StrId) == 0 {
+		if len(nsMeta.StrId) == 0 || nsMeta.StrId == defaults.DefaultNamespaceName {
 			// invalid namespace id, permanently disable account creation
 			nsMeta.Accounts.DisableMetronome()
 			err := r.nsMgr.UpdateNamespaceMetadata(r.ctx, *nsMeta)

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -22,10 +22,10 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/defaults"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/metrics"
 	ulog "github.com/tigrisdata/tigris/util/log"
-	"github.com/tigrisdata/tigris/server/defaults"
 )
 
 type UsageReporter struct {


### PR DESCRIPTION
## Describe your changes
- `default_namespace` does not get persisted, hence disabling usage reporting for it

## How best to test these changes
- Unit tests

## Issue ticket number and link
