### PR TITLE
fix: avoid saving copies for namespace accounts

### DIFF
--- a/server/metadata/namespace.go
+++ b/server/metadata/namespace.go
@@ -44,7 +44,7 @@ type NamespaceMetadata struct {
 	// displayName for the namespace
 	Name string
 	// external accounts
-	Accounts AccountIntegrations
+	Accounts *AccountIntegrations
 }
 
 // DefaultNamespace is for "default" namespace in the cluster. This is useful when there is no need to logically group
@@ -96,9 +96,10 @@ func (n *DefaultNamespace) SetMetadata(update NamespaceMetadata) {
 
 func NewNamespaceMetadata(id uint32, name string, displayName string) NamespaceMetadata {
 	return NamespaceMetadata{
-		Id:    id,
-		StrId: name,
-		Name:  displayName,
+		Id:       id,
+		StrId:    name,
+		Name:     displayName,
+		Accounts: &AccountIntegrations{},
 	}
 }
 

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -139,7 +139,6 @@ func (r *UsageReporter) pushUsage() error {
 				if err != nil || !added {
 					log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error adding default plan %s", nsMeta.StrId)
 				}
-
 			}
 		}
 

--- a/server/services/v1/billing/reporter_test.go
+++ b/server/services/v1/billing/reporter_test.go
@@ -44,7 +44,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				Id:    2,
 				StrId: "ns2",
 				Name:  "with metronome integration",
-				Accounts: metadata.AccountIntegrations{
+				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
 						Enabled: true,
 						Id:      "m2",
@@ -55,13 +55,13 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				Id:       3,
 				StrId:    "ns3",
 				Name:     "with metronome disabled",
-				Accounts: metadata.AccountIntegrations{},
+				Accounts: &metadata.AccountIntegrations{},
 			},
 			"ns4": {
 				Id:    4,
 				StrId: "ns4",
 				Name:  "with empty metronome id",
-				Accounts: metadata.AccountIntegrations{
+				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
 						Enabled: true,
 						Id:      "",
@@ -264,7 +264,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				Id:    5,
 				StrId: nsId,
 				Name:  "Failure to pushUsage events for this namespace",
-				Accounts: metadata.AccountIntegrations{
+				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
 						Enabled: true,
 						Id:      uuid.New().String(),
@@ -331,7 +331,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			nsId: {
 				Id:    1,
 				StrId: nsId,
-				Accounts: metadata.AccountIntegrations{
+				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
 						Enabled: true,
 						Id:      uuid.New().String(),
@@ -370,7 +370,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			nsId: {
 				Id:    1,
 				StrId: nsId,
-				Accounts: metadata.AccountIntegrations{
+				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
 						Enabled: false,
 						Id:      uuid.New().String(),


### PR DESCRIPTION
## Describe your changes
- Made accounts on namespace object to be of pointer type so they are not copied/overridden
- Fixed the existing unit tests to reflect the change

## How best to test these changes
- Unit tests
