### PR TITLE
fix: Count single write unit for each search deletes, minimum threshold for compression configurable, and fixing go imports

### DIFF
--- a/config/server.dev.yaml
+++ b/config/server.dev.yaml
@@ -17,12 +17,16 @@
 server:
   host: localhost
   port: 8081
+  chunking: true
+  compression: true
 
 cdc:
   enabled: false
 
 kv:
   chunking: true
+  compression: true
+  min_compression_threshold: 1
 
 search:
   host: localhost

--- a/config/server.test.yaml
+++ b/config/server.test.yaml
@@ -22,6 +22,13 @@ environment: test
 search:
   auth_key: ts_test_key
   host: tigris_search
+  chunking: true
+  compression: true
+
+kv:
+  chunking: true
+  compression: true
+  min_compression_threshold: 1
 
 log:
   level: debug

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -365,6 +365,7 @@ var DefaultConfig = Config{
 	KV: KVConfig{
 		Chunking:    false,
 		Compression: false,
+		MinCompressThreshold: 0,
 	},
 	SecondaryIndex: SecondaryIndexConfig{
 		ReadEnabled:   true,
@@ -566,6 +567,7 @@ type KVConfig struct {
 	Chunking bool `mapstructure:"chunking" yaml:"chunking" json:"chunking"`
 	// Compression allows us to compress payload before storing in storage.
 	Compression bool `mapstructure:"compression" yaml:"compression" json:"compression"`
+	MinCompressThreshold int32 `mapstructure:"min_compression_threshold" yaml:"min_compression_threshold" json:"min_compression_threshold"`
 }
 
 // FoundationDBConfig keeps FoundationDB configuration parameters.

--- a/server/metadata/key_generator.go
+++ b/server/metadata/key_generator.go
@@ -16,10 +16,10 @@ package metadata
 
 import (
 	"context"
-	"github.com/tigrisdata/tigris/server/metrics"
 
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
 )

--- a/server/metadata/metadata.go
+++ b/server/metadata/metadata.go
@@ -16,13 +16,13 @@ package metadata
 
 import (
 	"context"
-	"github.com/tigrisdata/tigris/server/metrics"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/internal"
 	"github.com/tigrisdata/tigris/keys"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
 	ulog "github.com/tigrisdata/tigris/util/log"

--- a/server/services/v1/billing_test.go
+++ b/server/services/v1/billing_test.go
@@ -17,7 +17,6 @@ package v1
 import (
 	"context"
 	"testing"
-
 	"time"
 
 	"github.com/google/uuid"

--- a/server/services/v1/database/search_reader.go
+++ b/server/services/v1/database/search_reader.go
@@ -16,12 +16,12 @@ package database
 
 import (
 	"context"
-	"github.com/tigrisdata/tigris/server/metrics"
 
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/query/filter"
 	qsearch "github.com/tigrisdata/tigris/query/search"
 	"github.com/tigrisdata/tigris/schema"
+	"github.com/tigrisdata/tigris/server/metrics"
 	tsearch "github.com/tigrisdata/tigris/server/search"
 	"github.com/tigrisdata/tigris/store/search"
 	"github.com/tigrisdata/tigris/util"

--- a/server/services/v1/search/base_runner.go
+++ b/server/services/v1/search/base_runner.go
@@ -17,7 +17,6 @@ package search
 import (
 	"bytes"
 	"context"
-	"github.com/tigrisdata/tigris/server/metrics"
 
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/internal"
@@ -25,6 +24,7 @@ import (
 	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/server/config"
 	"github.com/tigrisdata/tigris/server/metadata"
+	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/server/types"
 	"github.com/tigrisdata/tigris/store/kv"

--- a/server/services/v1/search/runner.go
+++ b/server/services/v1/search/runner.go
@@ -517,7 +517,8 @@ func (runner *DeleteRunner) deleteDocumentsById(ctx context.Context, tenant *met
 	resp := &api.DeleteDocumentResponse{}
 
 	for _, id := range req.Ids {
-		metrics.AddSearchBytesInContext(ctx, int64(len(id)))
+		// 1 delete means 1 search write unit consumed which is why the bytes are set as the upper limit 4KB.
+		metrics.AddSearchBytesInContext(ctx, int64(config.SearchUnitSize))
 		wr := &api.DocStatus{
 			Id: id,
 		}

--- a/server/services/v1/search/session.go
+++ b/server/services/v1/search/session.go
@@ -26,7 +26,7 @@ import (
 )
 
 type SessionOptions struct {
-	IncVersion      bool
+	IncVersion bool
 }
 
 type Session interface {

--- a/store/kv/compression.go
+++ b/store/kv/compression.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/tigrisdata/tigris/internal"
+	"github.com/tigrisdata/tigris/server/config"
 )
 
 const (
@@ -67,7 +68,12 @@ type CompressTx struct {
 }
 
 func (tx *CompressTx) shouldCompress(data *internal.TableData) bool {
-	return data.ActualUserPayloadSize() > minCompressionThreshold && tx.enabled
+	minCompThreshold := config.DefaultConfig.KV.MinCompressThreshold
+	if minCompThreshold <= 0 {
+		minCompThreshold = minCompressionThreshold
+	}
+
+	return data.ActualUserPayloadSize() > minCompThreshold && tx.enabled
 }
 
 func (tx *CompressTx) compress(data *internal.TableData) *internal.TableData {


### PR DESCRIPTION
## Describe your changes
- Count single write for search deletes
- Make minimum threshold for compression configurable
- Fixing go imports

## How best to test these changes

## Issue ticket number and link
