### PR TITLE
fix: Allow project/collection/branch name empty in query

### DIFF
--- a/server/services/v1/observability.go
+++ b/server/services/v1/observability.go
@@ -225,11 +225,16 @@ func isAllowedMetricQueryInput(tagValue string) bool {
 }
 
 func validateQueryTimeSeriesMetricsRequest(req *api.QueryTimeSeriesMetricsRequest) error {
-	if !isAllowedMetricQueryInput(req.MetricName) || !isAllowedMetricQueryInput(req.Db) || !isAllowedMetricQueryInput(req.Collection) {
+	// project(db), collection & branch names can be empty
+	if !isAllowedMetricQueryInput(req.MetricName) ||
+		(req.Db != "" && !isAllowedMetricQueryInput(req.Db)) ||
+		(req.Collection != "" && !isAllowedMetricQueryInput(req.Collection)) ||
+		(req.Branch != "" && !isAllowedMetricQueryInput(req.Branch)) {
 		log.Info().
 			Str("metric_name", req.MetricName).
 			Str("project", req.Db).
 			Str("collection", req.Collection).
+			Str("branch", req.Branch).
 			Msg("Failed to query metrics: reason = invalid character detected in the input")
 		return errors.PermissionDenied("Failed to query metrics: reason = invalid character detected in the input")
 	}

--- a/server/services/v1/observability_test.go
+++ b/server/services/v1/observability_test.go
@@ -18,9 +18,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	api "github.com/tigrisdata/tigris/api/server/v1"
 )
 
 func TestDatadogQueryValidation(t *testing.T) {
+	require.True(t, isAllowedMetricQueryInput("tigris.requests_count_ok.count"))
 	require.True(t, isAllowedMetricQueryInput("users"))
 	require.True(t, isAllowedMetricQueryInput("user_db"))
 	require.True(t, isAllowedMetricQueryInput("user_db_1"))
@@ -33,4 +35,23 @@ func TestDatadogQueryValidation(t *testing.T) {
 	require.False(t, isAllowedMetricQueryInput("users "))
 	require.False(t, isAllowedMetricQueryInput("users,foo:bar"))
 	require.False(t, isAllowedMetricQueryInput(""))
+}
+
+func TestMetricsQueryRequest(t *testing.T) {
+	require.NoError(t, validateQueryTimeSeriesMetricsRequest(&api.QueryTimeSeriesMetricsRequest{
+		Db:         "",
+		Branch:     "",
+		Collection: "",
+		From:       0,
+		To:         10,
+		MetricName: "tigris.requests_count_ok.count",
+	}))
+
+	require.NoError(t, validateQueryTimeSeriesMetricsRequest(&api.QueryTimeSeriesMetricsRequest{
+		Db:         "p1",
+		Collection: "",
+		From:       0,
+		To:         10,
+		MetricName: "tigris.requests_count_ok.count",
+	}))
 }


### PR DESCRIPTION
## Describe your changes
While querying metrics across projects/collections/branches, they are passed as empty - allow server to make such requests.

## How best to test these changes
Added unit test.

## Issue ticket number and link
