### PR TITLE
fix: Handle filtering completely on Tigris layer for read queries, handle escaped characters and unicode properly

### DIFF
--- a/query/filter/selector.go
+++ b/query/filter/selector.go
@@ -168,6 +168,8 @@ func (s *Selector) ToSearchFilter() string {
 			}
 			return filterString
 		}
+	case schema.StringType:
+		return fmt.Sprintf(op, s.Field.InMemoryName(), fmt.Sprintf("`%s`", v.AsInterface()))
 	}
 	return fmt.Sprintf(op, s.Field.InMemoryName(), v.AsInterface())
 }

--- a/query/search/search_test.go
+++ b/query/search/search_test.go
@@ -36,7 +36,7 @@ func TestSearchBuilder(t *testing.T) {
 
 	b := NewBuilder()
 	q := b.Filter(wrappedF).Query("test").Build()
-	require.Equal(t, "a:=4 && (int_value:=1 && string_value1:=shoe)", q.WrappedF.SearchFilter())
+	require.Equal(t, "a:=4 && (int_value:=1 && string_value1:=`shoe`)", q.WrappedF.SearchFilter())
 	require.Equal(t, "test", q.Q)
 }
 

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -182,7 +182,7 @@ func authFunction(ctx context.Context, jwtValidators []*validator.Validator, con
 
 	// if not found from cache
 	if validatedToken == nil {
-		var count = 0
+		count := 0
 		for i, jwtValidator := range jwtValidators {
 			validatedToken, err = jwtValidator.ValidateToken(ctx, tkn)
 			if err == nil {

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -598,19 +598,8 @@ func (runner *BaseQueryRunner) buildReaderOptions(req *api.ReadRequest, collecti
 		return options, errors.InvalidArgument("can't perform sort on this field")
 	}
 
-	if runner.noFallbackToSearch(options) {
-		// case when fallback is disabled or we explicitly need to perform table scan
-		options.tablePlan, err = planner.GenerateTablePlan(sortPlan, from)
-		return options, err
-	}
-
-	// fallback
-	options.inMemoryStore = true
-	return options, nil
-}
-
-func (*BaseQueryRunner) noFallbackToSearch(options readerOptions) bool {
-	return !config.DefaultConfig.Search.IsReadEnabled() || !options.filter.IsSearchIndexed()
+	options.tablePlan, err = planner.GenerateTablePlan(sortPlan, from)
+	return options, err
 }
 
 func (runner *StreamingQueryRunner) instrumentRunner(ctx context.Context, options readerOptions) context.Context {

--- a/value/value.go
+++ b/value/value.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"strconv"
 
+	"github.com/buger/jsonparser"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/schema"
@@ -60,7 +61,11 @@ func NewValueUsingCollation(fieldType schema.FieldType, value []byte, collation 
 	}
 
 	if fieldType == schema.StringType && len(value) > 0 {
-		return NewStringValue(string(value), collation), nil
+		parsed, err := jsonparser.ParseString(value)
+		if err != nil {
+			return nil, err
+		}
+		return NewStringValue(parsed, collation), nil
 	}
 
 	return NewValue(fieldType, value)
@@ -89,7 +94,11 @@ func NewValue(fieldType schema.FieldType, value []byte) (Value, error) {
 
 		return NewIntValue(val), nil
 	case schema.StringType, schema.UUIDType:
-		return NewStringValue(string(value), nil), nil
+		parsed, err := jsonparser.ParseString(value)
+		if err != nil {
+			return nil, err
+		}
+		return NewStringValue(parsed, nil), nil
 	case schema.DateTimeType:
 		return NewDateTimeValue(string(value)), nil
 	case schema.ByteType:


### PR DESCRIPTION
## Describe your changes
This diff removes any fallback logic and ensures that escaped characters and Unicode are handled properly during filtering.

Also details here about unmarshaler behavior with escaped characters: https://stackoverflow.com/questions/28595664/how-to-stop-json-marshal-from-escaping-and

## How best to test these changes

## Issue ticket number and link
