### PR TITLE
feat: add method filter for long running requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,7 @@ require (
 	go4.org/intern v0.0.0-20230205224052-192e9f60865c // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230426161633-7e06285ff160 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -629,6 +629,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -151,6 +151,7 @@ type MetricsConfig struct {
 	DebugMessages     bool                        `mapstructure:"debug_messages" yaml:"debug_messages" json:"debug_messages"`
 	TimerQuantiles    []float64                   `mapstructure:"quantiles" yaml:"quantiles" json:"quantiles"`
 	LogLongMethodTime time.Duration               `mapstructure:"log_long_method_time" yaml:"log_long_method_time" json:"log_long_method_time"`
+	LongRequestConfig LongRequestConfig           `mapstructure:"long_request_config" yaml:"long_request_config" json:"long_request_config"`
 	Requests          RequestsMetricGroupConfig   `mapstructure:"requests" yaml:"requests" json:"requests"`
 	Fdb               FdbMetricGroupConfig        `mapstructure:"fdb" yaml:"fdb" json:"fdb"`
 	Search            SearchMetricGroupConfig     `mapstructure:"search" yaml:"search" json:"search"`
@@ -160,6 +161,10 @@ type MetricsConfig struct {
 	Auth              AuthMetricsConfig           `mapstructure:"auth" yaml:"auth" json:"auth"`
 	SecondaryIndex    SecondaryIndexMetricsConfig `mapstructure:"secondary_index" yaml:"secondary_index" json:"secondary_index"`
 	Queue             QueueMetricsConfig          `mapstructure:"queue" yaml:"queue" json:"queue"`
+}
+
+type LongRequestConfig struct {
+	FilteredMethods []string `mapstructure:"filtered_methods" yaml:"filtered_methods" json:"filtered_methods"`
 }
 
 type TimerConfig struct {
@@ -386,6 +391,11 @@ var DefaultConfig = Config{
 		DebugMessages:     false,
 		TimerQuantiles:    []float64{0.5, 0.95, 0.99},
 		LogLongMethodTime: 500 * time.Millisecond,
+		LongRequestConfig: LongRequestConfig{
+			FilteredMethods: []string{
+				"QueryTimeSeriesMetrics",
+			},
+		},
 		Requests: RequestsMetricGroupConfig{
 			Enabled: true,
 			Counter: CounterConfig{


### PR DESCRIPTION
## Describe your changes

Known to be long running methods can be filtered from the logs, like QueryTimeSeriesMetrics.

## How best to test these changes

Tested locally.

## Issue ticket number and link

TIG-1508