### PR TITLE
fix: Allow dashes in while querying metric tags

### DIFF
--- a/server/services/v1/observability.go
+++ b/server/services/v1/observability.go
@@ -220,7 +220,7 @@ func (o *observabilityService) RegisterGRPC(grpc *grpc.Server) error {
 }
 
 func isAllowedMetricQueryInput(tagValue string) bool {
-	allowedPattern := regexp.MustCompile("^[a-zA-Z0-9_.]*$")
+	allowedPattern := regexp.MustCompile("^[a-zA-Z]+[a-zA-Z0-9._-]+$")
 	return allowedPattern.MatchString(tagValue)
 }
 

--- a/server/services/v1/observability_test.go
+++ b/server/services/v1/observability_test.go
@@ -25,7 +25,12 @@ func TestDatadogQueryValidation(t *testing.T) {
 	require.True(t, isAllowedMetricQueryInput("user_db"))
 	require.True(t, isAllowedMetricQueryInput("user_db_1"))
 	require.True(t, isAllowedMetricQueryInput("requests_count_ok.count"))
+	require.True(t, isAllowedMetricQueryInput("project-1"))
+
+	require.False(t, isAllowedMetricQueryInput(".project-1")) // must not start with dot
+	require.False(t, isAllowedMetricQueryInput("-project-1")) // must not start with dash
 	require.False(t, isAllowedMetricQueryInput("users:"))
 	require.False(t, isAllowedMetricQueryInput("users "))
 	require.False(t, isAllowedMetricQueryInput("users,foo:bar"))
+	require.False(t, isAllowedMetricQueryInput(""))
 }


### PR DESCRIPTION
## Describe your changes
Project and collection names were updated to allow `-` in the name. However the metric query endpoint did not allow it. This PR fixes this out of sync validation.

## How best to test these changes
Updated existing test to cover this.

## Issue ticket number and link
