### PR TITLE
feat: Add support for building(backfilling) collection search index using an API

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -31,7 +31,8 @@ const (
 	DeleteMethodName  = apiMethodPrefix + "Delete"
 	ReadMethodName    = apiMethodPrefix + "Read"
 
-	IndexCollection = apiMethodPrefix + "IndexCollection"
+	IndexCollection                 = apiMethodPrefix + "IndexCollection"
+	SearchIndexCollectionMethodName = apiMethodPrefix + "BuildSearchIndex"
 
 	SearchMethodName = apiMethodPrefix + "Search"
 

--- a/cmd/consistency/workload/document.go
+++ b/cmd/consistency/workload/document.go
@@ -15,7 +15,7 @@
 package workload
 
 import (
-	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
@@ -29,8 +29,8 @@ type IDocument interface {
 }
 
 type Document struct {
-	Id int64 `json:"id"`
-	F2 string
+	Id int64  `json:"id"`
+	F2 string `json:"F2" fake:"{sentence:50}"`
 	F3 []byte
 	F4 uuid.UUID
 	F5 time.Time
@@ -41,13 +41,15 @@ func (d *Document) ID() int64 {
 }
 
 func NewDocument(uniqueId int64) *Document {
-	return &Document{
-		Id: uniqueId,
-		F2: fmt.Sprintf("id_%d", uniqueId),
-		F3: []byte(`1234`),
-		F4: uuid.New(),
-		F5: time.Now().UTC(),
+	var document Document
+	if err := gofakeit.Struct(&document); err != nil {
+		log.Panic().Err(err).Msgf("failed in generating fake document")
 	}
+	document.Id = uniqueId
+	document.F3 = []byte(document.F2[0:rand.Intn(len(document.F2))]) //nolint:gosec
+	document.F4 = uuid.New()
+	document.F5 = time.Now().UTC()
+	return &document
 }
 
 func SerializeDocV1(doc *DocumentV1) ([]byte, error) {

--- a/server/middleware/timeout.go
+++ b/server/middleware/timeout.go
@@ -39,12 +39,12 @@ func timeoutUnaryServerInterceptor(timeout time.Duration) grpc.UnaryServerInterc
 		ctx, cancel = setDeadlineUsingHeader(ctx)
 
 		d, ok := ctx.Deadline()
-		if ok && info.FullMethod != api.IndexCollection && time.Until(d) > MaximumTimeout {
+		if ok && !isLongRunningAPI(info.FullMethod) && time.Until(d) > MaximumTimeout {
 			timeout = MaximumTimeout
 			ok = false
 		}
 
-		if !ok && info.FullMethod == api.IndexCollection {
+		if !ok && isLongRunningAPI(info.FullMethod) {
 			timeout = LongRunningTimeout
 		}
 
@@ -63,6 +63,10 @@ func timeoutUnaryServerInterceptor(timeout time.Duration) grpc.UnaryServerInterc
 
 		return handler(ctx, req)
 	}
+}
+
+func isLongRunningAPI(method string) bool {
+	return method == api.IndexCollection || method == api.SearchIndexCollectionMethodName
 }
 
 func setDeadlineUsingHeader(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -178,7 +178,7 @@ func (s *apiService) CommitTransaction(ctx context.Context, _ *api.CommitTransac
 
 	err := session.Commit(s.versionH, session.GetTx().Context().GetStagedDatabase() != nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, database.CreateApiError(err)
 	}
 
 	return &api.CommitTransactionResponse{}, nil
@@ -254,6 +254,21 @@ func (s *apiService) BuildCollectionIndex(ctx context.Context, r *api.BuildColle
 	}
 
 	return resp.Response.(*api.BuildCollectionIndexResponse), nil
+}
+
+func (s *apiService) BuildSearchIndex(ctx context.Context, r *api.BuildCollectionSearchIndexRequest) (*api.BuildCollectionSearchIndexResponse, error) {
+	qm := metrics.WriteQueryMetrics{}
+	accessToken, _ := request.GetAccessToken(ctx)
+
+	resp, err := s.sessions.ReadOnlyExecute(ctx, s.runnerFactory.GetSearchIndexRunner(r, &qm, accessToken), database.ReqOptions{
+		MetadataChange:     true,
+		InstantVerTracking: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Response.(*api.BuildCollectionSearchIndexResponse), nil
 }
 
 func (s *apiService) Replace(ctx context.Context, r *api.ReplaceRequest) (*api.ReplaceResponse, error) {

--- a/server/services/v1/billing/metronome_test.go
+++ b/server/services/v1/billing/metronome_test.go
@@ -17,11 +17,10 @@ package billing
 import (
 	"context"
 	"fmt"
-	"testing"
-	"time"
-
 	"io"
 	"net/http"
+	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/h2non/gock"
@@ -758,7 +757,6 @@ func TestMetronome_GetUsage(t *testing.T) {
 		require.Nil(t, resp)
 		require.True(t, gock.IsDone())
 	})
-
 }
 
 func TestMetronome_buildInvoice(t *testing.T) {

--- a/server/services/v1/billing/provider.go
+++ b/server/services/v1/billing/provider.go
@@ -16,7 +16,6 @@ package billing
 
 import (
 	"context"
-
 	"time"
 
 	"github.com/google/uuid"

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -79,13 +79,13 @@ func (runner *BaseQueryRunner) getDatabase(_ context.Context, tx transaction.Tx,
 
 	project, err := tenant.GetProject(projName)
 	if err != nil {
-		return nil, createApiError(err)
+		return nil, CreateApiError(err)
 	}
 
 	// otherwise, simply read from the in-memory cache/disk.
 	db, err := project.GetDatabase(dbBranch)
 	if err != nil {
-		return nil, createApiError(err)
+		return nil, CreateApiError(err)
 	}
 
 	return db, nil

--- a/server/services/v1/database/collection_runner.go
+++ b/server/services/v1/database/collection_runner.go
@@ -106,7 +106,7 @@ func (runner *CollectionQueryRunner) createOrUpdate(ctx context.Context, tx tran
 		collectionExists = true
 		oldMetadata, err = tenant.GetCollectionMetadata(ctx, tx, db, req.GetCollection())
 		if err != nil && err != errors.ErrNotFound {
-			return Response{}, ctx, createApiError(err)
+			return Response{}, ctx, CreateApiError(err)
 		}
 	}
 
@@ -150,7 +150,7 @@ func (runner *CollectionQueryRunner) createOrUpdate(ctx context.Context, tx tran
 		if config.DefaultConfig.SecondaryIndex.WriteEnabled && oldMetadata != nil {
 			updatedMetadata, err := tenant.GetCollectionMetadata(ctx, tx, db, req.GetCollection())
 			if err != nil {
-				return Response{}, nil, createApiError(err)
+				return Response{}, nil, CreateApiError(err)
 			}
 
 			indexer := NewSecondaryIndexer(db.GetCollection(req.GetCollection()))
@@ -158,7 +158,7 @@ func (runner *CollectionQueryRunner) createOrUpdate(ctx context.Context, tx tran
 			for _, oldIndex := range oldMetadata.Indexes {
 				if !schema.HasIndex(updatedMetadata.Indexes, oldIndex) {
 					if err = indexer.DeleteIndex(ctx, tx, oldIndex); err != nil {
-						return Response{}, nil, createApiError(err)
+						return Response{}, nil, CreateApiError(err)
 					}
 				}
 			}

--- a/server/services/v1/database/database_runner.go
+++ b/server/services/v1/database/database_runner.go
@@ -202,7 +202,7 @@ func (runner *BranchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		dbBranch := metadata.NewDatabaseNameWithBranch(runner.createBranch.GetProject(), runner.createBranch.GetBranch())
 		err := tenant.CreateBranch(ctx, tx, runner.createBranch.GetProject(), dbBranch)
 		if err != nil {
-			return Response{}, ctx, createApiError(err)
+			return Response{}, ctx, CreateApiError(err)
 		}
 
 		countDDLCreateUnit(ctx)
@@ -216,7 +216,7 @@ func (runner *BranchQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		dbBranch := metadata.NewDatabaseNameWithBranch(runner.deleteBranch.GetProject(), runner.deleteBranch.GetBranch())
 		err := tenant.DeleteBranch(ctx, tx, runner.deleteBranch.GetProject(), dbBranch)
 		if err != nil {
-			return Response{}, ctx, createApiError(err)
+			return Response{}, ctx, CreateApiError(err)
 		}
 
 		countDDLDropUnit(ctx)

--- a/server/services/v1/database/errors.go
+++ b/server/services/v1/database/errors.go
@@ -24,8 +24,8 @@ import (
 	"github.com/tigrisdata/tigris/store/search"
 )
 
-// createApiError helps construct API errors from internal errors.
-func createApiError(err error) error {
+// CreateApiError helps construct API errors from internal errors.
+func CreateApiError(err error) error {
 	switch e := err.(type) {
 	case nil:
 		return nil
@@ -58,6 +58,8 @@ func createApiError(err error) error {
 		case kv.ErrCodeValueSizeExceeded, kv.ErrCodeTransactionSizeExceeded:
 			// ToDo: change it to 413, need to add it in proto
 			return apiErrors.ContentTooLarge(e.Msg())
+		case kv.ErrCodeConflictingTransaction:
+			return apiErrors.Aborted(e.Msg())
 		}
 	default:
 		return err

--- a/server/services/v1/database/indexer_runner.go
+++ b/server/services/v1/database/indexer_runner.go
@@ -15,14 +15,23 @@
 package database
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"time"
 
+	"github.com/buger/jsonparser"
 	"github.com/rs/zerolog/log"
 	api "github.com/tigrisdata/tigris/api/server/v1"
+	"github.com/tigrisdata/tigris/errors"
+	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/metrics"
+	"github.com/tigrisdata/tigris/store/kv"
+	"github.com/tigrisdata/tigris/store/search"
 	ulog "github.com/tigrisdata/tigris/util/log"
+	"github.com/tigrisdata/tigris/value"
 )
 
 type IndexerRunner struct {
@@ -38,8 +47,7 @@ func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tena
 		return Response{}, ctx, err
 	}
 
-	db, coll, err := runner.getDBAndCollection(ctx, tx, tenant,
-		runner.req.GetProject(), runner.req.GetCollection(), runner.req.GetBranch())
+	db, coll, err := runner.getDBAndCollection(ctx, tx, tenant, runner.req.GetProject(), runner.req.GetCollection(), runner.req.GetBranch())
 	if err != nil {
 		return Response{}, ctx, err
 	}
@@ -80,4 +88,144 @@ func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tena
 			Indexes: runner.indexToCollectionIndex(coll.SecondaryIndexes.All),
 		},
 	}, ctx, nil
+}
+
+type SearchIndexerRunner struct {
+	*BaseQueryRunner
+
+	ctx          context.Context
+	req          *api.BuildCollectionSearchIndexRequest
+	queryMetrics *metrics.WriteQueryMetrics
+	collection   *schema.DefaultCollection
+	sigDone      chan struct{}
+	close        bool
+	rowsWritten  int64
+	since        time.Time
+	logSince     time.Time
+}
+
+func (runner *SearchIndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tenant) (Response, context.Context, error) {
+	start := time.Now()
+	tx, err := runner.txMgr.StartTx(ctx)
+	if err != nil {
+		return Response{}, ctx, err
+	}
+	if _, runner.collection, err = runner.getDBAndCollection(
+		ctx,
+		tx,
+		tenant,
+		runner.req.GetProject(),
+		runner.req.GetCollection(),
+		runner.req.GetBranch(),
+	); err != nil {
+		return Response{}, ctx, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return Response{}, ctx, err
+	}
+
+	if _, err = runner.searchStore.DescribeCollection(ctx, runner.collection.ImplicitSearchIndex.StoreIndexName()); err != nil {
+		if search.IsErrNotFound(err) {
+			// this will be as part of options
+			err = runner.searchStore.CreateCollection(ctx, runner.collection.ImplicitSearchIndex.StoreSchema)
+		}
+
+		if err != nil {
+			return Response{}, ctx, err
+		}
+	}
+
+	runner.sigDone = make(chan struct{}, 1)
+	runner.ctx = ctx
+	runner.since = time.Now()
+	runner.logSince = time.Now()
+	s := NewStreamer(ctx, tenant, runner.BaseQueryRunner, runner)
+	s.Stream(createReadReq(runner.req))
+
+	runner.wait()
+
+	log.Info().Msgf("Total written '%d' rows in time '%v' for collection '%s' index '%s'",
+		runner.rowsWritten, time.Since(start), runner.collection.Name, runner.collection.ImplicitSearchIndex.StoreIndexName())
+
+	return Response{
+		Response: &api.BuildCollectionSearchIndexResponse{
+			Status: OkStatus,
+		},
+	}, nil, nil
+}
+
+func (runner *SearchIndexerRunner) wait() {
+	select {
+	case <-runner.ctx.Done():
+	case <-runner.sigDone:
+	}
+
+	runner.close = true
+}
+
+func (runner *SearchIndexerRunner) done() {
+	close(runner.sigDone)
+}
+
+func (runner *SearchIndexerRunner) consume(r *api.ReadResponse) error {
+	if runner.close {
+		return errors.Aborted("consumer exited")
+	}
+	index := runner.collection.PrimaryKey
+	indexParts := make([]any, len(index.Fields)+1)
+	indexParts[0] = index.Name
+	for i, f := range index.Fields {
+		jsonVal, dtp, _, err := jsonparser.Get(r.Data, f.FieldName)
+		if err != nil || dtp == jsonparser.NotExist {
+			return errors.Internal("unable to build index '%s' '%v'", err, dtp)
+		}
+
+		v, err := value.NewValue(f.Type(), jsonVal)
+		if err != nil {
+			return errors.Internal("unable to build index '%s' '%v'", err, dtp)
+		}
+		indexParts[i+1] = v.AsInterface()
+	}
+
+	id, err := CreateSearchKey(kv.BuildKey(indexParts...))
+	if err != nil {
+		return errors.Internal("unable to build search key '%v'", err)
+	}
+
+	searchData, err := PackSearchFields(runner.ctx, internal.NewTableData(r.Data), runner.collection, id)
+	if err != nil {
+		return err
+	}
+
+	reader := bytes.NewReader(searchData)
+	var resp []search.IndexResp
+	if resp, err = runner.searchStore.IndexDocuments(runner.ctx, runner.collection.ImplicitSearchIndex.StoreIndexName(), reader, search.IndexDocumentsOptions{
+		Action:    search.Create,
+		BatchSize: 1,
+	}); err != nil {
+		return err
+	}
+	if len(resp) == 1 && !resp[0].Success {
+		if resp[0].Code != http.StatusConflict {
+			// ignore the conflicts
+			return search.NewSearchError(resp[0].Code, search.ErrCodeUnhandled, resp[0].Error)
+		}
+	}
+
+	runner.rowsWritten++
+	if time.Since(runner.logSince) > 60*time.Second {
+		log.Info().Msgf("Written '%d' rows in time '%v' for collection '%s' index '%s'",
+			runner.rowsWritten, time.Since(runner.since), runner.collection.Name, runner.collection.ImplicitSearchIndex.StoreIndexName())
+		runner.logSince = time.Now()
+	}
+
+	return nil
+}
+
+func createReadReq(req *api.BuildCollectionSearchIndexRequest) *api.ReadRequest {
+	return &api.ReadRequest{
+		Project:    req.Project,
+		Collection: req.Collection,
+		Branch:     req.Branch,
+	}
 }

--- a/server/services/v1/database/query_runner_factory.go
+++ b/server/services/v1/database/query_runner_factory.go
@@ -135,10 +135,18 @@ func (f *QueryRunnerFactory) GetBranchQueryRunner(accessToken *types.AccessToken
 	}
 }
 
-func (f *QueryRunnerFactory) GetIndexRunner(req *api.BuildCollectionIndexRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *IndexerRunner {
+func (f *QueryRunnerFactory) GetIndexRunner(r *api.BuildCollectionIndexRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *IndexerRunner {
 	return &IndexerRunner{
-		req:             req,
-		queryMetrics:    queryMetrics,
 		BaseQueryRunner: NewBaseQueryRunner(f.encoder, f.cdcMgr, f.txMgr, f.searchStore, accessToken),
+		req:             r,
+		queryMetrics:    queryMetrics,
+	}
+}
+
+func (f *QueryRunnerFactory) GetSearchIndexRunner(r *api.BuildCollectionSearchIndexRequest, queryMetrics *metrics.WriteQueryMetrics, accessToken *types.AccessToken) *SearchIndexerRunner {
+	return &SearchIndexerRunner{
+		BaseQueryRunner: NewBaseQueryRunner(f.encoder, f.cdcMgr, f.txMgr, f.searchStore, accessToken),
+		req:             r,
+		queryMetrics:    queryMetrics,
 	}
 }

--- a/server/services/v1/database/request.go
+++ b/server/services/v1/database/request.go
@@ -26,6 +26,7 @@ const (
 	DeletedStatus  string = "deleted"
 	CreatedStatus  string = "created"
 	DroppedStatus  string = "dropped"
+	OkStatus       string = "success"
 )
 
 // Streaming is a wrapper interface for passing around for streaming reads.

--- a/server/services/v1/database/sessions.go
+++ b/server/services/v1/database/sessions.go
@@ -89,7 +89,7 @@ func (m *SessionManagerWithMetrics) measure(ctx context.Context, name string, f 
 func (m *SessionManagerWithMetrics) Create(ctx context.Context, trackVerInOwnTxn bool, instantVerTracking bool, track bool) (qs *QuerySession, err error) {
 	m.measure(ctx, "Create", func(ctx context.Context) error {
 		qs, err = m.s.Create(ctx, trackVerInOwnTxn, instantVerTracking, track)
-		return createApiError(err)
+		return CreateApiError(err)
 	})
 	return
 }
@@ -123,7 +123,7 @@ func (m *SessionManagerWithMetrics) Execute(ctx context.Context, runner QueryRun
 func (m *SessionManagerWithMetrics) executeWithRetry(ctx context.Context, runner QueryRunner, req ReqOptions) (resp Response, err error) {
 	m.measure(ctx, "executeWithRetry", func(ctx context.Context) error {
 		resp, err = m.s.executeWithRetry(ctx, runner, req)
-		return createApiError(err)
+		return CreateApiError(err)
 	})
 	return
 }
@@ -275,24 +275,21 @@ func (sessMgr *SessionManager) Execute(ctx context.Context, runner QueryRunner, 
 		}
 		resp, ctx, err := session.Run(runner)
 		session.ctx = ctx
-		return resp, createApiError(err)
+		return resp, CreateApiError(err)
 	}
 
 	resp, err := sessMgr.executeWithRetry(ctx, runner, req)
-	if err == kv.ErrConflictingTransaction {
-		return Response{}, errors.Aborted(err.Error())
-	}
-	return resp, createApiError(err)
+	return resp, CreateApiError(err)
 }
 
 func (sessMgr *SessionManager) ReadOnlyExecute(ctx context.Context, runner ReadOnlyQueryRunner, _ ReqOptions) (Response, error) {
 	session, err := sessMgr.CreateReadOnlySession(ctx)
 	if err != nil {
-		return Response{}, createApiError(err)
+		return Response{}, CreateApiError(err)
 	}
 
 	resp, _, err := session.Run(runner)
-	return resp, createApiError(err)
+	return resp, CreateApiError(err)
 }
 
 func (sessMgr *SessionManager) executeWithRetry(ctx context.Context, runner QueryRunner, req ReqOptions) (resp Response, err error) {

--- a/server/services/v1/database/stream_producer.go
+++ b/server/services/v1/database/stream_producer.go
@@ -1,0 +1,91 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	api "github.com/tigrisdata/tigris/api/server/v1"
+	metadata2 "github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/metrics"
+	"google.golang.org/grpc/metadata"
+)
+
+type consumer interface {
+	consume(r *api.ReadResponse) error
+	done()
+}
+
+type StreamProducer struct {
+	consumer consumer
+	base     *BaseQueryRunner
+	tenant   *metadata2.Tenant
+}
+
+func NewStreamer(_ context.Context, tenant *metadata2.Tenant, base *BaseQueryRunner, consumer consumer) *StreamProducer {
+	return &StreamProducer{
+		tenant:   tenant,
+		base:     base,
+		consumer: consumer,
+	}
+}
+
+func (c *StreamProducer) SetHeader(_ metadata.MD) error {
+	return nil
+}
+
+func (c *StreamProducer) SendHeader(_ metadata.MD) error {
+	return nil
+}
+
+func (c *StreamProducer) SetTrailer(_ metadata.MD) {}
+
+func (c *StreamProducer) Context() context.Context {
+	return context.TODO()
+}
+
+func (c *StreamProducer) SendMsg(_ interface{}) error {
+	return nil
+}
+
+func (c *StreamProducer) RecvMsg(_ interface{}) error {
+	return nil
+}
+
+func (c *StreamProducer) Stream(req *api.ReadRequest) {
+	streamingRunner := &StreamingQueryRunner{
+		req:             req,
+		streaming:       c,
+		BaseQueryRunner: c.base,
+		queryMetrics:    &metrics.StreamingQueryMetrics{},
+	}
+
+	go func() {
+		defer c.consumer.done()
+
+		_, _, err := streamingRunner.ReadOnly(context.Background(), c.tenant)
+		if err != nil {
+			// resume it based on last point
+			log.Error().Err(err).Msgf("Completed building of search index with an error '%v'", err)
+			return
+		}
+		log.Info().Msgf("Successfully completed building of search index for '%s'", streamingRunner.req.Collection)
+	}()
+}
+
+func (c *StreamProducer) Send(r *api.ReadResponse) error {
+	return c.consumer.consume(r)
+}

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -4847,8 +4847,7 @@ func TestFilteringOnArrays(t *testing.T) {
 			inputDocument,
 		},
 	}
-	for i, c := range cases {
-		fmt.Println("i: ", i)
+	for _, c := range cases {
 		readAndValidate(t,
 			db,
 			collection,


### PR DESCRIPTION
## Describe your changes

- Endpoint to build(backfill) collection search index
- Ensure sorting on field annotation is honored even if secondary indexes are enabled.

## How best to test these changes

## Issue ticket number and link
