### PR TITLE
feat: Index metadata toggle and write mode index

### DIFF
--- a/query/filter/key_builder_test.go
+++ b/query/filter/key_builder_test.go
@@ -460,5 +460,12 @@ func encodeString(val string) any {
 }
 
 func fieldsToQueryableFields(fields []*schema.Field) []*schema.QueryableField {
-	return schema.NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil, false)
+	builder := schema.NewQueryableFieldsBuilder()
+	qf := make([]*schema.QueryableField, len(fields))
+
+	for i, field := range fields {
+		qf[i] = builder.NewQueryableField(field.Name(), field, nil)
+	}
+
+	return qf
 }

--- a/schema/collection.go
+++ b/schema/collection.go
@@ -167,7 +167,7 @@ func NewDefaultCollection(id uint32, schVer uint32, factory *Factory, schemas Ve
 	if implicitSearchIndex != nil {
 		prevVersionInSearch = implicitSearchIndex.prevVersionInSearch
 	}
-	queryableFields := NewQueryableFieldsBuilder().BuildQueryableFields(factory.Fields, prevVersionInSearch, true)
+	queryableFields := NewQueryableFieldsBuilder().BuildQueryableFields(factory.Fields, prevVersionInSearch, factory.Indexes.IndexMetadata)
 
 	schemaDeltas, err := buildSchemaDeltas(schemas)
 	if err != nil {
@@ -216,6 +216,10 @@ func (*DefaultCollection) SecondaryIndexKeyword() string {
 	return "skey"
 }
 
+func (d *DefaultCollection) SecondaryIndexMetadata() bool {
+	return d.SecondaryIndexes.IndexMetadata
+}
+
 func (d *DefaultCollection) GetVersion() uint32 {
 	return d.SchVer
 }
@@ -250,7 +254,7 @@ func (d *DefaultCollection) GetActiveIndexedFields() []*QueryableField {
 func (d *DefaultCollection) GetWriteModeIndexes() []*QueryableField {
 	var indexed []*QueryableField
 	for _, q := range d.QueryableFields {
-		if q.Indexed && !d.SecondaryIndexes.IsWriteModeIndex(q.FieldName) {
+		if q.Indexed && !d.SecondaryIndexes.IsActiveIndex(q.FieldName) {
 			indexed = append(indexed, q)
 		}
 	}

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -292,14 +292,13 @@ var SupportedFieldProperties = container.NewHashSet(
 // Indexes is to wrap different index that a collection can have.
 type Indexes struct {
 	All []*Index
+
+	// Schema level set if the collection should index the `created_at` and `updated_at` metadata
+	IndexMetadata bool
 }
 
 func (i *Indexes) IsActiveIndex(name string) bool {
 	return i.indexesHasStateState(name, INDEX_ACTIVE)
-}
-
-func (i *Indexes) IsWriteModeIndex(name string) bool {
-	return i.indexesHasStateState(name, INDEX_WRITE_MODE)
 }
 
 func (i *Indexes) indexesHasStateState(name string, state IndexState) bool {

--- a/schema/queryable.go
+++ b/schema/queryable.go
@@ -209,21 +209,23 @@ func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fie
 		}
 	}
 
-	if includeMetadata {
-		ptrTrue := true
-		// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
-		queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[CreatedAt], &Field{
-			FieldName: ReservedFields[CreatedAt],
-			DataType:  DateTimeType,
-			Indexed:   &ptrTrue,
-		}, fieldsInSearch))
+	ptrTrue := true
+	// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
+	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[CreatedAt], &Field{
+		FieldName:     ReservedFields[CreatedAt],
+		DataType:      DateTimeType,
+		Sorted:        &ptrTrue,
+		SearchIndexed: &ptrTrue,
+		Indexed:       &includeMetadata,
+	}, fieldsInSearch))
 
-		queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
-			FieldName: ReservedFields[UpdatedAt],
-			DataType:  DateTimeType,
-			Indexed:   &ptrTrue,
-		}, fieldsInSearch))
-	}
+	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
+		FieldName:     ReservedFields[UpdatedAt],
+		DataType:      DateTimeType,
+		Sorted:        &ptrTrue,
+		SearchIndexed: &ptrTrue,
+		Indexed:       &includeMetadata,
+	}, fieldsInSearch))
 
 	return queryableFields
 }

--- a/schema/queryable.go
+++ b/schema/queryable.go
@@ -209,21 +209,21 @@ func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fie
 		}
 	}
 
-	ptrTrue := true
+	ptrFalse := false
 	// Allowing metadata fields to be queryable. User provided reserved fields are rejected by FieldBuilder.
 	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[CreatedAt], &Field{
 		FieldName:     ReservedFields[CreatedAt],
 		DataType:      DateTimeType,
-		Sorted:        &ptrTrue,
-		SearchIndexed: &ptrTrue,
+		Sorted:        &ptrFalse,
+		SearchIndexed: &ptrFalse,
 		Indexed:       &indexMetadata,
 	}, fieldsInSearch))
 
 	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
 		FieldName:     ReservedFields[UpdatedAt],
 		DataType:      DateTimeType,
-		Sorted:        &ptrTrue,
-		SearchIndexed: &ptrTrue,
+		Sorted:        &ptrFalse,
+		SearchIndexed: &ptrFalse,
 		Indexed:       &indexMetadata,
 	}, fieldsInSearch))
 

--- a/schema/queryable.go
+++ b/schema/queryable.go
@@ -192,7 +192,7 @@ func (*QueryableFieldsBuilder) NewQueryableField(name string, f *Field, fieldsIn
 	return q
 }
 
-func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fieldsInSearch []tsApi.Field, includeMetadata bool) []*QueryableField {
+func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fieldsInSearch []tsApi.Field, indexMetadata bool) []*QueryableField {
 	var queryableFields []*QueryableField
 
 	for _, f := range fields {
@@ -216,7 +216,7 @@ func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fie
 		DataType:      DateTimeType,
 		Sorted:        &ptrTrue,
 		SearchIndexed: &ptrTrue,
-		Indexed:       &includeMetadata,
+		Indexed:       &indexMetadata,
 	}, fieldsInSearch))
 
 	queryableFields = append(queryableFields, builder.NewQueryableField(ReservedFields[UpdatedAt], &Field{
@@ -224,7 +224,7 @@ func (builder *QueryableFieldsBuilder) BuildQueryableFields(fields []*Field, fie
 		DataType:      DateTimeType,
 		Sorted:        &ptrTrue,
 		SearchIndexed: &ptrTrue,
-		Indexed:       &includeMetadata,
+		Indexed:       &indexMetadata,
 	}, fieldsInSearch))
 
 	return queryableFields

--- a/schema/queryable_test.go
+++ b/schema/queryable_test.go
@@ -63,24 +63,21 @@ func TestBuildQueryableFields(t *testing.T) {
 }
 
 func TestIncludeMetadata(t *testing.T) {
-	fields := []*Field{
-		{FieldName: "A1", DataType: Int32Type},
-		{FieldName: "A2", DataType: Int64Type},
-	}
+	fields := []*Field{}
+	expTypes := []string{"int64", "int64"}
+	expFields := []string{"_tigris_created_at", "_tigris_updated_at"}
 
 	queryable := NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil, true)
-	expTypes := []string{"int32", "int64", "int64", "int64"}
-	expFields := []string{"A1", "A2", "_tigris_created_at", "_tigris_updated_at"}
 	for i, q := range queryable {
 		require.Equal(t, expFields[i], q.FieldName)
 		require.Equal(t, expTypes[i], q.SearchType)
+		require.True(t, q.Indexed)
 	}
 
 	queryable = NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil, false)
-	expTypes = []string{"int32", "int64"}
-	expFields = []string{"A1", "A2"}
 	for i, q := range queryable {
 		require.Equal(t, expFields[i], q.FieldName)
 		require.Equal(t, expTypes[i], q.SearchType)
+		require.False(t, q.Indexed)
 	}
 }

--- a/schema/queryable_test.go
+++ b/schema/queryable_test.go
@@ -61,3 +61,26 @@ func TestBuildQueryableFields(t *testing.T) {
 		require.Equal(t, expTypes[i], q.SearchType)
 	}
 }
+
+func TestIncludeMetadata(t *testing.T) {
+	fields := []*Field{
+		{FieldName: "A1", DataType: Int32Type},
+		{FieldName: "A2", DataType: Int64Type},
+	}
+
+	queryable := NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil, true)
+	expTypes := []string{"int32", "int64", "int64", "int64"}
+	expFields := []string{"A1", "A2", "_tigris_created_at", "_tigris_updated_at"}
+	for i, q := range queryable {
+		require.Equal(t, expFields[i], q.FieldName)
+		require.Equal(t, expTypes[i], q.SearchType)
+	}
+
+	queryable = NewQueryableFieldsBuilder().BuildQueryableFields(fields, nil, false)
+	expTypes = []string{"int32", "int64"}
+	expFields = []string{"A1", "A2"}
+	for i, q := range queryable {
+		require.Equal(t, expFields[i], q.FieldName)
+		require.Equal(t, expTypes[i], q.SearchType)
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -200,20 +200,27 @@ func (fb *FactoryBuilder) Build(collection string, reqSchema jsoniter.RawMessage
 		}
 	}
 
+	// Hard coded for now, this needs to be read from the schema at the top-level
+	indexMetadata := true
+	secondaryIndex := make([]*Index, 0)
+
+	if indexMetadata {
+		secondaryIndex = append(secondaryIndex, []*Index{
+			{
+				Name:    ReservedFields[CreatedAt],
+				IdxType: SECONDARY_INDEX,
+				State:   UNKNOWN,
+			},
+			{
+				Name:    ReservedFields[UpdatedAt],
+				IdxType: SECONDARY_INDEX,
+				State:   UNKNOWN,
+			},
+		}...)
+	}
+
 	// Create the secondary indexes with an unknown state
 	// to determine the state, tigris will need to read from the index metadata
-	secondaryIndex := []*Index{
-		{
-			Name:    ReservedFields[CreatedAt],
-			IdxType: SECONDARY_INDEX,
-			State:   UNKNOWN,
-		},
-		{
-			Name:    ReservedFields[UpdatedAt],
-			IdxType: SECONDARY_INDEX,
-			State:   UNKNOWN,
-		},
-	}
 	for _, field := range fields {
 		if field.Indexed != nil && *field.Indexed {
 			secondaryIndex = append(secondaryIndex, &Index{Name: field.Name(), IdxType: SECONDARY_INDEX, State: UNKNOWN, Fields: []*Field{field}})
@@ -229,7 +236,8 @@ func (fb *FactoryBuilder) Build(collection string, reqSchema jsoniter.RawMessage
 			State:   INDEX_ACTIVE,
 		},
 		Indexes: &Indexes{
-			All: secondaryIndex,
+			All:           secondaryIndex,
+			IndexMetadata: indexMetadata,
 		},
 		Name:           collection,
 		Schema:         reqSchema,

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -262,6 +262,7 @@ func TestCreateCollectionFromSchema(t *testing.T) {
 						State:   UNKNOWN,
 					},
 				},
+				IndexMetadata: true,
 			},
 			Fields: []*Field{
 				{FieldName: "id", DataType: Int64Type, PrimaryKeyField: &b},

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -124,7 +124,7 @@ func (runner *BaseQueryRunner) insertOrReplace(ctx context.Context, tx transacti
 	var err error
 	ts := internal.NewTimestamp()
 	allKeys := make([][]byte, 0, len(documents))
-	indexer := NewSecondaryIndexer(coll)
+	indexer := NewSecondaryIndexer(coll, false)
 	for _, doc := range documents {
 		// reset it back to doc
 		doc, err = runner.mutateAndValidatePayload(ctx, coll, newInsertPayloadMutator(coll, ts.ToRFC3339()), doc)

--- a/server/services/v1/database/collection_runner.go
+++ b/server/services/v1/database/collection_runner.go
@@ -153,7 +153,7 @@ func (runner *CollectionQueryRunner) createOrUpdate(ctx context.Context, tx tran
 				return Response{}, nil, CreateApiError(err)
 			}
 
-			indexer := NewSecondaryIndexer(db.GetCollection(req.GetCollection()))
+			indexer := NewSecondaryIndexer(db.GetCollection(req.GetCollection()), false)
 
 			for _, oldIndex := range oldMetadata.Indexes {
 				if !schema.HasIndex(updatedMetadata.Indexes, oldIndex) {

--- a/server/services/v1/database/indexer_runner.go
+++ b/server/services/v1/database/indexer_runner.go
@@ -56,7 +56,7 @@ func (runner *IndexerRunner) ReadOnly(ctx context.Context, tenant *metadata.Tena
 		return Response{}, ctx, err
 	}
 
-	indexer := NewSecondaryIndexer(coll)
+	indexer := NewSecondaryIndexer(coll, false)
 
 	for _, index := range coll.SecondaryIndexes.All {
 		if index.State == schema.INDEX_WRITE_MODE {

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -223,7 +223,7 @@ func (runner *UpdateQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 		return Response{}, ctx, err
 	}
 
-	indexer := NewSecondaryIndexer(coll)
+	indexer := NewSecondaryIndexer(coll, false)
 
 	ctx = runner.cdcMgr.WrapContext(ctx, db.Name())
 
@@ -370,7 +370,7 @@ func (runner *DeleteQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	}
 
 	ctx = runner.cdcMgr.WrapContext(ctx, db.Name())
-	indexer := NewSecondaryIndexer(coll)
+	indexer := NewSecondaryIndexer(coll, false)
 
 	if err = runner.mustBeDocumentsCollection(coll, "deleteReq"); err != nil {
 		return Response{}, ctx, err

--- a/server/services/v1/database/secondary_index_measure.go
+++ b/server/services/v1/database/secondary_index_measure.go
@@ -30,18 +30,17 @@ type secondaryIndexerWithMetrics struct {
 	q *SecondaryIndexerImpl
 }
 
-func NewSecondaryIndexer(coll *schema.DefaultCollection) SecondaryIndexer {
+func NewSecondaryIndexer(coll *schema.DefaultCollection, indexWriteModeOnly bool) SecondaryIndexer {
 	if config.DefaultConfig.Metrics.SecondaryIndex.Enabled {
-		return NewSecondaryIndexerWithMetrics(coll)
+		return newSecondaryIndexerWithMetrics(coll, indexWriteModeOnly)
 	}
 
-	return newSecondaryIndexerImpl(coll)
+	return newSecondaryIndexerImpl(coll, indexWriteModeOnly)
 }
 
-func NewSecondaryIndexerWithMetrics(coll *schema.DefaultCollection) SecondaryIndexer {
-	q := newSecondaryIndexerImpl(coll)
+func newSecondaryIndexerWithMetrics(coll *schema.DefaultCollection, indexWriteModeOnly bool) SecondaryIndexer {
 	return &secondaryIndexerWithMetrics{
-		q,
+		q: newSecondaryIndexerImpl(coll, indexWriteModeOnly),
 	}
 }
 

--- a/server/services/v1/database/secondary_index_reader.go
+++ b/server/services/v1/database/secondary_index_reader.go
@@ -222,7 +222,7 @@ func (r *SecondaryIndexReaderImpl) dbgPrintIndex() {
 		return
 	}
 
-	indexer := newSecondaryIndexerImpl(r.coll)
+	indexer := newSecondaryIndexerImpl(r.coll, false)
 	tableIter, err := indexer.scanIndex(r.ctx, r.tx)
 	if err != nil {
 		panic(err)

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -138,16 +138,19 @@ type SecondaryIndexerImpl struct {
 	// Used for unit tests because it can index deeper into a schema than we currently expose to the user
 	// This can be removed once indexing into arrays and objects is exposed to the user
 	indexAll bool
+	// only index fields that are not active. For background indexing
+	indexWriteModeOnly bool
 	// Spare indexes do not index missing fields
 	sparse bool
 }
 
-func newSecondaryIndexerImpl(coll *schema.DefaultCollection) *SecondaryIndexerImpl {
+func newSecondaryIndexerImpl(coll *schema.DefaultCollection, indexWriteModeOnly bool) *SecondaryIndexerImpl {
 	return &SecondaryIndexerImpl{
-		collation: value.NewCollationFrom(&api.Collation{Case: "csk"}),
-		coll:      coll,
-		indexAll:  false,
-		sparse:    false, // For now indexes are only non-sparse
+		collation:          value.NewCollationFrom(&api.Collation{Case: "csk"}),
+		coll:               coll,
+		indexAll:           false,
+		indexWriteModeOnly: indexWriteModeOnly,
+		sparse:             false, // For now indexes are only non-sparse
 	}
 }
 
@@ -440,20 +443,26 @@ func (q *SecondaryIndexerImpl) buildTableRows(tableData *internal.TableData) ([]
 
 func (q *SecondaryIndexerImpl) buildTSRows(tableData *internal.TableData) ([]IndexRow, error) {
 	timeStamps := []struct {
-		ts    *internal.Timestamp
-		field schema.ReservedField
+		ts          *internal.Timestamp
+		field       schema.ReservedField
+		shouldIndex bool
 	}{
 		{
 			tableData.CreatedAt,
 			schema.CreatedAt,
+			true,
 		},
 		{
 			tableData.UpdatedAt,
 			schema.UpdatedAt,
+			true,
 		},
 	}
 
 	rows := make([]IndexRow, 0, len(timeStamps))
+	if !q.coll.SecondaryIndexMetadata() {
+		return rows, nil
+	}
 
 	for _, ts := range timeStamps {
 		val := []byte{}
@@ -461,6 +470,20 @@ func (q *SecondaryIndexerImpl) buildTSRows(tableData *internal.TableData) ([]Ind
 		if ts.ts != nil {
 			val = []byte(ts.ts.ToRFC3339())
 			dt = schema.DateTimeType
+		}
+
+		if q.indexWriteModeOnly {
+			for _, idx := range q.coll.SecondaryIndexes.All {
+				if idx.Name == schema.ReservedFields[ts.field] {
+					if idx.State == schema.INDEX_ACTIVE {
+						ts.shouldIndex = false
+					}
+				}
+			}
+		}
+
+		if !ts.shouldIndex {
+			continue
 		}
 
 		row, err := newIndexRow(dt, q.collation, schema.ReservedFields[ts.field], val, 0, false)
@@ -633,6 +656,10 @@ func (q *SecondaryIndexerImpl) indexArray(doc []byte, field *schema.QueryableFie
 func (q *SecondaryIndexerImpl) getIndexedFields() []*schema.QueryableField {
 	if q.indexAll {
 		return q.coll.QueryableFields
+	}
+
+	if q.indexWriteModeOnly {
+		return q.coll.GetWriteModeIndexes()
 	}
 
 	return q.coll.GetIndexedFields()

--- a/server/services/v1/database/secondary_indexer.go
+++ b/server/services/v1/database/secondary_indexer.go
@@ -472,6 +472,9 @@ func (q *SecondaryIndexerImpl) buildTSRows(tableData *internal.TableData) ([]Ind
 			dt = schema.DateTimeType
 		}
 
+		// If the indexer is only indexing indexes in WriteMode
+		// this checks to see what state the metadata indexes are in
+		// and if we should index them
 		if q.indexWriteModeOnly {
 			for _, idx := range q.coll.SecondaryIndexes.All {
 				if idx.Name == schema.ReservedFields[ts.field] {

--- a/server/services/v1/database/secondary_indexer_test.go
+++ b/server/services/v1/database/secondary_indexer_test.go
@@ -89,6 +89,25 @@ func TestIndexingCreateSimpleKVsforDoc(t *testing.T) {
 		}
 		assertKVs(t, expected, updateSet.addKeys, updateSet.addCounts)
 	})
+
+	t.Run("insert with no metadata", func(t *testing.T) {
+		indexStore.coll.SecondaryIndexes.IndexMetadata = false
+		defer func() {
+			indexStore.coll.SecondaryIndexes.IndexMetadata = true
+		}()
+		updateSet, err := indexStore.buildAddAndRemoveKVs(td, nil, primaryKey)
+		assert.NoError(t, err)
+		expected := [][]any{
+			{"skey", KVSubspace, "id", value.ToSecondaryOrder(schema.Int64Type, nil), int64(1), 0, 1},
+			{"skey", KVSubspace, "double_f", value.ToSecondaryOrder(schema.DoubleType, nil), float64(2), 0, 1},
+			{"skey", KVSubspace, "created", value.ToSecondaryOrder(schema.DateTimeType, nil), "2023-01-16T12:55:17.304154Z", 0, 1},
+			{"skey", KVSubspace, "updated", value.ToSecondaryOrder(schema.DateTimeType, nil), "2023-01-16T12:55:17.304154Z", 0, 1},
+			{"skey", KVSubspace, "arr", value.ToSecondaryOrder(schema.Int64Type, nil), int64(1), 0, 1},
+			{"skey", KVSubspace, "arr", value.ToSecondaryOrder(schema.Int64Type, nil), int64(2), 1, 1},
+		}
+		assertKVs(t, expected, updateSet.addKeys, updateSet.addCounts)
+	})
+
 	t.Run("update new values", func(t *testing.T) {
 		updateTD, _ := createDoc(`{"id":1, "double_f":3,"created":"2023-01-17T12:55:17.304154Z","updated": "2023-01-17T12:55:17.304154Z","binary_val": "cGVlay1hLWJvbwo=", "arr":[1,3]}`)
 		updateTD.CreatedAt = td.CreatedAt
@@ -771,6 +790,67 @@ func TestIndexingStoreAndGetSimpleKVsforDoc(t *testing.T) {
 	})
 }
 
+func TestWriteModeOnlyIndexing(t *testing.T) {
+	reqSchema := []byte(`{
+		"title": "t1",
+		"properties": {
+			"id": {
+				"type": "integer",
+				"index": true
+			},
+			"double_f": {
+				"type": "number",
+				"default": 1.5,
+				"index": true
+			},
+			"number": {
+				"type": "number",
+				"index": true
+			},
+			"created": {
+				"type": "string",
+				"format": "date-time",
+				"createdAt": true,
+				"index": true
+			},
+			"updated": {
+				"type": "string",
+				"format": "date-time",
+				"updatedAt": true,
+				"index": true
+			}
+		},
+		"primary_key": ["id"]
+	}`)
+
+	indexStore := setupTest(t, reqSchema)
+	indexStore.indexWriteModeOnly = true
+	indexStore.indexAll = false
+	td, primaryKey := createDoc(`{"id":1, "double_f":2,"number":4,"created":"2023-01-16T12:55:17.304154Z","updated": "2023-01-16T12:55:17.304154Z","binary_val": "cGVlay1hLWJvbwo=", "arr":[1,2]}`)
+
+	for _, idx := range indexStore.coll.SecondaryIndexes.All {
+		switch idx.Name {
+		case "double_f":
+			idx.State = schema.INDEX_WRITE_MODE
+		case "updated":
+			idx.State = schema.INDEX_WRITE_MODE_BUILDING
+		case "number":
+			idx.State = schema.UNKNOWN
+		default:
+			idx.State = schema.INDEX_ACTIVE
+		}
+	}
+
+	updateSet, err := indexStore.buildAddAndRemoveKVs(td, nil, primaryKey)
+	assert.NoError(t, err)
+	expected := [][]any{
+		{"skey", KVSubspace, "double_f", value.ToSecondaryOrder(schema.DoubleType, nil), float64(2), 0, 1},
+		{"skey", KVSubspace, "number", value.ToSecondaryOrder(schema.DoubleType, nil), float64(4), 0, 1},
+		{"skey", KVSubspace, "updated", value.ToSecondaryOrder(schema.DateTimeType, nil), "2023-01-16T12:55:17.304154Z", 0, 1},
+	}
+	assertKVs(t, expected, updateSet.addKeys, updateSet.addCounts)
+}
+
 func TestBulkIndexing(t *testing.T) {
 	reqSchema := []byte(`{
 		"title": "t1",
@@ -840,7 +920,7 @@ func setupTest(t *testing.T, reqSchema []byte) *SecondaryIndexerImpl {
 	assert.NoError(t, err)
 	coll.EncodedName = []byte("t1")
 	coll.EncodedTableIndexName = []byte("sidx1")
-	indexer := newSecondaryIndexerImpl(coll)
+	indexer := newSecondaryIndexerImpl(coll, false)
 	indexer.indexAll = true
 
 	return indexer

--- a/server/services/v1/workers/worker.go
+++ b/server/services/v1/workers/worker.go
@@ -255,7 +255,7 @@ func (w *Worker) buildIndexTask(queueItem *metadata.QueueItem) error {
 	}
 
 	coll := db.GetCollection(task.CollName)
-	// Indexer will only index indexes that are in not `INDEX_ACTIVE` state
+	// Indexer will only index indexes that are not `INDEX_ACTIVE` state
 	indexer := database.NewSecondaryIndexer(coll, true)
 
 	// Extend the lease of the queue item so that another worker does not

--- a/server/services/v1/workers/worker.go
+++ b/server/services/v1/workers/worker.go
@@ -255,7 +255,8 @@ func (w *Worker) buildIndexTask(queueItem *metadata.QueueItem) error {
 	}
 
 	coll := db.GetCollection(task.CollName)
-	indexer := database.NewSecondaryIndexer(coll)
+	// Indexer will only index indexes that are in not `INDEX_ACTIVE` state
+	indexer := database.NewSecondaryIndexer(coll, true)
 
 	// Extend the lease of the queue item so that another worker does not
 	// try and process it


### PR DESCRIPTION
## Describe your changes
Configure secondary indexes to not index the timestamp metadata. Configure the secondary_indexer to only index indexes that are not in active mode. This is for the background worker to reduce the number of indexes being written to.

## How best to test these changes
All tests should pass

## Issue ticket number and link
