### PR TITLE
feat: search index metrics

### DIFF
--- a/server/metadata/namespace.go
+++ b/server/metadata/namespace.go
@@ -120,7 +120,7 @@ func (a *AccountIntegrations) AddMetronome(id string) {
 	}
 }
 
-// DisableMetronome for this user
+// DisableMetronome for this user.
 func (a *AccountIntegrations) DisableMetronome() {
 	if a.Metronome == nil {
 		a.Metronome = &Metronome{}

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1758,7 +1758,6 @@ func (tenant *Tenant) SearchIndexSize(ctx context.Context, index *schema.SearchI
 }
 
 func (tenant *Tenant) ProjectSearchSize(ctx context.Context, tx transaction.Tx, project *Project) (*kv.TableStats, error) {
-
 	projectSearchIndexes, err := tenant.ListSearchIndexes(ctx, tx, project)
 	if err != nil {
 		return nil, err
@@ -1774,7 +1773,6 @@ func (tenant *Tenant) SearchSize(ctx context.Context, tx transaction.Tx) (*kv.Ta
 
 	for _, p := range tenant.projects {
 		projectSearchIndexes, err := tenant.ListSearchIndexes(ctx, tx, p)
-
 		if err != nil {
 			return nil, err
 		}

--- a/server/metadata/tenant_test.go
+++ b/server/metadata/tenant_test.go
@@ -1097,11 +1097,11 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tenant.reload(ctx, tmTx, nil, nil))
 
-	//proj1
+	// proj1
 	proj1, err := tenant.GetProject(tenantProj1)
 	require.NoError(t, err)
 
-	//proj2
+	// proj2
 	proj2, err := tenant.GetProject(tenantProj2)
 	require.NoError(t, err)
 
@@ -1122,17 +1122,17 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 	}`)
 	factory1, err := schema.NewFactoryBuilder(true).BuildSearch("prj1_test_index_1", jsSchema)
 	require.NoError(t, err)
-	//create prj1_test_index_1 for proj1
+
 	require.NoError(t, tenant.CreateSearchIndex(ctx, tmTx, proj1, factory1))
 
 	factory2, err := schema.NewFactoryBuilder(true).BuildSearch("prj1_test_index_2", jsSchema)
 	require.NoError(t, err)
-	//create prj1_test_index_2 for proj1
+
 	require.NoError(t, tenant.CreateSearchIndex(ctx, tmTx, proj1, factory2))
 
 	factory3, err := schema.NewFactoryBuilder(true).BuildSearch("prj2_test_index", jsSchema)
 	require.NoError(t, err)
-	//create index for proj2
+
 	require.NoError(t, tenant.CreateSearchIndex(ctx, tmTx, proj2, factory3))
 
 	indexesInSearchStore, err := tenant.searchStore.AllCollections(ctx)
@@ -1142,7 +1142,6 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 	require.NotNil(t, indexesInSearchStore[tenant.Encoder.EncodeSearchTableName(tenant.namespace.Id(), proj2.Id(), factory3.Name)])
 
 	t.Run("search_index_size", func(t *testing.T) {
-		//initial size 0
 		sz, err := tenant.ProjectSearchSize(ctx, tmTx, proj1)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), sz.StoredBytes)
@@ -1175,7 +1174,6 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1024000), sz.StoredBytes)
 
-		//proj2, "test_index_2"
 		index, ok = proj2.search.GetIndex("prj2_test_index")
 		require.True(t, ok)
 		table = m.encoder.EncodeFDBSearchTableName(index.StoreIndexName())
@@ -1187,6 +1185,7 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 
 		for i := 0; i < 150; i++ {
 			err = tx.Insert(ctx, table, kv.BuildKey(fmt.Sprintf("aaa%d", i)), &internal.TableData{RawData: make([]byte, docSize)})
+			require.NoError(t, err)
 		}
 		_ = tx.Commit(ctx)
 
@@ -1194,7 +1193,6 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1536000), sz.StoredBytes)
 
-		//proj1
 		index, ok = proj1.search.GetIndex("prj1_test_index_2")
 		require.True(t, ok)
 		table = m.encoder.EncodeFDBSearchTableName(index.StoreIndexName())
@@ -1206,15 +1204,14 @@ func TestTenantManager_SearchDataSize(t *testing.T) {
 
 		for i := 0; i < 100; i++ {
 			err = tx.Insert(ctx, table, kv.BuildKey(fmt.Sprintf("aaa%d", i)), &internal.TableData{RawData: make([]byte, docSize)})
+			require.NoError(t, err)
 		}
 		_ = tx.Commit(ctx)
 
-		//search size of proj1
 		sz, err = tenant.ProjectSearchSize(ctx, tmTx, proj1)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2048000), sz.StoredBytes)
 
-		//search size of proj1
 		sz, err = tenant.ProjectSearchSize(ctx, tmTx, proj2)
 		require.NoError(t, err)
 		assert.Equal(t, int64(1536000), sz.StoredBytes)

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -196,6 +196,14 @@ func (m *Measurement) GetCollectionSizeTags() map[string]string {
 	return filterTags(standardizeTags(m.tags, getCollectionSizeTagKeys()), config.DefaultConfig.Metrics.Size.FilteredTags)
 }
 
+func (m *Measurement) GetSearchSizeTagKeys() map[string]string {
+	return filterTags(standardizeTags(m.tags, getSearchSizeTagKeys()), config.DefaultConfig.Metrics.Size.FilteredTags)
+}
+
+func (m *Measurement) GetSearchIndexSizeTagKeys() map[string]string {
+	return filterTags(standardizeTags(m.tags, getSearchIndexSizeTagKeys()), config.DefaultConfig.Metrics.Size.FilteredTags)
+}
+
 func (m *Measurement) GetNetworkTags() map[string]string {
 	return filterTags(standardizeTags(m.tags, getNetworkTagKeys()), config.DefaultConfig.Metrics.Network.FilteredTags)
 }

--- a/server/metrics/measurement_test.go
+++ b/server/metrics/measurement_test.go
@@ -219,6 +219,18 @@ func TestTracing(t *testing.T) {
 			assert.NotNil(t, collSizeTags[key])
 		}
 		assert.Equal(t, len(getCollectionSizeTagKeys()), len(collSizeTags))
+
+		searchSizeTags := measurement.GetSearchSizeTagKeys()
+		for _, key := range getSearchSizeTagKeys() {
+			assert.NotNil(t, searchSizeTags[key])
+		}
+		assert.Equal(t, len(getSearchSizeTagKeys()), len(searchSizeTags))
+
+		searchIndexSizeTags := measurement.GetSearchIndexSizeTagKeys()
+		for _, key := range getSearchIndexSizeTagKeys() {
+			assert.NotNil(t, searchIndexSizeTags[key])
+		}
+		assert.Equal(t, len(getSearchIndexSizeTagKeys()), len(searchIndexSizeTags))
 	})
 
 	t.Run("Test network tags", func(t *testing.T) {

--- a/server/metrics/size.go
+++ b/server/metrics/size.go
@@ -19,15 +19,19 @@ import (
 )
 
 var (
-	NamespaceSize  tally.Scope
-	DbSize         tally.Scope
-	CollectionSize tally.Scope
+	NamespaceSize   tally.Scope
+	DbSize          tally.Scope
+	CollectionSize  tally.Scope
+	SearchSize      tally.Scope
+	SearchIndexSize tally.Scope
 )
 
 func initializeSizeScopes() {
 	NamespaceSize = SizeMetrics.SubScope("namespace")
 	DbSize = SizeMetrics.SubScope("db")
 	CollectionSize = SizeMetrics.SubScope("collection")
+	SearchSize = SizeMetrics.SubScope("search")
+	SearchIndexSize = SizeMetrics.SubScope("search-index")
 }
 
 func getNameSpaceSizeTagKeys() []string {
@@ -67,6 +71,29 @@ func getCollectionSizeTagKeys() []string {
 	}
 }
 
+func getSearchSizeTagKeys() []string {
+	return []string{
+		"env",
+		"service",
+		"tigris_tenant",
+		"tigris_tenant_name",
+		"version",
+		"project",
+	}
+}
+
+func getSearchIndexSizeTagKeys() []string {
+	return []string{
+		"env",
+		"service",
+		"tigris_tenant",
+		"tigris_tenant_name",
+		"version",
+		"project",
+		"index",
+	}
+}
+
 func getNamespaceSizeTags(namespace string, namespaceName string) map[string]string {
 	return map[string]string{
 		"tigris_tenant":      namespace,
@@ -95,6 +122,23 @@ func getCollectionSizeTags(namespace string, namespaceName string, dbName string
 	}
 }
 
+func getSearchSizeTags(namespace string, namespaceName string, projectName string) map[string]string {
+	return map[string]string{
+		"tigris_tenant":      namespace,
+		"tigris_tenant_name": GetTenantNameTagValue(namespace, namespaceName),
+		"project":            projectName,
+	}
+}
+
+func getSearchIndexSizeTags(namespace string, namespaceName string, projectName string, indexName string) map[string]string {
+	return map[string]string{
+		"tigris_tenant":      namespace,
+		"tigris_tenant_name": GetTenantNameTagValue(namespace, namespaceName),
+		"project":            projectName,
+		"index":              indexName,
+	}
+}
+
 func UpdateNameSpaceSizeMetrics(namespace string, namespaceName string, size int64) {
 	if NamespaceSize != nil {
 		NamespaceSize.Tagged(getNamespaceSizeTags(namespace, namespaceName)).Gauge("bytes").Update(float64(size))
@@ -110,5 +154,17 @@ func UpdateDbSizeMetrics(namespace string, namespaceName string, dbName string, 
 func UpdateCollectionSizeMetrics(namespace string, namespaceName string, dbName string, branch string, collectionName string, size int64) {
 	if NamespaceSize != nil {
 		CollectionSize.Tagged(getCollectionSizeTags(namespace, namespaceName, dbName, branch, collectionName)).Gauge("bytes").Update(float64(size))
+	}
+}
+
+func UpdateSearchSizeMetrics(namespace string, namespaceName string, projectName string, size int64) {
+	if NamespaceSize != nil {
+		SearchSize.Tagged(getSearchSizeTags(namespace, namespaceName, projectName)).Gauge("bytes").Update(float64(size))
+	}
+}
+
+func UpdateSearchIndexSizeMetrics(namespace string, namespaceName string, projectName string, indexName string, size int64) {
+	if NamespaceSize != nil {
+		SearchIndexSize.Tagged(getSearchIndexSizeTags(namespace, namespaceName, projectName, indexName)).Gauge("bytes").Update(float64(size))
 	}
 }

--- a/server/metrics/size.go
+++ b/server/metrics/size.go
@@ -31,7 +31,7 @@ func initializeSizeScopes() {
 	DbSize = SizeMetrics.SubScope("db")
 	CollectionSize = SizeMetrics.SubScope("collection")
 	SearchSize = SizeMetrics.SubScope("search")
-	SearchIndexSize = SizeMetrics.SubScope("search-index")
+	SearchIndexSize = SizeMetrics.SubScope("search_index")
 }
 
 func getNameSpaceSizeTagKeys() []string {


### PR DESCRIPTION
## Describe your changes
- Added methods `SearchIndexSize`, `ProjectSearchSize`,  `SearchSize` to metadata/tenant.go to get size of search tables. 
- Added respective unit test cases for the above methods
- Updating the search metrics while updating the mertics for namespace 
- Added the search index tags

## How best to test these changes
make test command

## Issue ticket number and link
#886 