### PR TITLE
feat: Request Usage data from metronome

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -250,11 +250,14 @@ type Billing struct {
 }
 
 type Metronome struct {
-	Enabled     bool   `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
-	URL         string `mapstructure:"url" yaml:"url" json:"url"`
-	ApiKey      string `mapstructure:"api_key" yaml:"api_key" json:"api_key"`
-	DefaultPlan string `mapstructure:"default_plan" yaml:"default_plan" json:"default_plan"`
+	Enabled       bool          `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	URL           string        `mapstructure:"url" yaml:"url" json:"url"`
+	ApiKey        string        `mapstructure:"api_key" yaml:"api_key" json:"api_key"`
+	DefaultPlan   string        `mapstructure:"default_plan" yaml:"default_plan" json:"default_plan"`
+	BilledMetrics BilledMetrics `mapstructure:"billed_metrics" yaml:"billed_metrics" json:"billed_metrics"`
 }
+
+type BilledMetrics = map[string]string
 
 type BillingReporter struct {
 	Enabled         bool          `mapstructure:"enabled" yaml:"enabled" json:"enabled"`

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -355,7 +355,7 @@ func (m *Measurement) RecordDuration(scope tally.Scope, tags map[string]string) 
 	case SecondaryIndexRespTime, SecondaryIndexErrorRespTime:
 		timerEnabled = cfg.SecondaryIndex.Timer.TimerEnabled
 		histogramEnabled = cfg.SecondaryIndex.Timer.HistogramEnabled
-	case MetronomeCreateAccount, MetronomeAddPlan, MetronomeIngest, MetronomeGetInvoice, MetronomeListInvoices:
+	case MetronomeCreateAccount, MetronomeAddPlan, MetronomeIngest, MetronomeGetInvoice, MetronomeListInvoices, MetronomeGetUsage:
 		timerEnabled = true
 		histogramEnabled = true
 	}

--- a/server/metrics/metronome.go
+++ b/server/metrics/metronome.go
@@ -26,6 +26,7 @@ var (
 	MetronomeIngest        tally.Scope
 	MetronomeListInvoices  tally.Scope
 	MetronomeGetInvoice    tally.Scope
+	MetronomeGetUsage      tally.Scope
 )
 
 func initializeMetronomeScopes() {
@@ -34,6 +35,7 @@ func initializeMetronomeScopes() {
 	MetronomeIngest = MetronomeMetrics.SubScope("ingest")
 	MetronomeListInvoices = MetronomeMetrics.SubScope("list_invoices")
 	MetronomeGetInvoice = MetronomeMetrics.SubScope("get_invoice")
+	MetronomeGetUsage = MetronomeMetrics.SubScope("get_usage")
 }
 
 func GetResponseCodeTags(code int) map[string]string {

--- a/server/services/v1/billing.go
+++ b/server/services/v1/billing.go
@@ -65,7 +65,7 @@ func (b *billingService) ListInvoices(ctx context.Context, req *api.ListInvoices
 	return b.GetInvoices(ctx, mId, req)
 }
 
-func (b *billingService) getMetronomeId(ctx context.Context, namespaceId string) (billing.MetronomeId, error) {
+func (b *billingService) getMetronomeId(ctx context.Context, namespaceId string) (billing.AccountId, error) {
 	nsMeta := b.nsMgr.GetNamespaceMetadata(ctx, namespaceId)
 	if nsMeta == nil {
 		log.Warn().Msgf("Could not find namespace, this must not happen with right authn/authz configured")

--- a/server/services/v1/billing/event.go
+++ b/server/services/v1/billing/event.go
@@ -25,6 +25,12 @@ const (
 	EventTypeUsage   string = "usage"
 	EventTypeStorage string = "storage"
 	TimeFormat              = time.RFC3339
+
+	StorageIndexBytes = "index_bytes"
+	StorageDbBytes    = "database_bytes"
+
+	UsageSearchUnits = "search_units"
+	UsageDbUnits     = "database_units"
 )
 
 type UsageEvent struct {
@@ -88,11 +94,11 @@ func (ub *UsageEventBuilder) Build() *UsageEvent {
 	}
 	// the key names must match the registered billing metrics in metronome
 	if ub.searchUnits != nil {
-		props["search_units"] = *ub.searchUnits
+		props[UsageSearchUnits] = *ub.searchUnits
 	}
 
 	if ub.databaseUnits != nil {
-		props["database_units"] = *ub.databaseUnits
+		props[UsageDbUnits] = *ub.databaseUnits
 	}
 	billingMetric.Properties = &props
 	return billingMetric
@@ -159,11 +165,11 @@ func (sb *StorageEventBuilder) Build() *StorageEvent {
 
 	// the key names must match the registered billing metrics in metronome
 	if sb.indexBytes != nil {
-		props["index_bytes"] = *sb.indexBytes
+		props[StorageIndexBytes] = *sb.indexBytes
 	}
 
 	if sb.databaseBytes != nil {
-		props["database_bytes"] = *sb.databaseBytes
+		props[StorageDbBytes] = *sb.databaseBytes
 	}
 	billingMetric.Properties = &props
 	return billingMetric

--- a/server/services/v1/billing/event_test.go
+++ b/server/services/v1/billing/event_test.go
@@ -40,7 +40,7 @@ func TestStorageEvent(t *testing.T) {
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "storage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"database_bytes": float64(24),
+			StorageDbBytes: float64(24),
 		})
 	})
 
@@ -60,8 +60,8 @@ func TestStorageEvent(t *testing.T) {
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "storage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"index_bytes":    float64(0),
-			"database_bytes": float64(0),
+			StorageIndexBytes: float64(0),
+			StorageDbBytes:    float64(0),
 		})
 	})
 
@@ -85,8 +85,8 @@ func TestStorageEvent(t *testing.T) {
 		require.Equal(t, actual["timestamp"], "2023-02-21T08:53:41Z")
 		require.Equal(t, actual["event_type"], "storage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"index_bytes":    float64(12),
-			"database_bytes": float64(345),
+			StorageIndexBytes: float64(12),
+			StorageDbBytes:    float64(345),
 		})
 	})
 
@@ -124,7 +124,7 @@ func TestUsageEvent(t *testing.T) {
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "usage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"database_units": float64(55),
+			UsageDbUnits: float64(55),
 		})
 	})
 
@@ -142,8 +142,8 @@ func TestUsageEvent(t *testing.T) {
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "usage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"database_units": float64(0),
-			"search_units":   float64(0),
+			UsageDbUnits:     float64(0),
+			UsageSearchUnits: float64(0),
 		})
 	})
 
@@ -167,8 +167,8 @@ func TestUsageEvent(t *testing.T) {
 		require.Equal(t, actual["timestamp"], "2023-02-21T08:53:41Z")
 		require.Equal(t, actual["event_type"], "usage")
 		require.Equal(t, actual["properties"], map[string]any{
-			"database_units": float64(123),
-			"search_units":   float64(542),
+			UsageDbUnits:     float64(123),
+			UsageSearchUnits: float64(542),
 		})
 	})
 

--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -21,32 +21,44 @@ import (
 	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
 	biller "github.com/tigrisdata/metronome-go-client"
 	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/uber-go/tally"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type MetronomeId = uuid.UUID
-
 type Metronome struct {
-	Config config.Metronome
-	client *biller.ClientWithResponses
+	Config              config.Metronome
+	client              *biller.ClientWithResponses
+	billedMetricsByName map[string]uuid.UUID
+	billedMetricsById   map[uuid.UUID]string
 }
 
-func NewMetronomeProvider(config config.Metronome) (*Metronome, error) {
-	bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(config.ApiKey)
+func NewMetronomeProvider(conf config.Metronome) (*Metronome, error) {
+	bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(conf.ApiKey)
 	if err != nil {
 		return nil, err
 	}
-	client, err := biller.NewClientWithResponses(config.URL, biller.WithRequestEditorFn(bearerTokenProvider.Intercept))
+	client, err := biller.NewClientWithResponses(conf.URL, biller.WithRequestEditorFn(bearerTokenProvider.Intercept))
 	if err != nil {
 		return nil, err
 	}
-	return &Metronome{Config: config, client: client}, nil
+	// billable metrics should be uuids
+	bm, bu := map[string]uuid.UUID{}, map[uuid.UUID]string{}
+	for name, id := range conf.BilledMetrics {
+		uid, err := uuid.Parse(id)
+		if err != nil {
+			return nil, err
+		}
+		bm[name] = uid
+		bu[uid] = name
+	}
+	return &Metronome{Config: conf, client: client, billedMetricsByName: bm, billedMetricsById: bu}, nil
 }
 
 func (m *Metronome) measure(ctx context.Context, scope tally.Scope, operation string, f func(ctx context.Context) (*http.Response, error)) {
@@ -78,7 +90,7 @@ func (m *Metronome) measure(ctx context.Context, scope tally.Scope, operation st
 	me.IncrementCount(scope, errTags, "availability", availability)
 }
 
-func (m *Metronome) CreateAccount(ctx context.Context, namespaceId string, name string) (MetronomeId, error) {
+func (m *Metronome) CreateAccount(ctx context.Context, namespaceId string, name string) (AccountId, error) {
 	var (
 		resp *biller.CreateCustomerResponse
 		err  error
@@ -108,7 +120,7 @@ func (m *Metronome) CreateAccount(ctx context.Context, namespaceId string, name 
 	return resp.JSON200.Data.Id, nil
 }
 
-func (m *Metronome) AddDefaultPlan(ctx context.Context, accountId MetronomeId) (bool, error) {
+func (m *Metronome) AddDefaultPlan(ctx context.Context, accountId AccountId) (bool, error) {
 	planId, err := uuid.Parse(m.Config.DefaultPlan)
 	if err != nil {
 		return false, err
@@ -116,7 +128,7 @@ func (m *Metronome) AddDefaultPlan(ctx context.Context, accountId MetronomeId) (
 	return m.AddPlan(ctx, accountId, planId)
 }
 
-func (m *Metronome) AddPlan(ctx context.Context, accountId MetronomeId, planId uuid.UUID) (bool, error) {
+func (m *Metronome) AddPlan(ctx context.Context, accountId AccountId, planId uuid.UUID) (bool, error) {
 	var (
 		resp *biller.AddPlanToCustomerResponse
 		err  error
@@ -226,7 +238,7 @@ func (m *Metronome) pushBillingEvents(ctx context.Context, events []biller.Event
 	return nil
 }
 
-func (m *Metronome) GetInvoices(ctx context.Context, accountId MetronomeId, r *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error) {
+func (m *Metronome) GetInvoices(ctx context.Context, accountId AccountId, r *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error) {
 	var (
 		resp *biller.ListInvoicesResponse
 		err  error
@@ -279,7 +291,7 @@ func (m *Metronome) GetInvoices(ctx context.Context, accountId MetronomeId, r *a
 	}, nil
 }
 
-func (m *Metronome) GetInvoiceById(ctx context.Context, accountId MetronomeId, invoiceId string) (*api.ListInvoicesResponse, error) {
+func (m *Metronome) GetInvoiceById(ctx context.Context, accountId AccountId, invoiceId string) (*api.ListInvoicesResponse, error) {
 	var (
 		resp *biller.GetInvoiceResponse
 		err  error
@@ -311,6 +323,100 @@ func (m *Metronome) GetInvoiceById(ctx context.Context, accountId MetronomeId, i
 	}
 	return &api.ListInvoicesResponse{
 		Data: data,
+	}, nil
+}
+
+func (m *Metronome) GetUsage(ctx context.Context, id AccountId, r *UsageRequest) (*UsageAggregate, error) {
+	var (
+		resp *biller.GetUsageBatchResponse
+		err  error
+	)
+	if r.StartTime == nil || r.StartTime.IsZero() {
+		return nil, errors.InvalidArgument("'%s' is not a valid start time", r.StartTime)
+	}
+	if r.EndTime == nil || r.EndTime.IsZero() {
+		return nil, errors.InvalidArgument("'%s' is not a valid end time", r.EndTime)
+	}
+
+	type mBillableMetric struct {
+		GroupBy *struct {
+			Key    string    `json:"key"`
+			Values *[]string `json:"values,omitempty"`
+		} `json:"group_by,omitempty"`
+		Id types.UUID `json:"id"`
+	}
+
+	reqParams := biller.GetUsageBatchJSONRequestBody{
+		BillableMetrics: (*[]struct {
+			GroupBy *struct {
+				Key    string    `json:"key"`
+				Values *[]string `json:"values,omitempty"`
+			} `json:"group_by,omitempty"`
+			Id types.UUID `json:"id"`
+		})(&[]struct {
+			GroupBy *struct {
+				Key    string
+				Values *[]string
+			}
+			Id uuid.UUID
+		}{}),
+		CustomerIds:  &[]AccountId{id},
+		StartingOn:   *r.StartTime,
+		EndingBefore: *r.EndTime,
+		WindowSize:   "hour",
+	}
+
+	l := reqParams.BillableMetrics
+	if r.BillableMetric == nil || len(*r.BillableMetric) == 0 {
+		// query all metrics
+		for _, bid := range m.billedMetricsByName {
+			*l = append(*l, mBillableMetric{Id: bid})
+		}
+	} else {
+		for _, name := range *r.BillableMetric {
+			if id, ok := m.billedMetricsByName[name]; ok {
+				*l = append(*l, mBillableMetric{Id: id})
+			} else {
+				return nil, errors.InvalidArgument("'%s' is not a valid billable metric", name)
+			}
+		}
+	}
+
+	m.measure(ctx, metrics.MetronomeGetUsage, "get_usage", func(ctx context.Context) (*http.Response, error) {
+		resp, err = m.client.GetUsageBatchWithResponse(ctx, &biller.GetUsageBatchParams{NextPage: r.NextPage}, reqParams)
+		if resp == nil {
+			return nil, err
+		}
+		return resp.HTTPResponse, err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, NewMetronomeError(resp.StatusCode(), resp.Body)
+	}
+
+	aggUsage := map[string][]*Usage{}
+	for _, param := range *reqParams.BillableMetrics {
+		n := m.billedMetricsById[param.Id]
+		aggUsage[n] = []*Usage{}
+	}
+
+	for _, d := range resp.JSON200.Data {
+		if n, ok := m.billedMetricsById[d.BillableMetricId]; ok {
+			aggUsage[n] = append(aggUsage[n], &Usage{
+				StartTime: d.StartTimestamp,
+				EndTime:   d.EndTimestamp,
+				Value:     d.Value,
+			})
+		}
+	}
+
+	return &UsageAggregate{
+		Data:     aggUsage,
+		NextPage: resp.JSON200.NextPage,
 	}, nil
 }
 

--- a/server/services/v1/billing/noop.go
+++ b/server/services/v1/billing/noop.go
@@ -24,15 +24,15 @@ import (
 
 type noop struct{}
 
-func (n *noop) CreateAccount(_ context.Context, _ string, _ string) (MetronomeId, error) {
+func (n *noop) CreateAccount(_ context.Context, _ string, _ string) (AccountId, error) {
 	return uuid.Nil, errors.Unimplemented("billing not enabled on this server")
 }
 
-func (n *noop) AddDefaultPlan(ctx context.Context, accountId MetronomeId) (bool, error) {
+func (n *noop) AddDefaultPlan(ctx context.Context, accountId AccountId) (bool, error) {
 	return n.AddPlan(ctx, accountId, uuid.New())
 }
 
-func (*noop) AddPlan(_ context.Context, _ MetronomeId, _ uuid.UUID) (bool, error) {
+func (*noop) AddPlan(_ context.Context, _ AccountId, _ uuid.UUID) (bool, error) {
 	return false, errors.Unimplemented("billing not enabled on this server")
 }
 
@@ -44,10 +44,14 @@ func (*noop) PushStorageEvents(_ context.Context, _ []*StorageEvent) error {
 	return errors.Unimplemented("billing not enabled on this server")
 }
 
-func (*noop) GetInvoices(_ context.Context, _ MetronomeId, _ *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error) {
+func (*noop) GetInvoices(_ context.Context, _ AccountId, _ *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error) {
 	return nil, errors.Unimplemented("billing not enabled on this server")
 }
 
-func (*noop) GetInvoiceById(_ context.Context, _ MetronomeId, _ string) (*api.ListInvoicesResponse, error) {
+func (*noop) GetInvoiceById(_ context.Context, _ AccountId, _ string) (*api.ListInvoicesResponse, error) {
+	return nil, errors.Unimplemented("billing not enabled on this server")
+}
+
+func (*noop) GetUsage(_ context.Context, _ AccountId, _ *UsageRequest) (*UsageAggregate, error) {
 	return nil, errors.Unimplemented("billing not enabled on this server")
 }

--- a/server/services/v1/billing/provider.go
+++ b/server/services/v1/billing/provider.go
@@ -17,20 +17,43 @@ package billing
 import (
 	"context"
 
+	"time"
+
 	"github.com/google/uuid"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/server/config"
 	ulog "github.com/tigrisdata/tigris/util/log"
 )
 
+type AccountId = uuid.UUID
+
 type Provider interface {
-	CreateAccount(ctx context.Context, namespaceId string, name string) (MetronomeId, error)
-	AddDefaultPlan(ctx context.Context, accountId MetronomeId) (bool, error)
-	AddPlan(ctx context.Context, accountId MetronomeId, planId uuid.UUID) (bool, error)
+	CreateAccount(ctx context.Context, namespaceId string, name string) (AccountId, error)
+	AddDefaultPlan(ctx context.Context, accountId AccountId) (bool, error)
+	AddPlan(ctx context.Context, accountId AccountId, planId uuid.UUID) (bool, error)
 	PushUsageEvents(ctx context.Context, events []*UsageEvent) error
 	PushStorageEvents(ctx context.Context, events []*StorageEvent) error
-	GetInvoices(ctx context.Context, accountId MetronomeId, r *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error)
-	GetInvoiceById(ctx context.Context, accountId MetronomeId, invoiceId string) (*api.ListInvoicesResponse, error)
+	GetInvoices(ctx context.Context, accountId AccountId, r *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error)
+	GetInvoiceById(ctx context.Context, accountId AccountId, invoiceId string) (*api.ListInvoicesResponse, error)
+	GetUsage(ctx context.Context, id AccountId, r *UsageRequest) (*UsageAggregate, error)
+}
+
+type UsageRequest struct {
+	BillableMetric *[]string
+	StartTime      *time.Time
+	EndTime        *time.Time
+	NextPage       *string
+}
+
+type Usage struct {
+	StartTime time.Time
+	EndTime   time.Time
+	Value     *float32
+}
+
+type UsageAggregate struct {
+	Data     map[string][]*Usage
+	NextPage *string
 }
 
 func NewProvider() Provider {

--- a/server/services/v1/billing/reporter_test.go
+++ b/server/services/v1/billing/reporter_test.go
@@ -118,8 +118,8 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 					require.Contains(t, []string{"ns1", "ns2", "ns3", "ns4"}, e.CustomerId)
 
 					expected, actual := glbStatus.data.Tenants[e.CustomerId], *e.Properties
-					require.Equal(t, expected.WriteUnits+expected.ReadUnits, actual["database_units"])
-					require.Equal(t, expected.SearchUnits, actual["search_units"])
+					require.Equal(t, expected.WriteUnits+expected.ReadUnits, actual[UsageDbUnits])
+					require.Equal(t, expected.SearchUnits, actual[UsageSearchUnits])
 				}
 				return nil
 			}).Once()
@@ -239,8 +239,8 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				require.Equal(t, nsId, events[0].CustomerId)
 
 				props := *events[0].Properties
-				require.Equal(t, int64(9), props["database_units"])
-				require.Equal(t, int64(6), props["search_units"])
+				require.Equal(t, int64(9), props[UsageDbUnits])
+				require.Equal(t, int64(6), props[UsageSearchUnits])
 				return nil
 			}).
 			Once()
@@ -286,8 +286,8 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
 				require.Len(t, events, 1)
 				require.Equal(t, nsId, events[0].CustomerId)
-				require.Equal(t, int64(9), (*events[0].Properties)["database_units"])
-				require.Equal(t, int64(6), (*events[0].Properties)["search_units"])
+				require.Equal(t, int64(9), (*events[0].Properties)[UsageDbUnits])
+				require.Equal(t, int64(6), (*events[0].Properties)[UsageSearchUnits])
 
 				return fmt.Errorf("failed to push usage events")
 			}).Once()

--- a/server/services/v1/billing_test.go
+++ b/server/services/v1/billing_test.go
@@ -34,7 +34,7 @@ type billingServiceSuite struct {
 	billing          *billingService
 	ctx              context.Context
 	nsMeta           metadata.NamespaceMetadata
-	mId              billing.MetronomeId
+	mId              billing.AccountId
 }
 
 func TestBillingServiceSuite(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
- Interface to request usage data from metronome within a time window:
```go
		resp, err := metronome.GetUsage(ctx, cid, &UsageRequest{
			BillableMetric: nil, // will get data for all metrics
			StartTime:      &rt,
			EndTime:        &rt,
			NextPage:       &nextPageToken,
		})
```

- Optionally, usage can be filtered by specific billing metric name like:
```go
		resp, err := metronome.GetUsage(ctx, cid, &UsageRequest{
			BillableMetric: &[]string{"search_units", "database_bytes"},
			StartTime:      &startTime,
			EndTime:        &endTime,
			NextPage:       &nextPageToken,
		})
```
- billing metric ids are hardcoded in config for now for dev/preview/prod, which will be loaded as an unbounded map

## How best to test these changes
- Unit tests

## Pre-requisite
- [ ] tigrisdata/tigris-infra#918
