### PR TITLE
fix: skip reporting 0 values to metronome

### DIFF
--- a/server/services/v1/billing/event.go
+++ b/server/services/v1/billing/event.go
@@ -84,7 +84,6 @@ func (ub *UsageEventBuilder) Build() *UsageEvent {
 		ub.timestamp = time.Now()
 	}
 	billingMetric.Timestamp = ub.timestamp.Format(TimeFormat)
-	props := make(map[string]any)
 
 	// auto generate transaction id
 	if len(ub.transactionId) != 0 {
@@ -92,12 +91,15 @@ func (ub *UsageEventBuilder) Build() *UsageEvent {
 	} else {
 		billingMetric.TransactionId = ub.namespaceId + "_" + strconv.FormatInt(ub.timestamp.UnixMilli(), 10)
 	}
+
+	props := make(map[string]any)
 	// the key names must match the registered billing metrics in metronome
-	if ub.searchUnits != nil {
+	// skip '0' values
+	if ub.searchUnits != nil && *ub.searchUnits != 0 {
 		props[UsageSearchUnits] = *ub.searchUnits
 	}
 
-	if ub.databaseUnits != nil {
+	if ub.databaseUnits != nil && *ub.databaseUnits != 0 {
 		props[UsageDbUnits] = *ub.databaseUnits
 	}
 	billingMetric.Properties = &props
@@ -154,7 +156,6 @@ func (sb *StorageEventBuilder) Build() *StorageEvent {
 		sb.timestamp = time.Now()
 	}
 	billingMetric.Timestamp = sb.timestamp.Format(TimeFormat)
-	props := make(map[string]any)
 
 	// auto generate transaction id
 	if len(sb.transactionId) != 0 {
@@ -163,12 +164,14 @@ func (sb *StorageEventBuilder) Build() *StorageEvent {
 		billingMetric.TransactionId = sb.namespaceId + "_" + strconv.FormatInt(sb.timestamp.UnixMilli(), 10)
 	}
 
+	props := make(map[string]any)
 	// the key names must match the registered billing metrics in metronome
-	if sb.indexBytes != nil {
+	// skip '0' values
+	if sb.indexBytes != nil && *sb.indexBytes != 0 {
 		props[StorageIndexBytes] = *sb.indexBytes
 	}
 
-	if sb.databaseBytes != nil {
+	if sb.databaseBytes != nil && *sb.databaseBytes != 0 {
 		props[StorageDbBytes] = *sb.databaseBytes
 	}
 	billingMetric.Properties = &props

--- a/server/services/v1/billing/event_test.go
+++ b/server/services/v1/billing/event_test.go
@@ -44,7 +44,7 @@ func TestStorageEvent(t *testing.T) {
 		})
 	})
 
-	t.Run("with 0 values", func(t *testing.T) {
+	t.Run("with 0 values should be skipped", func(t *testing.T) {
 		billingEvent := NewStorageEventBuilder().
 			WithDatabaseBytes(0).
 			WithIndexBytes(0).Build()
@@ -59,10 +59,7 @@ func TestStorageEvent(t *testing.T) {
 		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "storage")
-		require.Equal(t, actual["properties"], map[string]any{
-			StorageIndexBytes: float64(0),
-			StorageDbBytes:    float64(0),
-		})
+		require.Empty(t, actual["properties"])
 	})
 
 	t.Run("complete object", func(t *testing.T) {
@@ -128,7 +125,7 @@ func TestUsageEvent(t *testing.T) {
 		})
 	})
 
-	t.Run("with 0 values", func(t *testing.T) {
+	t.Run("with 0 values should be skipped", func(t *testing.T) {
 		billingEvent := NewUsageEventBuilder().WithDatabaseUnits(0).WithSearchUnits(0).Build()
 
 		jsonEvent, err := jsoniter.Marshal(billingEvent)
@@ -141,10 +138,7 @@ func TestUsageEvent(t *testing.T) {
 		require.Equal(t, actual["transaction_id"], billingEvent.TransactionId)
 		require.NotEqual(t, actual["timestamp"], "")
 		require.Equal(t, actual["event_type"], "usage")
-		require.Equal(t, actual["properties"], map[string]any{
-			UsageDbUnits:     float64(0),
-			UsageSearchUnits: float64(0),
-		})
+		require.Empty(t, actual["properties"])
 	})
 
 	t.Run("complete object", func(t *testing.T) {

--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -161,6 +161,7 @@ func (m *Metronome) AddPlan(ctx context.Context, accountId AccountId, planId uui
 func (m *Metronome) PushUsageEvents(ctx context.Context, events []*UsageEvent) error {
 	var billingEvents []biller.Event
 	for _, se := range events {
+		// skip publishing events if they are not reporting any metrics
 		if se != nil && se.Properties != nil && len(*se.Properties) > 0 {
 			billingEvents = append(billingEvents, se.Event)
 		}
@@ -179,6 +180,7 @@ func (m *Metronome) PushUsageEvents(ctx context.Context, events []*UsageEvent) e
 func (m *Metronome) PushStorageEvents(ctx context.Context, events []*StorageEvent) error {
 	var billingEvents []biller.Event
 	for _, se := range events {
+		// skip publishing events if they are not reporting any metrics
 		if se != nil && se.Properties != nil && len(*se.Properties) > 0 {
 			billingEvents = append(billingEvents, se.Event)
 		}


### PR DESCRIPTION
## Describe your changes
- Do not add any 0 value metrics to events being published to metronome
- When there are no metrics to publish, the whole event will be skipped

## How best to test these changes
- Unit tests

## Issue ticket number and link
