### PR TITLE
fix: Fixed the error reset for log_only

### DIFF
--- a/server/middleware/authz.go
+++ b/server/middleware/authz.go
@@ -339,8 +339,7 @@ func authzStreamServerInterceptor() grpc.StreamServerInterceptor {
 	}
 }
 
-func authorize(ctx context.Context) error {
-	var err error
+func authorize(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
 			if config.DefaultConfig.Auth.Authz.LogOnly {


### PR DESCRIPTION
## Describe your changes
Fixed the error reset for log_only with named return parameter.

## How best to test these changes

## Issue ticket number and link
