### PR TITLE
feat: long request contains number of inserted documents

### DIFF
--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -92,6 +92,11 @@ func (runner *InsertQueryRunner) Run(ctx context.Context, tx transaction.Tx, ten
 	runner.queryMetrics.SetWriteType("insert")
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
 
+	reqStatus, reqStatusFound := metrics.RequestStatusFromContext(ctx)
+	if reqStatus != nil && reqStatusFound {
+		reqStatus.AddResultDocs(int64(len(runner.req.Documents)))
+	}
+
 	return Response{
 		CreatedAt: ts,
 		AllKeys:   allKeys,
@@ -126,6 +131,11 @@ func (runner *ReplaceQueryRunner) Run(ctx context.Context, tx transaction.Tx, te
 
 	runner.queryMetrics.SetWriteType("replace")
 	metrics.UpdateSpanTags(ctx, runner.queryMetrics)
+
+	reqStatus, reqStatusFound := metrics.RequestStatusFromContext(ctx)
+	if reqStatus != nil && reqStatusFound {
+		reqStatus.AddResultDocs(int64(len(runner.req.Documents)))
+	}
 
 	return Response{
 		CreatedAt: ts,


### PR DESCRIPTION
## Describe your changes

Long running insert and replace requests also have the number of documents logged.

## How best to test these changes

Tested locally.

```
$ tigris insert --project=sampledb users \
> '[
>     {"id": 1, "name": "Jania McGrory", "balance": 6045.7},
>     {"id": 2, "name": "Bunny Instone", "balance": 2948.87}
> ]'
```

```
2023-05-15T14:20:31Z ERR metrics/measurement.go:442 long method call bytes received=130 bytes sent=45 grpc method=Insert has error=false result documents=2 start time=1684160431 stop time=1684160431 tenant name=default_namespace_default_namespace threshold=1 total time (ms)=25
```

## Issue ticket number and link

TIG-1509