### PR TITLE
feat: Return server response time in headers

### DIFF
--- a/api/server/v1/header.go
+++ b/api/server/v1/header.go
@@ -45,12 +45,13 @@ const (
 	HeaderSchemaSignOff             = "Tigris-Schema-Sign-Off"
 	HeaderBypassAuthCache           = "Tigris-Bypass-Auth-Cache" // #nosec G101
 	HeaderReadSearchDataFromStorage = "Tigris-Search-Read-From-Storage"
+	HeaderServerTiming              = "Server-Timing"
 )
 
 func CustomMatcher(key string) (string, bool) {
 	key = textproto.CanonicalMIMEHeaderKey(key)
 	switch key {
-	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie, HeaderAccept:
+	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie, HeaderAccept, HeaderServerTiming:
 		return key, true
 	default:
 		if strings.HasPrefix(key, HeaderPrefix) {

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -238,6 +238,10 @@ func (m *Measurement) GetAuthErrorTags(err error) map[string]string {
 	return filterTags(standardizeTags(mergeTags(m.tags, getTagsForError(err)), getAuthErrorTagKeys()), config.DefaultConfig.Metrics.Auth.FilteredTags)
 }
 
+func (m *Measurement) TimeSinceStart() time.Duration {
+	return time.Since(m.startedAt)
+}
+
 func (m *Measurement) SaveMeasurementToContext(ctx context.Context) (context.Context, error) {
 	if m.datadogSpan == nil && m.jaegerSpan == nil {
 		return nil, fmt.Errorf("parent span was not created")

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -47,6 +47,7 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 
 	// The order of the interceptors matter with optional elements in them
 	streamInterceptors := []grpc.StreamServerInterceptor{
+		headersStreamServerInterceptor(),
 		metadataExtractorStream(),
 	}
 
@@ -70,7 +71,6 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 		grpcLogging.StreamServerInterceptor(grpcZerolog.InterceptorLogger(sampledTaggedLogger), []grpcLogging.Option{}...),
 		validatorStreamServerInterceptor(),
 		grpcRecovery.StreamServerInterceptor(grpcRecovery.WithRecoveryHandler(recoveryHandler)),
-		headersStreamServerInterceptor(),
 	}...)
 	stream := middleware.ChainStreamServer(streamInterceptors...)
 
@@ -81,6 +81,7 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 
 	// The order of the interceptors matter with optional elements in them
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		headersUnaryServerInterceptor(),
 		metadataExtractorUnary(),
 	}
 
@@ -106,7 +107,6 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 		validatorUnaryServerInterceptor(),
 		timeoutUnaryServerInterceptor(DefaultTimeout),
 		grpcRecovery.UnaryServerInterceptor(grpcRecovery.WithRecoveryHandler(recoveryHandler)),
-		headersUnaryServerInterceptor(),
 	}...)
 	unary := middleware.ChainUnaryServer(unaryInterceptors...)
 

--- a/store/kv/chunk.go
+++ b/store/kv/chunk.go
@@ -230,8 +230,8 @@ func (it *ChunkIterator) handleReverse(value *KeyValue) bool {
 	}
 
 	totalChunks := lastChunk + 1
-	chunks := make([][]byte, totalChunks)
-	chunks[totalChunks-1] = value.Data.RawData
+	chunks := make([]*internal.TableData, totalChunks)
+	chunks[totalChunks-1] = value.Data
 
 	chunkNo := totalChunks - 2
 	for ; chunkNo >= 0; chunkNo-- {
@@ -246,7 +246,7 @@ func (it *ChunkIterator) handleReverse(value *KeyValue) bool {
 			}
 		}
 
-		chunks[chunkNo] = chunked.Data.RawData
+		chunks[chunkNo] = chunked.Data
 	}
 	if it.Iterator.Err() != nil {
 		// there can be an error in between we need to return that error
@@ -260,10 +260,11 @@ func (it *ChunkIterator) handleReverse(value *KeyValue) bool {
 	}
 
 	for _, chunk := range chunks {
-		_, _ = buf.Write(chunk)
+		_, _ = buf.Write(chunk.RawData)
 	}
 
-	value.Data.RawData = buf.Bytes()
+	// Zeroth chunk has all the meta attributes
+	value.Data = chunks[0].CloneWithAttributesOnly(buf.Bytes())
 	return hasNext
 }
 


### PR DESCRIPTION
## Describe your changes
- Returning the server response time in headers. In the case of streaming, this will return the time taken just before sending the first byte i.e. TTFB.
- Fixing a bug in reverse iterator in case of chunking. 

## How best to test these changes

## Issue ticket number and link
