### PR TITLE
fix: Remove extra null fields from search response

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -331,13 +331,14 @@ var DefaultConfig = Config{
 		StreamBuffer:   200,
 	},
 	Search: SearchConfig{
-		Host:           "localhost",
-		Port:           8108,
-		ReadEnabled:    true,
-		WriteEnabled:   true,
-		StorageEnabled: true,
-		Chunking:       true,
-		Compression:    false,
+		Host:              "localhost",
+		Port:              8108,
+		ReadEnabled:       true,
+		WriteEnabled:      true,
+		StorageEnabled:    true,
+		Chunking:          true,
+		Compression:       false,
+		IgnoreExtraFields: false,
 	},
 	KV: KVConfig{
 		Chunking:    false,
@@ -548,7 +549,8 @@ type SearchConfig struct {
 	// Chunking allows us to persist bigger search indexes payload in storage.
 	Chunking bool `mapstructure:"chunking" yaml:"chunking" json:"chunking"`
 	// Compression allows us to compress payload before storing in storage.
-	Compression bool `mapstructure:"compression" yaml:"compression" json:"compression"`
+	Compression       bool `mapstructure:"compression" yaml:"compression" json:"compression"`
+	IgnoreExtraFields bool `mapstructure:"ignore_extra_fields" yaml:"ignore_extra_fields" json:"ignore_extra_fields"`
 }
 
 type SecondaryIndexConfig struct {

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -190,7 +190,7 @@ func (*BaseQueryRunner) mutateAndValidatePayload(ctx context.Context, coll *sche
 	if request.NeedSchemaValidation(ctx) {
 		if mutator.ofType() == updateMutator {
 			// there may be dot notation in the field
-			deserializedDoc = util.UnFlatMap(deserializedDoc)
+			deserializedDoc = util.UnFlatMap(deserializedDoc, false)
 		}
 		if err = coll.Validate(deserializedDoc); err != nil {
 			// schema validation failed

--- a/server/services/v1/database/search_indexer_test.go
+++ b/server/services/v1/database/search_indexer_test.go
@@ -42,7 +42,7 @@ func TestFlattenObj(t *testing.T) {
 	require.Equal(t, float64(3), flattened["b.e"])
 	require.Equal(t, []any{float64(1), float64(2), float64(3)}, flattened["b.f"])
 
-	require.True(t, reflect.DeepEqual(unFlattenMap, util.UnFlatMap(flattened)))
+	require.True(t, reflect.DeepEqual(unFlattenMap, util.UnFlatMap(flattened, false)))
 }
 
 func TestPackSearchFields(t *testing.T) {

--- a/server/services/v1/search/indexer.go
+++ b/server/services/v1/search/indexer.go
@@ -239,7 +239,7 @@ func (transformer *transformer) inverseStart(doc map[string]any) (map[string]any
 	delete(doc, schema.ReservedFields[schema.UpdatedAt])
 
 	// unFlatten the map now
-	doc = util.UnFlatMap(doc)
+	doc = util.UnFlatMap(doc, false)
 	return doc, createdAt, updatedAt, nil
 }
 

--- a/test/v1/server/document_test.go
+++ b/test/v1/server/document_test.go
@@ -5559,6 +5559,9 @@ func TestComplexObjectsCollectionSearch(t *testing.T) {
                   "properties": {
                     "a": {
                       "type": "string"
+                    },
+                    "b": {
+                      "type": "string"
                     }
                   }
                 }
@@ -5587,8 +5590,31 @@ func TestComplexObjectsCollectionSearch(t *testing.T) {
               "properties": {
                 "a": {
                   "type": "string"
+                },
+                "b": {
+                  "type": "string"
                 }
               }
+            }
+          },
+          "f": {
+            "searchIndex": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "g": {
+            "searchIndex": true,
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "h": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           }
         }
@@ -5614,6 +5640,9 @@ func TestComplexObjectsCollectionSearch(t *testing.T) {
           "properties": {
             "a": {
               "type": "string"
+            },
+            "b": {
+              "type": "string"
             }
           }
         }
@@ -5623,6 +5652,27 @@ func TestComplexObjectsCollectionSearch(t *testing.T) {
         "type": "array",
         "items": {
           "type": "string"
+        }
+      },
+      "h": {
+        "searchIndex": true,
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "i": {
+        "searchIndex": true,
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      },
+      "j": {
+        "searchIndex": true,
+        "type": "array",
+        "items": {
+          "type": "object"
         }
       }
     }
@@ -5642,16 +5692,22 @@ func TestComplexObjectsCollectionSearch(t *testing.T) {
 			"c": Map{
 				"a": "foo",
 				"b": Map{"name": "this is free flow object but not indexed"},
-				"c": []Map{{"a": "car"}, {"a": "bike"}},
+				"c": []Map{{"a": "car"}, {"a": "bike", "b": nil}},
 				"d": []string{"PARIS", "LONDON", "ENGLAND"},
 			},
 			"d": []string{"SANTA CLARA", "SAN JOSE"},
-			"e": []Map{{"a": "football"}, {"a": "basketball"}},
+			"e": []Map{{"a": "football", "b": nil}, {"a": "basketball", "b": nil}},
+			"f": nil,
+			"g": nil,
+			"h": nil,
 		},
 		"d": Map{"agent": "free flow object top level"},
-		"e": []Map{{"random": "array of free flow object"}},
-		"f": []Map{{"a": "array of object with a field"}},
+		"e": []Map{{"random": "array of free flow object", "some_null": nil}, {"random": "array of free flow object", "some_null": nil}},
+		"f": []Map{{"a": "array of object with a field", "b": nil}, {"a": "array of object with a field second", "b": nil}},
 		"g": []string{"NEW YORK", "MIAMI"},
+		"h": nil,
+		"i": nil,
+		"j": nil,
 	}
 
 	insertDocuments(t, project, collectionName, []Doc{docA}, false).

--- a/util/util.go
+++ b/util/util.go
@@ -104,7 +104,7 @@ func flatMap(key string, obj map[string]any, resp map[string]any, notFlat contai
 	}
 }
 
-func UnFlatMap(flat map[string]any) map[string]any {
+func UnFlatMap(flat map[string]any, ignoreExtra bool) map[string]any {
 	result := make(map[string]any)
 
 	for k, v := range flat {
@@ -116,7 +116,13 @@ func UnFlatMap(flat map[string]any) map[string]any {
 				m[keys[i]] = make(map[string]any)
 			}
 
-			m = m[keys[i]].(map[string]any)
+			if ignoreExtra {
+				if _, ok := m[keys[i]].(map[string]any); ok {
+					m = m[keys[i]].(map[string]any)
+				}
+			} else {
+				m = m[keys[i]].(map[string]any)
+			}
 		}
 
 		if v != nil {


### PR DESCRIPTION
## Describe your changes
For an array of objects, if a field is set as null, then Search may return this extra field in a different form than stored. This diff is removing these extra fields that are not needed. 

## How best to test these changes

## Issue ticket number and link
