### PR TITLE
fix: Valid sort with no indexed fields in filter

### DIFF
--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -222,7 +222,7 @@ func (*BaseQueryRunner) buildSecondaryIndexKeysUsingFilter(coll *schema.DefaultC
 
 	filterFactory := filter.NewFactoryForSecondaryIndex(coll.GetActiveIndexedFields())
 	filters, err := filterFactory.Factorize(reqFilter)
-	if err != nil {
+	if err != nil && sortFields == nil {
 		return nil, err
 	}
 	return BuildSecondaryIndexKeys(coll, filters, sortFields)

--- a/test/v1/server/secondary_index_test.go
+++ b/test/v1/server/secondary_index_test.go
@@ -456,6 +456,19 @@ func firstFilterName(filter Map) string {
 	return fieldName
 }
 
+func TestQuery_SortWithNonIndexedFilter(t *testing.T) {
+	db, coll := setupIndexBuildTest(t, testBuildIndexSchema)
+	defer cleanupTests(t, db)
+	writeDocs(t, db, coll, 0, 5)
+
+	filter := Map{"double_value": 11.01}
+	options := []Map{{"int_value": "$desc"}}
+
+	resp := readByFilter(t, db, coll, filter, nil, nil, options)
+	ids := getIds(resp)
+	assert.Equal(t, []int{1}, ids)
+}
+
 func TestQuery_RangeWithNull(t *testing.T) {
 	db, coll := setupTests(t)
 	insertDocs(t, db, coll, Doc{


### PR DESCRIPTION
## Describe your changes
Fixes when the filter does not have an indexed field in the filter but the sort field is useable, the secondary secondary index can still be used

## How best to test these changes
All tests should pass

## Issue ticket number and link
