### PR TITLE
feat: more information in long request log

### DIFF
--- a/server/metrics/network.go
+++ b/server/metrics/network.go
@@ -42,16 +42,16 @@ func initializeNetworkScopes() {
 	BytesSent = NetworkMetrics.SubScope("bytes")
 }
 
-func (*Measurement) CountSentBytes(scope tally.Scope, tags map[string]string, size int) {
+func (m *Measurement) CountSentBytes(scope tally.Scope, tags map[string]string) {
 	if scope != nil {
 		// proto.Size has int, need to convert it here
-		scope.Tagged(tags).Counter("sent").Inc(int64(size))
+		scope.Tagged(tags).Counter("sent").Inc(int64(m.sentBytes))
 	}
 }
 
-func (*Measurement) CountReceivedBytes(scope tally.Scope, tags map[string]string, size int) {
+func (m *Measurement) CountReceivedBytes(scope tally.Scope, tags map[string]string) {
 	if scope != nil {
 		// proto.Size has int, need to convert it here
-		scope.Tagged(tags).Counter("received").Inc(int64(size))
+		scope.Tagged(tags).Counter("received").Inc(int64(m.receivedBytes))
 	}
 }

--- a/server/metrics/network_test.go
+++ b/server/metrics/network_test.go
@@ -26,10 +26,12 @@ func TestNetworkMetrics(t *testing.T) {
 	testMeasurement := NewMeasurement("test.service.name", "TestResource", "rpc", GetGlobalTags())
 
 	t.Run("Test bytes send", func(t *testing.T) {
-		testMeasurement.CountSentBytes(BytesSent, testMeasurement.GetNetworkTags(), 100)
+		testMeasurement.AddSentBytes(100)
+		testMeasurement.CountSentBytes(BytesSent, testMeasurement.GetNetworkTags())
 	})
 
 	t.Run("Test bytes received", func(t *testing.T) {
-		testMeasurement.CountReceivedBytes(BytesReceived, testMeasurement.GetNetworkTags(), 100)
+		testMeasurement.AddReceivedBytes(100)
+		testMeasurement.CountReceivedBytes(BytesReceived, testMeasurement.GetNetworkTags())
 	})
 }


### PR DESCRIPTION
## Describe your changes

The log for long request now contains the following:
* tenant name
* sent bytes (based on proto size) for the given request
* received bytes (based on proto size) for the given request

Improved test coverage around these counters

## How best to test these changes

I issued a long request locally and saw the fields on the logs there

## Issue ticket number and link

TIG-1438