### PR TITLE
fix: Fix schema validation for dot notation in Update Query

### DIFF
--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -188,6 +188,10 @@ func (*BaseQueryRunner) mutateAndValidatePayload(ctx context.Context, coll *sche
 	}
 
 	if request.NeedSchemaValidation(ctx) {
+		if mutator.ofType() == updateMutator {
+			// there may be dot notation in the field
+			deserializedDoc = util.UnFlatMap(deserializedDoc)
+		}
 		if err = coll.Validate(deserializedDoc); err != nil {
 			// schema validation failed
 			return doc, err

--- a/server/services/v1/database/mutator.go
+++ b/server/services/v1/database/mutator.go
@@ -21,11 +21,17 @@ import (
 	"github.com/tigrisdata/tigris/server/services/v1/common"
 )
 
+const (
+	insertMutator = "insert_mutator"
+	updateMutator = "update_mutator"
+)
+
 type mutator interface {
 	isMutated() bool
 	stringToInt64(doc map[string]any) error
 	setDefaultsInIncomingPayload(doc map[string]any) error
 	setDefaultsInExistingPayload(doc map[string]any) error
+	ofType() string
 }
 
 type baseMutator struct {
@@ -75,6 +81,8 @@ func (mutator *insertPayloadMutator) setDefaults(doc map[string]any, field *sche
 	}
 }
 
+func (*insertPayloadMutator) ofType() string { return insertMutator }
+
 type updatePayloadMutator struct {
 	*baseMutator
 
@@ -114,6 +122,8 @@ func (mutator *updatePayloadMutator) setDefaults(doc map[string]any, field *sche
 		doc[field.FieldName] = mutator.updatedAt
 	}
 }
+
+func (*updatePayloadMutator) ofType() string { return updateMutator }
 
 func (p *baseMutator) isMutated() bool {
 	return p.mutated


### PR DESCRIPTION
## Describe your changes
In case of an update if there is a field with dot notation then we need to make sure to validate the schema with unflattened form. 

## How best to test these changes

## Issue ticket number and link
