### PR TITLE
feat: Add more server timing information in the header

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -500,7 +500,7 @@ var DefaultConfig = Config{
 		Storage: StorageLimitsConfig{
 			Enabled:         false,
 			DataSizeLimit:   100 * 1024 * 1024,
-			RefreshInterval: 60 * time.Second,
+			RefreshInterval: 600 * time.Second,
 		},
 	},
 	Observability: ObservabilityConfig{

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -63,6 +63,9 @@ type Measurement struct {
 	nDocs           int64
 	sentBytes       int
 	receivedBytes   int
+
+	commitDuration time.Duration
+	searchDuration time.Duration
 }
 
 type MeasurementCtxKey struct{}
@@ -111,6 +114,22 @@ func (m *Measurement) AddSentBytes(value int) {
 
 func (m *Measurement) AddReceivedBytes(value int) {
 	m.receivedBytes += value
+}
+
+func (m *Measurement) GetCommitDuration() time.Duration {
+	return m.commitDuration
+}
+
+func (m *Measurement) GetSearchIndexDuration() time.Duration {
+	return m.searchDuration
+}
+
+func (m *Measurement) SetCommitDuration(dur time.Duration) {
+	m.commitDuration = dur
+}
+
+func (m *Measurement) SetSearchIndexDuration(dur time.Duration) {
+	m.searchDuration = dur
 }
 
 func (*Measurement) CountUnits(reqStatus *RequestStatus, tags map[string]string) {

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -47,7 +47,6 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 
 	// The order of the interceptors matter with optional elements in them
 	streamInterceptors := []grpc.StreamServerInterceptor{
-		headersStreamServerInterceptor(),
 		metadataExtractorStream(),
 	}
 
@@ -81,7 +80,6 @@ func Get(cfg *config.Config) (grpc.UnaryServerInterceptor, grpc.StreamServerInte
 
 	// The order of the interceptors matter with optional elements in them
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
-		headersUnaryServerInterceptor(),
 		metadataExtractorUnary(),
 	}
 


### PR DESCRIPTION
## Describe your changes
For write workloads, this will return database commit time and search index time separately in response headers. 

## How best to test these changes

## Issue ticket number and link
