### PR TITLE
feat: Background workers for index building

### DIFF
--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -733,6 +733,23 @@ func (x *DescribeCollectionResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (x *DescribeCollectionResponse) UnmarshalJSON(data []byte) error {
+
+	var desc collDesc
+	err := jsoniter.Unmarshal(data, &desc)
+	if err != nil {
+		return err
+	}
+
+	x.Collection = desc.Collection
+	x.Metadata = desc.Metadata
+	x.Schema = []byte(desc.Schema)
+	x.Size = desc.Size
+	x.Indexes = desc.Indexes
+
+	return nil
+}
+
 func (x *DescribeDatabaseResponse) MarshalJSON() ([]byte, error) {
 	resp := struct {
 		Metadata    *DatabaseMetadata `json:"metadata"`

--- a/api/server/v1/marshaler.go
+++ b/api/server/v1/marshaler.go
@@ -734,7 +734,6 @@ func (x *DescribeCollectionResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (x *DescribeCollectionResponse) UnmarshalJSON(data []byte) error {
-
 	var desc collDesc
 	err := jsoniter.Unmarshal(data, &desc)
 	if err != nil {

--- a/config/server.dev.yaml
+++ b/config/server.dev.yaml
@@ -41,4 +41,4 @@ secondary_index:
 
 workers:
   enabled: true
-  count: 5
+  count: 2

--- a/config/server.dev.yaml
+++ b/config/server.dev.yaml
@@ -38,3 +38,7 @@ secondary_index:
   read_enabled: true
   write_enabled: true
   mutate_enabled: true
+
+workers:
+  enabled: true
+  count: 5

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -514,7 +514,7 @@ var DefaultConfig = Config{
 	},
 	Workers: WorkersConfig{
 		Enabled: false,
-		Count:   5,
+		Count:   2,
 	},
 }
 

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -44,6 +44,7 @@ type Config struct {
 	Search          SearchConfig         `yaml:"search" json:"search"`
 	KV              KVConfig             `yaml:"kv" json:"kv"`
 	SecondaryIndex  SecondaryIndexConfig `mapstructure:"secondary_index" yaml:"secondary_index" json:"secondary_index"`
+	Workers         WorkersConfig        `yaml:"workers" json:"workers"`
 	Cache           CacheConfig          `yaml:"cache" json:"cache"`
 	Tracing         TracingConfig        `yaml:"tracing" json:"tracing"`
 	Metrics         MetricsConfig        `yaml:"metrics" json:"metrics"`
@@ -220,6 +221,11 @@ type SecondaryIndexMetricsConfig struct {
 	Counter      CounterConfig `mapstructure:"counter" yaml:"counter" json:"counter"`
 	Timer        TimerConfig   `mapstructure:"timer" yaml:"timer" json:"timer"`
 	FilteredTags []string      `mapstructure:"filtered_tags" yaml:"filtered_tags" json:"filtered_tags"`
+}
+
+type WorkersConfig struct {
+	Enabled bool `mapstructure:"enabled" yaml:"enabled" json:"enabled"`
+	Count   uint `mapstructure:"count" yaml:"count" json:"count"`
 }
 
 type ProfilingConfig struct {
@@ -505,6 +511,10 @@ var DefaultConfig = Config{
 	},
 	MetadataCluster: ClusterConfig{
 		Url: "https://api.global.tigrisdata.cloud",
+	},
+	Workers: WorkersConfig{
+		Enabled: false,
+		Count:   5,
 	},
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -120,7 +120,7 @@ func mainWithCode() int {
 	defer quota.Cleanup()
 
 	if cfg.Workers.Enabled {
-		workerPool := workers.NewWorkerPool(cfg.Workers.Count, tenantMgr.GetQueue(), txMgr, tenantMgr, 300*time.Millisecond)
+		workerPool := workers.NewWorkerPool(cfg.Workers.Count, tenantMgr.GetQueue(), txMgr, tenantMgr, 2*time.Second, 30*time.Second)
 		if !ulog.E(workerPool.Start()) {
 			defer workerPool.Stop()
 			log.Info().Msgf("initialized worker pool with %d workers", cfg.Workers.Count)

--- a/server/main.go
+++ b/server/main.go
@@ -121,11 +121,10 @@ func mainWithCode() int {
 
 	if cfg.Workers.Enabled {
 		workerPool := workers.NewWorkerPool(cfg.Workers.Count, tenantMgr.GetQueue(), txMgr, tenantMgr, 300*time.Millisecond)
-		if err := workerPool.Start(); ulog.E(err) {
-			log.Error().Err(err).Msgf("error starting worker pool")
+		if !ulog.E(workerPool.Start()) {
+			defer workerPool.Stop()
+			log.Info().Msgf("initialized worker pool with %d workers", cfg.Workers.Count)
 		}
-		defer workerPool.Stop()
-		log.Info().Msgf("initialized worker pool with %d workers", cfg.Workers.Count)
 	}
 
 	bProvider := billing.NewProvider()

--- a/server/metadata/collection.go
+++ b/server/metadata/collection.go
@@ -96,7 +96,6 @@ func (c *CollectionSubspace) updateMetadataIndexes(ctx context.Context, tx trans
 
 	if shouldAddIndexBuildTask && config.DefaultConfig.Workers.Enabled {
 		queueData, err := jsoniter.Marshal(IndexBuildTask{
-			TaskType:    1,
 			NamespaceId: ns.StrId(),
 			ProjName:    db.DbName(),
 			Branch:      db.BranchName(),

--- a/server/metadata/collection.go
+++ b/server/metadata/collection.go
@@ -79,7 +79,7 @@ func (c *CollectionSubspace) Create(ctx context.Context, tx transaction.Tx, ns N
 	return meta, nil
 }
 
-func (c *CollectionSubspace) updateMetadataIndexes(ctx context.Context, tx transaction.Tx, ns Namespace, db *Database, name string, _id uint32, metadata *CollectionMetadata, updatedIndexes []*schema.Index,
+func (c *CollectionSubspace) updateMetadataIndexes(ctx context.Context, tx transaction.Tx, ns Namespace, db *Database, name string, _ uint32, metadata *CollectionMetadata, updatedIndexes []*schema.Index,
 ) error {
 	shouldAddIndexBuildTask := false
 	for _, updateIdx := range updatedIndexes {

--- a/server/metadata/dictionary_test.go
+++ b/server/metadata/dictionary_test.go
@@ -32,6 +32,13 @@ func testClearDictionary(ctx context.Context, k *Dictionary, kvStore kv.TxStore)
 	_ = kvStore.DropTable(ctx, k.NamespaceSubspaceName())
 }
 
+func buildNsAndDBFrom(nsMeta *NamespaceMetadata, dbMeta *DatabaseMetadata) (Namespace, *Database) {
+	ns := NewTenantNamespace(nsMeta.Name, *nsMeta)
+	db := NewDatabase(dbMeta.ID, "db-1")
+
+	return ns, db
+}
+
 func TestDictionaryEncoding(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -47,7 +54,8 @@ func TestDictionaryEncoding(t *testing.T) {
 
 	tx, err := tm.StartTx(ctx)
 	require.NoError(t, err)
-	require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")))
+	nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
+	require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", nsMeta))
 	require.NoError(t, tx.Commit(ctx))
 
 	tx, err = tm.StartTx(ctx)
@@ -58,7 +66,8 @@ func TestDictionaryEncoding(t *testing.T) {
 
 	tx, err = tm.StartTx(ctx)
 	require.NoError(t, err)
-	collMeta, err := k.CreateCollection(ctx, tx, "coll-1", 1234, startId, createSecondaryIdxs())
+	ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+	collMeta, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit(ctx))
 
@@ -143,7 +152,8 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")))
+		nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
+		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", nsMeta))
 		require.NoError(t, tx.Commit(ctx))
 
 		tx, err = tm.StartTx(ctx)
@@ -154,7 +164,8 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err = tm.StartTx(ctx)
 		require.NoError(t, err)
-		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", 1234, dbMeta.ID, createSecondaryIdxs())
+		ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 		require.NoError(t, tx.Commit(ctx))
 
@@ -190,7 +201,8 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")))
+		nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
+		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", nsMeta))
 		require.NoError(t, tx.Commit(ctx))
 
 		tx, err = tm.StartTx(ctx)
@@ -202,7 +214,9 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err = tm.StartTx(ctx)
 		require.NoError(t, err)
-		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", 1234, dbMeta.ID, createSecondaryIdxs())
+
+		ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 		require.NoError(t, tx.Commit(ctx))
 		require.NotEqual(t, 0, collMeta.ID)
@@ -245,7 +259,8 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err := tm.StartTx(ctx)
 		require.NoError(t, err)
-		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")))
+		nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
+		require.NoError(t, k.ReserveNamespace(ctx, tx, "proj1-org-1", nsMeta))
 		require.NoError(t, tx.Commit(ctx))
 
 		tx, err = tm.StartTx(ctx)
@@ -256,7 +271,8 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err = tm.StartTx(ctx)
 		require.NoError(t, err)
-		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", 1234, dbMeta.ID, createSecondaryIdxs())
+		ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+		collMeta, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 		require.NoError(t, tx.Commit(ctx))
 
@@ -281,7 +297,7 @@ func TestDictionaryEncodingDropped(t *testing.T) {
 
 		tx, err = tm.StartTx(ctx)
 		require.NoError(t, err)
-		newColl, err := k.CreateCollection(ctx, tx, "coll-1", 1234, dbMeta.ID, createSecondaryIdxs())
+		newColl, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 		require.NoError(t, tx.Commit(ctx))
 
@@ -299,6 +315,7 @@ func TestDictionaryEncoding_Error(t *testing.T) {
 	defer cancel()
 
 	k := NewMetadataDictionary(newTestNameRegistry(t))
+	nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
 	testClearDictionary(ctx, k, kvStore)
 
 	tm := transaction.NewManager(kvStore)
@@ -309,7 +326,11 @@ func TestDictionaryEncoding_Error(t *testing.T) {
 	_, err = k.CreateDatabase(ctx, tx, "db-1", 0, 0)
 	require.Error(t, errors.InvalidArgument("invalid namespace id"), err)
 
-	_, err = k.CreateCollection(ctx, tx, "coll-1", 1234, 0, createSecondaryIdxs())
+	dbMeta := &DatabaseMetadata{
+		ID: 0,
+	}
+	ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+	_, err = k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 	require.Error(t, errors.InvalidArgument("invalid database id"), err)
 
 	_, err = k.CreatePrimaryIndex(ctx, tx, "pkey", 1234, 1, 0)
@@ -348,6 +369,7 @@ func TestDictionaryEncoding_GetMethods(t *testing.T) {
 		defer cancel()
 
 		k := NewMetadataDictionary(newTestNameRegistry(t))
+		nsMeta := NewNamespaceMetadata(1, "proj1-org-1", "proj1-org-1-display_name")
 		testClearDictionary(ctx, k, kvStore)
 
 		tx, err := tm.StartTx(ctx)
@@ -355,9 +377,10 @@ func TestDictionaryEncoding_GetMethods(t *testing.T) {
 		dbMeta, err := k.CreateDatabase(ctx, tx, "db-1", 1, 0)
 		require.NoError(t, err)
 
-		cid1, err := k.CreateCollection(ctx, tx, "coll-1", 1, dbMeta.ID, createSecondaryIdxs())
+		ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+		cid1, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
-		cid2, err := k.CreateCollection(ctx, tx, "coll-2", 1, dbMeta.ID, createSecondaryIdxs())
+		cid2, err := k.CreateCollection(ctx, tx, "coll-2", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 
 		collToId, err := k.GetCollections(ctx, tx, 1, dbMeta.ID)
@@ -380,7 +403,9 @@ func TestDictionaryEncoding_GetMethods(t *testing.T) {
 		dbMeta, err := k.CreateDatabase(ctx, tx, "db-1", 1, 0)
 		require.NoError(t, err)
 
-		cid1, err := k.CreateCollection(ctx, tx, "coll-1", 1, dbMeta.ID, createSecondaryIdxs())
+		nsMeta := NewNamespaceMetadata(1234, "proj1-org-1", "proj1-org-1-display_name")
+		ns, db := buildNsAndDBFrom(&nsMeta, dbMeta)
+		cid1, err := k.CreateCollection(ctx, tx, "coll-1", ns, db, createSecondaryIdxs())
 		require.NoError(t, err)
 
 		pkID, err := k.CreatePrimaryIndex(ctx, tx, "pkey", 1, dbMeta.ID, cid1.ID)

--- a/server/metadata/queue_test.go
+++ b/server/metadata/queue_test.go
@@ -28,7 +28,7 @@ func initQueueTest(t *testing.T) (*QueueSubspace, transaction.Tx, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	s := newQueueStore(newTestNameRegistry(t))
+	s := NewQueueStore(newTestNameRegistry(t))
 
 	_ = kvStore.DropTable(ctx, s.SubspaceName)
 
@@ -51,7 +51,7 @@ func TestEnqueueAndpeek(t *testing.T) {
 
 		checkQueueEmpty(t, queue, tx)
 
-		item := NewQueueItem(0, []byte("item1"))
+		item := NewQueueItem(0, []byte("item1"), TEST_QUEUE_TASK)
 		assert.NoError(t, queue.Enqueue(ctx, tx, item, 100*time.Millisecond))
 
 		checkQueueEmpty(t, queue, tx)
@@ -71,7 +71,7 @@ func TestEnqueueAndpeek(t *testing.T) {
 		defer cleanup()
 
 		for i, data := range toEnQueue {
-			item := NewQueueItem(0, []byte(data))
+			item := NewQueueItem(0, []byte(data), TEST_QUEUE_TASK)
 			assert.NoError(t, queue.Enqueue(ctx, tx, item, time.Duration(i*100)*time.Millisecond))
 		}
 
@@ -96,7 +96,7 @@ func TestEnqueueAndpeek(t *testing.T) {
 		defer cleanup()
 
 		for _, data := range toEnQueue {
-			item := NewQueueItem(0, []byte(data))
+			item := NewQueueItem(0, []byte(data), TEST_QUEUE_TASK)
 			assert.NoError(t, queue.Enqueue(ctx, tx, item, 1*time.Millisecond))
 		}
 
@@ -110,9 +110,9 @@ func TestEnqueueAndpeek(t *testing.T) {
 
 func TestPriorityInPeek(t *testing.T) {
 	t.Run("orderd by different time and priority", func(t *testing.T) {
-		item1 := NewQueueItem(0, []byte("one-item"))
-		item2 := NewQueueItem(1, []byte("two-item"))
-		item3 := NewQueueItem(0, []byte("one-item"))
+		item1 := NewQueueItem(0, []byte("one-item"), TEST_QUEUE_TASK)
+		item2 := NewQueueItem(1, []byte("two-item"), TEST_QUEUE_TASK)
+		item3 := NewQueueItem(0, []byte("one-item"), TEST_QUEUE_TASK)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -135,7 +135,7 @@ func TestPriorityInPeek(t *testing.T) {
 }
 
 func TestEnqueueObtainComplete(t *testing.T) {
-	item := NewQueueItem(0, []byte("one-item"))
+	item := NewQueueItem(0, []byte("one-item"), TEST_QUEUE_TASK)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -168,7 +168,7 @@ func TestEnqueueObtainComplete(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
-	item := NewQueueItem(0, []byte("one-item"))
+	item := NewQueueItem(0, []byte("one-item"), TEST_QUEUE_TASK)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -188,7 +188,7 @@ func TestWorkProcessFlow(t *testing.T) {
 	items := make([]*QueueItem, 0, 5)
 	activeItems := make([]QueueItem, 0, 5)
 	for _, data := range []string{"one", "two", "three", "four", "five"} {
-		items = append(items, NewQueueItem(0, []byte(data)))
+		items = append(items, NewQueueItem(0, []byte(data), TEST_QUEUE_TASK))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -203,6 +203,10 @@ func (m *TenantManager) GetEncoder() Encoder {
 	return m.encoder
 }
 
+func (m *TenantManager) GetQueue() *QueueSubspace {
+	return m.metaStore.queueStore
+}
+
 // CreateTenant is a thread safe implementation of creating a new tenant. It returns an error if it already exists.
 func (m *TenantManager) CreateTenant(ctx context.Context, tx transaction.Tx, namespace Namespace) (Namespace, error) {
 	m.Lock()
@@ -1331,7 +1335,7 @@ func (tenant *Tenant) createCollection(ctx context.Context, tx transaction.Tx, d
 
 	database.MetadataChange = true
 
-	collMeta, err := tenant.MetaStore.CreateCollection(ctx, tx, schFactory.Name, tenant.namespace.Id(), database.id, schFactory.SecondaryIndexes())
+	collMeta, err := tenant.MetaStore.CreateCollection(ctx, tx, schFactory.Name, tenant.namespace, database, schFactory.SecondaryIndexes())
 	if err != nil {
 		return err
 	}
@@ -1440,8 +1444,7 @@ func (tenant *Tenant) updateCollection(ctx context.Context, tx transaction.Tx, d
 	if err != nil {
 		return err
 	}
-
-	collMeta, err := tenant.MetaStore.UpdateCollection(ctx, tx, existingCollection.Name, tenant.namespace.Id(), database.id, existingCollection.Id, schFactory.SecondaryIndexes())
+	collMeta, err := tenant.MetaStore.UpdateCollection(ctx, tx, existingCollection.Name, tenant.namespace, database, existingCollection.Id, schFactory.SecondaryIndexes())
 	if err != nil {
 		return err
 	}
@@ -1531,7 +1534,7 @@ func (tenant *Tenant) UpdateCollectionIndexes(ctx context.Context, tx transactio
 	if !ok {
 		return errors.NotFound("collection doesn't exists '%s'", collectionName)
 	}
-	_, err := tenant.MetaStore.Collection().Update(ctx, tx, tenant.namespace.Id(), db.id, collectionName, cHolder.id, indexes)
+	_, err := tenant.MetaStore.Collection().Update(ctx, tx, tenant.namespace, db, collectionName, cHolder.id, indexes)
 	if err != nil {
 		return err
 	}

--- a/server/services/v1/database/indexer_runner.go
+++ b/server/services/v1/database/indexer_runner.go
@@ -67,7 +67,7 @@ func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tena
 		return Response{}, ctx, err
 	}
 
-	if err = indexer.BuildCollection(ctx, runner.txMgr); err != nil {
+	if err = indexer.BuildCollection(ctx, runner.txMgr, nil); err != nil {
 		log.Err(err).Msgf("Failed to index collection \"%s\" for db \"%s\"", coll.Name, db.DbName())
 		return Response{}, ctx, err
 	}

--- a/server/services/v1/database/secondary_index_measure.go
+++ b/server/services/v1/database/secondary_index_measure.go
@@ -63,9 +63,9 @@ func (*secondaryIndexerWithMetrics) measure(ctx context.Context, name string, f 
 	}
 }
 
-func (m *secondaryIndexerWithMetrics) BuildCollection(ctx context.Context, txMgr *transaction.Manager) (err error) {
+func (m *secondaryIndexerWithMetrics) BuildCollection(ctx context.Context, txMgr *transaction.Manager, progressUpdateFn ProgressUpdateFn) (err error) {
 	m.measure(ctx, "BuildCollection", func(ctx context.Context) error {
-		err = m.q.BuildCollection(ctx, txMgr)
+		err = m.q.BuildCollection(ctx, txMgr, progressUpdateFn)
 		return err
 	})
 	return

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -817,7 +817,7 @@ func TestBulkIndexing(t *testing.T) {
 	}
 	assert.NoError(t, tx.Commit(ctx))
 
-	err = indexStore.BuildCollection(ctx, tm)
+	err = indexStore.BuildCollection(ctx, tm, nil)
 	assert.NoError(t, err)
 
 	tx, err = tm.StartTx(ctx)

--- a/server/services/v1/workers/worker.go
+++ b/server/services/v1/workers/worker.go
@@ -1,0 +1,408 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workers
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/rs/zerolog/log"
+	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/services/v1/database"
+	"github.com/tigrisdata/tigris/server/transaction"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+const (
+	MAX_ERROR_COUNT = 10
+	LEASE_TIME      = 1 * time.Minute
+)
+
+type WorkerTestTask struct {
+	Sleep            time.Duration `json:"sleep"`
+	NumErrors        int           `json:"error_count"`
+	ShouldStopWorker bool          `json:"should_stop_worker"`
+}
+
+type Worker struct {
+	id        uint
+	queue     *metadata.QueueSubspace
+	txMgr     *transaction.Manager
+	tenantMgr *metadata.TenantManager
+	errCount  uint
+	// Indicated to the worker to shutdown
+	done chan struct{}
+	// How long the worker sleeps between checking queue
+	sleepTime    time.Duration
+	itemEvent    chan<- Event
+	hearbeatChan chan<- uint
+}
+
+type Event struct {
+	Success  bool
+	Item     metadata.QueueItem
+	WorkerId uint
+}
+
+func newEvent(success bool, item metadata.QueueItem, workerId uint) Event {
+	return Event{
+		success,
+		item,
+		workerId,
+	}
+}
+
+func newWorker(id uint, queue *metadata.QueueSubspace, txMgr *transaction.Manager, tenantMgr *metadata.TenantManager, sleepTime time.Duration, itemEvent chan<- Event, heartbeatChan chan<- uint) *Worker {
+	return &Worker{
+		id:           id,
+		queue:        queue,
+		txMgr:        txMgr,
+		tenantMgr:    tenantMgr,
+		errCount:     0,
+		done:         make(chan struct{}, 1),
+		sleepTime:    sleepTime,
+		itemEvent:    itemEvent,
+		hearbeatChan: heartbeatChan,
+	}
+}
+
+// Add a slightly random jitter for each worker
+// This helps avoid a situation where every worker
+// starts or peaks at the exact time and all tries to read from the job queue.
+func (w *Worker) jitterSleep() {
+	//nolint:gosec // it is ok to use a weak random generator here
+	jitterSleep := rand.Intn(500)
+	time.Sleep(time.Duration(jitterSleep)*time.Millisecond + w.sleepTime)
+}
+
+func (w *Worker) Start() {
+	w.jitterSleep()
+	w.Loop()
+}
+
+func (w *Worker) Loop() {
+	hbTicker := time.NewTicker(1500 * time.Millisecond)
+	for {
+		select {
+		case <-w.done:
+			log.Info().Msgf("Worker %d shutting down", w.id)
+			return
+		case <-hbTicker.C:
+			w.hearbeatChan <- w.id
+		default:
+			err := w.peekAndProcess()
+			if err != nil {
+				w.errCount += 1
+				// if the worker is getting to many errors in a row
+				// shut the worker down and restart a new one
+				if w.errCount >= MAX_ERROR_COUNT {
+					w.Stop()
+				}
+				return
+			}
+			w.errCount = 0
+		}
+		w.jitterSleep()
+	}
+}
+
+func (w *Worker) Stop() {
+	w.done <- struct{}{}
+}
+
+func (w *Worker) peekAndProcess() error {
+	ctx := context.Background()
+	tx, err := w.txMgr.StartTx(ctx)
+	if err != nil {
+		return err
+	}
+	items, err := w.queue.Peek(ctx, tx, 10)
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return tx.Rollback(ctx)
+	}
+	selectedItem, err := w.queue.ObtainLease(ctx, tx, &items[0], LEASE_TIME)
+	log.Debug().Msgf("Worker %d: proceeding it %s", w.id, selectedItem.Id)
+	if err != nil {
+		return err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	if err = w.processItem(selectedItem); err != nil {
+		log.Err(err).Msgf("Worker %d: failed to proceeds %s", w.id, selectedItem.Id)
+		return w.handleFailedProcessing(ctx, selectedItem)
+	}
+
+	log.Info().Msgf("Worker %d: Completed %s", w.id, selectedItem.Id)
+	w.itemEvent <- newEvent(true, *selectedItem, w.id)
+	return nil
+}
+
+func (w *Worker) handleFailedProcessing(ctx context.Context, selectedItem *metadata.QueueItem) error {
+	selectedItem.ErrorCount += 1
+	tx, err := w.txMgr.StartTx(ctx)
+	if err != nil {
+		return err
+	}
+	// The queue item has had to many errors the job will remove it from the queue
+	if selectedItem.ErrorCount >= MAX_ERROR_COUNT {
+		log.Err(err).Msgf("Worker %d: Max fail count, dropping item %s from the queue", w.id, selectedItem.Id)
+		w.itemEvent <- newEvent(false, *selectedItem, w.id)
+		if err = w.queue.Dequeue(ctx, tx, selectedItem); err != nil {
+			return err
+		}
+	} else {
+		if err = w.queue.Requeue(ctx, tx, selectedItem, w.sleepTime*time.Duration(selectedItem.ErrorCount)); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (w *Worker) processItem(queueItem *metadata.QueueItem) error {
+	switch queueItem.TaskType {
+	case metadata.BUILD_INDEX_QUEUE_TASK:
+		return w.buildIndexTask(queueItem)
+	case metadata.TEST_QUEUE_TASK:
+		return w.testQueueTask(queueItem)
+	}
+
+	return fmt.Errorf("unknown job type")
+}
+
+func (w *Worker) testQueueTask(item *metadata.QueueItem) error {
+	ctx := context.Background()
+	var testTask WorkerTestTask
+	if err := jsoniter.Unmarshal(item.Data, &testTask); err != nil {
+		return err
+	}
+
+	if testTask.ShouldStopWorker {
+		testTask.ShouldStopWorker = false
+		item.Data, _ = jsoniter.Marshal(testTask)
+		w.Stop()
+		return fmt.Errorf("forced worker stop %d", w.id)
+	}
+
+	if testTask.NumErrors > 0 {
+		testTask.NumErrors -= 1
+		item.Data, _ = jsoniter.Marshal(testTask)
+		return fmt.Errorf("test error generated %d", testTask.NumErrors)
+	}
+
+	tx, err := w.txMgr.StartTx(ctx)
+	if err != nil {
+		return err
+	}
+	if err = w.queue.Complete(ctx, tx, item); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (w *Worker) buildIndexTask(queueItem *metadata.QueueItem) error {
+	var task metadata.IndexBuildTask
+	if err := jsoniter.Unmarshal(queueItem.Data, &task); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	dbBranch := metadata.NewDatabaseNameWithBranch(task.ProjName, task.Branch)
+	tenant, _ := w.tenantMgr.GetTenant(ctx, task.NamespaceId)
+
+	project, err := tenant.GetProject(task.ProjName)
+	if err != nil {
+		return err
+	}
+
+	db, err := project.GetDatabase(dbBranch)
+	if err != nil {
+		return err
+	}
+
+	coll := db.GetCollection(task.CollName)
+	indexer := database.NewSecondaryIndexer(coll)
+
+	// Extend the lease of the queue item so that another worker does not
+	// try and process it
+	progressUpdate := func(ctx context.Context, tx transaction.Tx) error {
+		return w.queue.RenewLease(ctx, tx, queueItem, LEASE_TIME)
+	}
+	if err = indexer.BuildCollection(ctx, w.txMgr, progressUpdate); err != nil {
+		return err
+	}
+
+	for _, index := range coll.SecondaryIndexes.All {
+		index.State = schema.INDEX_ACTIVE
+	}
+
+	tx, err := w.txMgr.StartTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err = tenant.UpdateCollectionIndexes(ctx, tx, db, coll.Name, coll.SecondaryIndexes.All); ulog.E(err) {
+		return err
+	}
+
+	if err = w.queue.Complete(ctx, tx, queueItem); ulog.E(err) {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+type WorkerInfo struct {
+	worker       *Worker
+	lastHearbeat time.Time
+}
+
+type WorkerPool struct {
+	sync.Mutex
+	maxWorkers       uint
+	queue            *metadata.QueueSubspace
+	txMgr            *transaction.Manager
+	tenantMgr        *metadata.TenantManager
+	workers          []WorkerInfo
+	nextWorkerId     uint
+	workerSleepTime  time.Duration
+	heartbeatChan    chan uint
+	stopChan         chan struct{}
+	eventChan        chan Event
+	eventListeteners []chan<- Event
+}
+
+type Complete func(item *metadata.QueueItem)
+
+func NewWorkerPool(maxWorkers uint, queue *metadata.QueueSubspace, txMgr *transaction.Manager, tenantMgr *metadata.TenantManager, workerSleepTime time.Duration) *WorkerPool {
+	return &WorkerPool{
+		maxWorkers:      maxWorkers,
+		queue:           queue,
+		txMgr:           txMgr,
+		tenantMgr:       tenantMgr,
+		workers:         make([]WorkerInfo, 0),
+		nextWorkerId:    0,
+		workerSleepTime: workerSleepTime,
+		heartbeatChan:   make(chan uint, maxWorkers*3),
+		stopChan:        make(chan struct{}, 1),
+		eventChan:       make(chan Event, maxWorkers*3),
+		// This is for testing
+		eventListeteners: make([]chan<- Event, 0),
+	}
+}
+
+func (pool *WorkerPool) Start() error {
+	for i := uint(0); i < pool.maxWorkers; i++ {
+		pool.nextWorkerId = i
+		pool.workers = append(pool.workers, pool.newWorker(i))
+	}
+
+	go pool.Loop()
+	return nil
+}
+
+func (pool *WorkerPool) newWorker(id uint) WorkerInfo {
+	worker := newWorker(id, pool.queue, pool.txMgr, pool.tenantMgr, pool.workerSleepTime, pool.eventChan, pool.heartbeatChan)
+	go worker.Start()
+	return WorkerInfo{
+		worker:       worker,
+		lastHearbeat: time.Now(),
+	}
+}
+
+func (pool *WorkerPool) Subscribe(listener chan<- Event) {
+	pool.Lock()
+	defer pool.Unlock()
+	pool.eventListeteners = append(pool.eventListeteners, listener)
+}
+
+func (pool *WorkerPool) notify(event Event) {
+	pool.Lock()
+	defer pool.Unlock()
+	for _, listener := range pool.eventListeteners {
+		listener <- event
+	}
+}
+
+func (pool *WorkerPool) Loop() {
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-pool.stopChan:
+			log.Info().Msg("shutting down worker pool")
+			return
+		case id := <-pool.heartbeatChan:
+			pool.rxHeartbeats(id)
+		case event := <-pool.eventChan:
+			pool.notify(event)
+		case <-ticker.C:
+			pool.checkHeartbeats()
+		}
+	}
+}
+
+func (pool *WorkerPool) rxHeartbeats(workerId uint) {
+	pool.Lock()
+	defer pool.Unlock()
+
+	for _, info := range pool.workers {
+		if info.worker.id == workerId {
+			info.lastHearbeat = time.Now()
+			return
+		}
+	}
+
+	log.Error().Msgf("received heartbeat from missing worker id %d", workerId)
+}
+
+func (pool *WorkerPool) checkHeartbeats() {
+	pool.Lock()
+	defer pool.Unlock()
+
+	now := time.Now()
+	active := pool.workers[:0]
+	for _, info := range pool.workers {
+		if now.Sub(info.lastHearbeat) > 2*time.Second {
+			info.worker.Stop()
+			pool.nextWorkerId++
+			log.Info().Msgf("No response from worker %d adding new worker", info.worker.id)
+			active = append(active, pool.newWorker(pool.nextWorkerId))
+		} else {
+			info.lastHearbeat = time.Now()
+			active = append(active, info)
+		}
+	}
+
+	pool.workers = active
+}
+
+func (pool *WorkerPool) Stop() {
+	pool.Lock()
+	defer pool.Unlock()
+	for _, info := range pool.workers {
+		info.worker.Stop()
+	}
+	pool.stopChan <- struct{}{}
+}

--- a/server/services/v1/workers/worker.go
+++ b/server/services/v1/workers/worker.go
@@ -113,11 +113,12 @@ func (w *Worker) Loop() {
 				// if the worker is getting to many errors in a row
 				// shut the worker down and restart a new one
 				if w.errCount >= MAX_ERROR_COUNT {
-					w.Stop()
+					log.Err(err).Msgf("Worker %d exceeded error count and shutting down", w.id)
+					return
 				}
-				return
+			} else {
+				w.errCount = 0
 			}
-			w.errCount = 0
 		}
 		w.jitterSleep()
 	}
@@ -160,7 +161,7 @@ func (w *Worker) peekAndProcess() error {
 }
 
 func (w *Worker) handleFailedProcessing(ctx context.Context, selectedItem *metadata.QueueItem) error {
-	selectedItem.ErrorCount += 1
+	selectedItem.ErrorCount++
 	tx, err := w.txMgr.StartTx(ctx)
 	if err != nil {
 		return err

--- a/server/services/v1/workers/worker_test.go
+++ b/server/services/v1/workers/worker_test.go
@@ -1,0 +1,188 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigris/server/config"
+	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/transaction"
+	"github.com/tigrisdata/tigris/store/kv"
+	ulog "github.com/tigrisdata/tigris/util/log"
+)
+
+var kvStore kv.TxStore
+
+func TestCompleteMultipleJobs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tm := transaction.NewManager(kvStore)
+	queue := metadata.NewQueueStore(&metadata.NameRegistry{QueueSB: "test_queue_" + t.Name()})
+	_ = kvStore.DropTable(ctx, queue.SubspaceName)
+	pool := NewWorkerPool(10, queue, tm, nil, 10*time.Millisecond)
+	assert.NoError(t, pool.Start())
+
+	for i := 0; i < 5; i++ {
+		tx, err := tm.StartTx(ctx)
+		assert.NoError(t, err)
+		err = queue.Enqueue(ctx, tx, testTask(t, time.Duration(i*10)*time.Millisecond, 0, false), 0)
+		assert.NoError(t, err)
+		assert.NoError(t, tx.Commit(ctx))
+	}
+
+	eventChan := make(chan Event)
+	pool.Subscribe(eventChan)
+
+	for i := 0; i < 5; i++ {
+		event := <-eventChan
+		assert.True(t, event.Success)
+	}
+	tx, err := tm.StartTx(ctx)
+	assert.NoError(t, err)
+	items, err := queue.GetAll(ctx, tx)
+	assert.NoError(t, err)
+	assert.NoError(t, tx.Rollback(ctx))
+	assert.Len(t, items, 0)
+}
+
+func TestJobWithToManyErrorsIsDropped(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tm := transaction.NewManager(kvStore)
+	queue := metadata.NewQueueStore(&metadata.NameRegistry{QueueSB: "test_queue_" + t.Name()})
+	_ = kvStore.DropTable(ctx, queue.SubspaceName)
+
+	pool := NewWorkerPool(3, queue, tm, nil, 10*time.Millisecond)
+	defer pool.Stop()
+	assert.NoError(t, pool.Start())
+	eventChan := make(chan Event)
+	pool.Subscribe(eventChan)
+
+	tx, err := tm.StartTx(ctx)
+	assert.NoError(t, err)
+	assert.NoError(t, queue.Enqueue(ctx, tx, testTask(t, 0, MAX_ERROR_COUNT+1, false), time.Duration(10*int(time.Millisecond))))
+	assert.NoError(t, tx.Commit(ctx))
+
+	event := <-eventChan
+	assert.Equal(t, uint8(10), event.Item.ErrorCount)
+	assert.Equal(t, false, event.Success)
+
+	time.Sleep(1 * time.Second)
+	tx, err = tm.StartTx(ctx)
+	assert.NoError(t, err)
+	items, err := queue.GetAll(ctx, tx)
+	assert.NoError(t, err)
+	assert.Len(t, items, 0)
+	assert.NoError(t, tx.Rollback(ctx))
+}
+
+func TestJobWithErrorCountMultipleWorkers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tm := transaction.NewManager(kvStore)
+	queue := metadata.NewQueueStore(&metadata.NameRegistry{QueueSB: "test_queue_" + t.Name()})
+	_ = kvStore.DropTable(ctx, queue.SubspaceName)
+
+	pool := NewWorkerPool(10, queue, tm, nil, 100*time.Millisecond)
+	defer pool.Stop()
+	assert.NoError(t, pool.Start())
+	completedChan := make(chan Event)
+	pool.Subscribe(completedChan)
+
+	for i := 0; i < 5; i++ {
+		tx, err := tm.StartTx(ctx)
+		assert.NoError(t, err)
+		assert.NoError(t, queue.Enqueue(ctx, tx, testTask(t, 0, i+1, false), time.Duration(i*10*int(time.Millisecond))))
+		assert.NoError(t, tx.Commit(ctx))
+	}
+	for i := 0; i < 5; i++ {
+		event := <-completedChan
+		assert.Equal(t, uint8(i+1), event.Item.ErrorCount)
+	}
+
+	tx, err := tm.StartTx(ctx)
+	assert.NoError(t, err)
+	items, err := queue.GetAll(ctx, tx)
+	assert.NoError(t, err)
+	assert.Len(t, items, 0)
+	assert.NoError(t, tx.Rollback(ctx))
+}
+
+func TestJobWithDyingWorkers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tm := transaction.NewManager(kvStore)
+	queue := metadata.NewQueueStore(&metadata.NameRegistry{QueueSB: "test_queue_" + t.Name()})
+	_ = kvStore.DropTable(ctx, queue.SubspaceName)
+
+	pool := NewWorkerPool(1, queue, tm, nil, 100*time.Millisecond)
+	defer pool.Stop()
+	assert.NoError(t, pool.Start())
+
+	completedChan := make(chan Event)
+	pool.Subscribe(completedChan)
+
+	tx, err := tm.StartTx(ctx)
+	assert.NoError(t, err)
+	assert.NoError(t, queue.Enqueue(ctx, tx, testTask(t, 0, 1, true), time.Duration(10*int(time.Millisecond))))
+	assert.NoError(t, tx.Commit(ctx))
+	event := <-completedChan
+	assert.Equal(t, uint8(2), event.Item.ErrorCount)
+
+	tx, err = tm.StartTx(ctx)
+	assert.NoError(t, err)
+	items, err := queue.GetAll(ctx, tx)
+	assert.NoError(t, err)
+	assert.Len(t, items, 0)
+	assert.NoError(t, tx.Rollback(ctx))
+}
+
+func testTask(t *testing.T, sleepTime time.Duration, errorCount int, shouldStopWorker bool) *metadata.QueueItem {
+	task := WorkerTestTask{
+		Sleep:            sleepTime,
+		NumErrors:        errorCount,
+		ShouldStopWorker: shouldStopWorker,
+	}
+	data, err := jsoniter.Marshal(task)
+	assert.NoError(t, err)
+	return metadata.NewQueueItem(0, data, metadata.TEST_QUEUE_TASK)
+}
+
+func TestMain(m *testing.M) {
+	ulog.Configure(ulog.LogConfig{Level: "disabled", Format: "console"})
+
+	fdbCfg, err := config.GetTestFDBConfig("../../../../")
+	if err != nil {
+		panic(fmt.Sprintf("failed to init FDB config: %v", err))
+	}
+
+	kvStore, err = kv.NewBuilder().WithStats().Build(fdbCfg)
+	if err != nil {
+		panic(fmt.Sprintf("failed to init FDB KV %v", err))
+	}
+
+	os.Exit(m.Run())
+}

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - TIGRIS_SERVER_SECONDARY_INDEX_WRITE_ENABLED=true
       - TIGRIS_SERVER_SECONDARY_INDEX_READ_ENABLED=true
       - TIGRIS_SERVER_SECONDARY_INDEX_MUTATE_ENABLED=true
+      - TIGRIS_SERVER_WORKERS_ENABLED=true
+      - TIGRIS_SERVER_WORKERS_COUNT=5
       - GOCOVERDIR=/tmp/tigris_coverdata
     build:
       context: ../../

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - TIGRIS_SERVER_SECONDARY_INDEX_READ_ENABLED=true
       - TIGRIS_SERVER_SECONDARY_INDEX_MUTATE_ENABLED=true
       - TIGRIS_SERVER_WORKERS_ENABLED=true
-      - TIGRIS_SERVER_WORKERS_COUNT=5
       - GOCOVERDIR=/tmp/tigris_coverdata
     build:
       context: ../../

--- a/test/v1/server/secondary_index_test.go
+++ b/test/v1/server/secondary_index_test.go
@@ -850,7 +850,6 @@ func TestQuery_BackgroundBuildIndex(t *testing.T) {
 
 	createCollection(t, db, coll, testBuildIndexSchema).Status(http.StatusOK)
 	waitForIndexesActive(t, db, coll)
-
 	cases := []struct {
 		filter Map
 		count  int
@@ -906,7 +905,6 @@ func TestQuery_BuildIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	checkIndexesActive(t, resp.Indexes)
-
 	str = describeCollection(t, db, coll, Map{}).Status(http.StatusOK).Body().Raw()
 	desc := Map{}
 	err = jsoniter.Unmarshal([]byte(str), &desc)
@@ -1013,7 +1011,7 @@ func waitForIndexesActive(t *testing.T, db string, coll string) {
 		}
 
 		count += 1
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 
 	assert.Fail(t, "indexes are not active")


### PR DESCRIPTION
## Describe your changes

Adds background workers and a worker pool to build secondary indexes. The background workers are managed via the worker pool. The background workers are off by default. I would like to do another PR first with metrics to give deeper insight into the system before enabling. 

## How best to test these changes
Current tests should pass 

## Issue ticket number and link
This closes #780 #911 #913 
