### PR TITLE
fix: Saving metadata on refresh accounts to cache

### DIFF
--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -294,6 +294,7 @@ func (m *TenantManager) RefreshNamespaceAccounts(ctx context.Context) error {
 			tenant.Lock()
 			tenantMeta := tenant.namespace.Metadata()
 			tenantMeta.Accounts = metadata.Accounts
+			tenant.namespace.SetMetadata(tenantMeta)
 			tenant.Unlock()
 		}
 	}


### PR DESCRIPTION
## Describe your changes
- There is an existing bug where `RefreshNamespaceAccounts()` is supposed to reload cached metadata from disk but it was not functional
- This change updates the in-memory cached namespace metadata after reload from disk

## How best to test these changes
- Unit tests

## Issue ticket number and link
