### PR TITLE
Allow user to explicitly specify fields as nullable

### DIFF
--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -39,27 +39,27 @@ func TestFieldBuilder_Build(t *testing.T) {
 			expError error
 		}{
 			{
-				builder:  &FieldBuilder{FieldName: "test", Type: "boolean"},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("boolean")},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", Type: "bool"},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("bool")},
 				expError: errors.InvalidArgument("unsupported type detected 'bool'"),
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", Type: "string", Format: "uuid"},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("string"), Format: "uuid"},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", Type: "number"},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("number")},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", Type: "integer", Primary: &boolTrue},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("integer"), Primary: &boolTrue},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "_test", Type: "integer"},
+				builder:  &FieldBuilder{FieldName: "_test", TypeRaw: NewMultiType("integer")},
 				expError: nil,
 			},
 		}
@@ -105,7 +105,7 @@ func TestFieldBuilder_Build(t *testing.T) {
 	t.Run("test valid field name pattern", func(t *testing.T) {
 		validFieldNames := []string{"a1", "$a1", "$_a1", "$_", "A1", "Z1"}
 		for _, validFieldName := range validFieldNames {
-			_, err := (&FieldBuilder{FieldName: validFieldName, Type: "string"}).Build(false) // one time builder, thrown away after test concluded
+			_, err := (&FieldBuilder{FieldName: validFieldName, TypeRaw: NewMultiType("string")}).Build(false) // one time builder, thrown away after test concluded
 			require.NoError(t, err)
 		}
 	})

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -253,7 +253,7 @@ func ApplySearchIndexBackwardCompatibilityRules(existing *SearchIndex, current *
 // validated on builder and can't be done on field has to be done here. Similar to ValidateFieldAttributes, this is
 // also only done during incoming requests and ignored during reloading of schemas.
 func ValidateFieldBuilder(f FieldBuilder) error {
-	fieldType := ToFieldType(f.Type, f.Encoding, f.Format)
+	fieldType := f.Type()
 	if fieldType == UnknownType {
 		if len(f.Encoding) > 0 {
 			return errors.InvalidArgument("unsupported encoding '%s'", f.Encoding)
@@ -262,7 +262,7 @@ func ValidateFieldBuilder(f FieldBuilder) error {
 			return errors.InvalidArgument("unsupported format '%s'", f.Format)
 		}
 
-		return errors.InvalidArgument("unsupported type detected '%s'", f.Type)
+		return errors.InvalidArgument("unsupported type detected '%s'", f.TypeRaw.First())
 	}
 
 	if f.CreatedAt != nil || f.UpdatedAt != nil || f.Default != nil {


### PR DESCRIPTION
* This fixes external data validation using our schema.
* This would allow proper reconstruction of language schema.
* We would not need to cleanup nulls during import process. Just specify additional "null" as type.
