### PR TITLE
fix: (Revert): backfill missing metronome Ids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ CGO_ENABLED=1
 # Mocks required for unit tests
 MOCK_INTERFACES=\
 "server/services/v1/billing:Provider" \
-"server/metadata:NamespaceMetadataMgr" \
-"server/metadata:TenantGetter"
+"server/metadata:NamespaceMetadataMgr"
 
 all: server
 

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -41,15 +41,12 @@ const (
 	baseSchemaVersion = uint32(1)
 )
 
-// TenantGetter
-// 'make generate' to use mock
 type TenantGetter interface {
 	GetTenant(ctx context.Context, id string) (*Tenant, error)
 	AllTenants(ctx context.Context) []*Tenant
 }
 
-// NamespaceMetadataMgr
-// 'make generate' to use mock
+//go:generate mockery --name NamespaceMetadataMgr
 type NamespaceMetadataMgr interface {
 	GetNamespaceMetadata(ctx context.Context, namespaceId string) *NamespaceMetadata
 	UpdateNamespaceMetadata(ctx context.Context, meta NamespaceMetadata) error

--- a/server/metrics/measurement.go
+++ b/server/metrics/measurement.go
@@ -418,8 +418,7 @@ func (m *Measurement) RecordDuration(scope tally.Scope, tags map[string]string) 
 	case SecondaryIndexRespTime, SecondaryIndexErrorRespTime:
 		timerEnabled = cfg.SecondaryIndex.Timer.TimerEnabled
 		histogramEnabled = cfg.SecondaryIndex.Timer.HistogramEnabled
-	case MetronomeCreateAccount, MetronomeAddPlan, MetronomeIngest, MetronomeGetInvoice, MetronomeListInvoices,
-		MetronomeGetUsage, MetronomeGetCustomer:
+	case MetronomeCreateAccount, MetronomeAddPlan, MetronomeIngest, MetronomeGetInvoice, MetronomeListInvoices, MetronomeGetUsage:
 		timerEnabled = true
 		histogramEnabled = true
 	case RequestsRespTimeToFirstDoc:

--- a/server/metrics/metronome.go
+++ b/server/metrics/metronome.go
@@ -27,7 +27,6 @@ var (
 	MetronomeListInvoices  tally.Scope
 	MetronomeGetInvoice    tally.Scope
 	MetronomeGetUsage      tally.Scope
-	MetronomeGetCustomer   tally.Scope
 )
 
 func initializeMetronomeScopes() {
@@ -37,7 +36,6 @@ func initializeMetronomeScopes() {
 	MetronomeListInvoices = MetronomeMetrics.SubScope("list_invoices")
 	MetronomeGetInvoice = MetronomeMetrics.SubScope("get_invoice")
 	MetronomeGetUsage = MetronomeMetrics.SubScope("get_usage")
-	MetronomeGetCustomer = MetronomeMetrics.SubScope("get_customer")
 }
 
 func GetResponseCodeTags(code int) map[string]string {

--- a/server/services/v1/billing/metronome.go
+++ b/server/services/v1/billing/metronome.go
@@ -431,34 +431,6 @@ func (m *Metronome) GetUsage(ctx context.Context, id AccountId, r *UsageRequest)
 	}, nil
 }
 
-func (m *Metronome) GetAccountId(ctx context.Context, namespaceId string) (AccountId, error) {
-	var (
-		resp *biller.ListCustomersResponse
-		err  error
-	)
-	if len(namespaceId) == 0 {
-		return uuid.Nil, errors.InvalidArgument("namespaceId cannot be empty")
-	}
-	params := &biller.ListCustomersParams{IngestAlias: &namespaceId}
-	m.measure(ctx, metrics.MetronomeGetCustomer, "get_customer", func(ctx context.Context) (*http.Response, error) {
-		resp, err = m.client.ListCustomersWithResponse(ctx, params)
-		if resp == nil {
-			return nil, err
-		}
-		return resp.HTTPResponse, err
-	})
-	if err != nil {
-		return uuid.Nil, err
-	}
-	if resp.JSON200 == nil {
-		return uuid.Nil, NewMetronomeError(resp.StatusCode(), resp.Body)
-	}
-	if len(resp.JSON200.Data) == 0 {
-		return uuid.Nil, errors.NotFound("no account found for namespaceId %s", namespaceId)
-	}
-	return resp.JSON200.Data[0].Id, nil
-}
-
 func buildInvoice(input biller.Invoice) *api.Invoice {
 	if input.Id == uuid.Nil {
 		return nil

--- a/server/services/v1/billing/metronome_test.go
+++ b/server/services/v1/billing/metronome_test.go
@@ -773,86 +773,6 @@ func TestMetronome_GetUsage(t *testing.T) {
 	})
 }
 
-func TestMetronome_GetAccountId(t *testing.T) {
-	initializeMetricsForTest()
-	defer gock.Off()
-	cfg := config.DefaultConfig.Billing.Metronome
-	metronome, err := NewMetronomeProvider(cfg)
-	require.NoError(t, err)
-	ctx := context.TODO()
-
-	t.Run("when a valid customer exists", func(t *testing.T) {
-		nsId, expectedAccountId := "namespaceId", uuid.New()
-
-		gock.New(cfg.URL).
-			Get("customers").
-			MatchParam("ingest_alias", nsId).
-			Reply(200).
-			JSON(map[string]any{
-				"data": []map[string]any{{
-					"id":   expectedAccountId,
-					"name": "new customer",
-				}},
-			})
-		id, err := metronome.GetAccountId(ctx, nsId)
-
-		require.NoError(t, err)
-		require.Equal(t, expectedAccountId, id)
-		require.True(t, gock.IsDone())
-	})
-
-	t.Run("given a invalid namespaceId", func(t *testing.T) {
-		id, err := metronome.GetAccountId(ctx, "")
-		require.ErrorContains(t, err, "cannot be empty")
-		require.Equal(t, uuid.Nil, id)
-		require.True(t, gock.IsDone())
-	})
-
-	t.Run("no customer exists on metronome", func(t *testing.T) {
-		nsId := "namespaceId"
-
-		gock.New(cfg.URL).
-			Get("customers").
-			MatchParam("ingest_alias", nsId).
-			Reply(200).
-			JSON(map[string]any{
-				"data": []map[string]any{},
-			})
-
-		id, err := metronome.GetAccountId(ctx, nsId)
-		require.ErrorContains(t, err, "no account found")
-		require.Equal(t, uuid.Nil, id)
-		require.True(t, gock.IsDone())
-	})
-
-	t.Run("remote service failure", func(t *testing.T) {
-		nsId := "namespaceId"
-
-		gock.New(cfg.URL).
-			Get("customers").
-			MatchParam("ingest_alias", nsId).
-			Reply(400).
-			JSON(map[string]any{
-				"message": "bad request",
-			})
-
-		id, err := metronome.GetAccountId(ctx, nsId)
-		require.ErrorContains(t, err, "bad request")
-		require.Equal(t, uuid.Nil, id)
-		require.True(t, gock.IsDone())
-	})
-
-	t.Run("remote service times out", func(t *testing.T) {
-		gock.New(cfg.URL).Get("customers").ReplyError(fmt.Errorf("request timed out"))
-		id, err := metronome.GetAccountId(ctx, "ns123")
-
-		require.ErrorContains(t, err, "request timed out")
-		require.Equal(t, uuid.Nil, id)
-		require.True(t, gock.IsDone())
-	})
-	require.True(t, gock.IsDone())
-}
-
 func TestMetronome_buildInvoice(t *testing.T) {
 	t.Run("deserializes complete invoice", func(t *testing.T) {
 		payload := `
@@ -1034,5 +954,4 @@ func initializeMetricsForTest() {
 	metrics.MetronomeListInvoices = tally.NewTestScope("list_invoices", map[string]string{})
 	metrics.MetronomeGetInvoice = tally.NewTestScope("get_invoice", map[string]string{})
 	metrics.MetronomeGetUsage = tally.NewTestScope("get_usage", map[string]string{})
-	metrics.MetronomeGetCustomer = tally.NewTestScope("get_customer", map[string]string{})
 }

--- a/server/services/v1/billing/noop.go
+++ b/server/services/v1/billing/noop.go
@@ -55,7 +55,3 @@ func (*noop) GetInvoiceById(_ context.Context, _ AccountId, _ string) (*api.List
 func (*noop) GetUsage(_ context.Context, _ AccountId, _ *UsageRequest) (*api.GetUsageResponse, error) {
 	return nil, errors.Unimplemented("billing not enabled on this server")
 }
-
-func (*noop) GetAccountId(_ context.Context, _ string) (AccountId, error) {
-	return uuid.Nil, errors.Unimplemented("billing not enabled on this server")
-}

--- a/server/services/v1/billing/provider.go
+++ b/server/services/v1/billing/provider.go
@@ -35,7 +35,6 @@ type Provider interface {
 	GetInvoices(ctx context.Context, accountId AccountId, r *api.ListInvoicesRequest) (*api.ListInvoicesResponse, error)
 	GetInvoiceById(ctx context.Context, accountId AccountId, invoiceId string) (*api.ListInvoicesResponse, error)
 	GetUsage(ctx context.Context, id AccountId, r *UsageRequest) (*api.GetUsageResponse, error)
-	GetAccountId(ctx context.Context, namespaceId string) (AccountId, error)
 }
 
 type UsageRequest struct {

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -102,8 +102,44 @@ func (r *UsageReporter) pushUsage() error {
 
 	for namespaceId, stats := range chunk.Tenants {
 		nsMeta := r.nsMgr.GetNamespaceMetadata(r.ctx, namespaceId)
-		if success := r.setupBillingAccount(nsMeta); !success {
+		if nsMeta == nil {
+			log.Error().Msgf("invalid namespace id %s", namespaceId)
 			continue
+		}
+		if nsMeta.Accounts == nil {
+			nsMeta.Accounts = &metadata.AccountIntegrations{}
+		}
+		if len(nsMeta.StrId) == 0 || nsMeta.StrId == defaults.DefaultNamespaceName {
+			// invalid namespace id, permanently disable account creation
+			nsMeta.Accounts.DisableMetronome()
+			err := r.nsMgr.UpdateNamespaceMetadata(r.ctx, *nsMeta)
+			if err != nil {
+				log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error saving metadata for %s", nsMeta.StrId)
+			}
+			continue
+		}
+
+		if id, enabled := nsMeta.Accounts.GetMetronomeId(); !enabled {
+			continue
+		} else if len(id) == 0 {
+			log.Info().Str("ns", nsMeta.StrId).Msgf("creating Metronome account for %s", nsMeta.StrId)
+
+			billingId, err := r.billingSvc.CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name)
+			if !ulog.E(err) && billingId != uuid.Nil {
+				nsMeta.Accounts.AddMetronome(billingId.String())
+
+				// save updated namespace metadata
+				err = r.nsMgr.UpdateNamespaceMetadata(r.ctx, *nsMeta)
+				if err != nil {
+					log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error saving metadata for %s", nsMeta.StrId)
+				}
+
+				// add default plan to the user
+				added, err := r.billingSvc.AddDefaultPlan(r.ctx, billingId)
+				if err != nil || !added {
+					log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error adding default plan %s", nsMeta.StrId)
+				}
+			}
 		}
 
 		// continue to send event, metronome will disregard it if account does not exist
@@ -123,62 +159,6 @@ func (r *UsageReporter) pushUsage() error {
 		return err
 	}
 	return nil
-}
-
-// returns false if account cannot be setup, no data should be reported in that case
-// returns true, if billing account already exists or new account was setup
-func (r *UsageReporter) setupBillingAccount(nsMeta *metadata.NamespaceMetadata) bool {
-	if nsMeta == nil {
-		log.Error().Msgf("namespace metadata cannot be nil")
-		return false
-	}
-
-	if nsMeta.Accounts == nil {
-		nsMeta.Accounts = &metadata.AccountIntegrations{}
-	}
-
-	if len(nsMeta.StrId) == 0 || nsMeta.StrId == defaults.DefaultNamespaceName {
-		// invalid namespace id, permanently disable account creation
-		nsMeta.Accounts.DisableMetronome()
-		err := r.nsMgr.UpdateNamespaceMetadata(r.ctx, *nsMeta)
-		if err != nil {
-			log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error saving metadata for %s", nsMeta.StrId)
-		}
-		return false
-	}
-	if id, enabled := nsMeta.Accounts.GetMetronomeId(); !enabled {
-		return false
-	} else if len(id) > 0 {
-		return true
-	}
-
-	log.Info().Str("ns", nsMeta.StrId).Msgf("creating Metronome account for %s", nsMeta.StrId)
-	billingId, err := r.billingSvc.CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name)
-	if !ulog.E(err) && billingId != uuid.Nil {
-		// add default plan to the user
-		added, err := r.billingSvc.AddDefaultPlan(r.ctx, billingId)
-		if err != nil || !added {
-			log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error adding default plan %s", nsMeta.StrId)
-		}
-	} else {
-		// check if we received HTTP 409 from billing svc, in that case namespaceId already exists there
-		var metronomeError *MetronomeError
-		if !(errors.As(err, &metronomeError) && metronomeError.HttpCode == 409) {
-			return false
-		}
-		// get id from billing svc and store it
-		if billingId, err = r.billingSvc.GetAccountId(r.ctx, nsMeta.StrId); ulog.E(err) || billingId == uuid.Nil {
-			return true
-		}
-	}
-
-	nsMeta.Accounts.AddMetronome(billingId.String())
-	// save updated namespace metadata
-	err = r.nsMgr.UpdateNamespaceMetadata(r.ctx, *nsMeta)
-	if err != nil {
-		log.Error().Err(err).Str("ns", nsMeta.StrId).Msgf("error saving metadata for %s", nsMeta.StrId)
-	}
-	return true
 }
 
 func (r *UsageReporter) pushStorage() error {

--- a/server/services/v1/billing/reporter_test.go
+++ b/server/services/v1/billing/reporter_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
-	"github.com/tigrisdata/tigris/server/defaults"
 )
 
 var mockKvStore kv.TxStore
@@ -39,13 +38,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			"ns1": {
 				Id:    1,
 				StrId: "ns1",
-				Name:  "enabled metronome account",
-				Accounts: &metadata.AccountIntegrations{
-					Metronome: &metadata.Metronome{
-						Enabled: true,
-						Id:      "m1",
-					},
-				},
+				Name:  "no metronome integration",
 			},
 			"ns2": {
 				Id:    2,
@@ -59,18 +52,24 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				},
 			},
 			"ns3": {
-				Id:    3,
-				StrId: "ns3",
-				Name:  "disabled metronome account",
+				Id:       3,
+				StrId:    "ns3",
+				Name:     "with metronome disabled",
+				Accounts: &metadata.AccountIntegrations{},
+			},
+			"ns4": {
+				Id:    4,
+				StrId: "ns4",
+				Name:  "with empty metronome id",
 				Accounts: &metadata.AccountIntegrations{
 					Metronome: &metadata.Metronome{
-						Enabled: false,
-						Id:      "m3",
+						Enabled: true,
+						Id:      "",
 					},
 				},
 			},
 		}
-		//tenantMgr := &MockTenantManager{data: namespaces}
+		tenantMgr := &MockTenantManager{data: namespaces}
 		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
 			StartTime: time.Time{},
 			EndTime:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -90,6 +89,11 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 					WriteUnits:  32,
 					SearchUnits: 33,
 				},
+				"ns4": {
+					ReadUnits:   41,
+					WriteUnits:  42,
+					SearchUnits: 43,
+				},
 				"doesNotExist": { // this should be ignored and other events should be processed as normal
 					ReadUnits:   1,
 					WriteUnits:  2,
@@ -98,15 +102,25 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			},
 		}}
 
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		reporter, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
+		mockProvider := NewMockProvider(t)
+
+		// CreateAccount and AddDefaultPlan calls only for "ns1" and "ns3"
+		for _, n := range []string{"ns1", "ns3", "ns4"} {
+			mId := uuid.New()
+			mockProvider.EXPECT().CreateAccount(mock.Anything, namespaces[n].StrId, namespaces[n].Name).
+				Return(mId, nil).
+				Once()
+			mockProvider.EXPECT().AddDefaultPlan(mock.Anything, mId).
+				Return(true, nil).
+				Once()
+		}
 
 		// Usage events pushed for each namespace
 		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
 			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
-				require.Len(t, events, 2)
+				require.Len(t, events, 4)
 				for _, e := range events {
-					require.Contains(t, []string{"ns1", "ns2"}, e.CustomerId)
+					require.Contains(t, []string{"ns1", "ns2", "ns3", "ns4"}, e.CustomerId)
 
 					expected, actual := glbStatus.data.Tenants[e.CustomerId], *e.Properties
 					require.Equal(t, expected.WriteUnits+expected.ReadUnits, actual[UsageDbUnits])
@@ -115,53 +129,55 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				return nil
 			}).Once()
 
-		mockTenantMgr.EXPECT().GetNamespaceMetadata(reporter.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, s string) *metadata.NamespaceMetadata {
-				if n, ok := namespaces[s]; ok {
-					return &n
-				}
-				return nil
-			})
-		mockTenantMgr.EXPECT().RefreshNamespaceAccounts(reporter.ctx).Return(nil).Once()
-
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
 		err := reporter.pushUsage()
 		require.NoError(t, err)
+
+		// refreshNamespaceAccounts is only called once
+		require.Equal(t, 1, tenantMgr.refreshNamespaceCalls)
+
+		for _, ns := range namespaces {
+			// validate UpdateNamespaceMetadata adds metronome integration to all
+			id, enabled := ns.Accounts.GetMetronomeId()
+			require.Equal(t, true, enabled)
+			require.NotNil(t, id)
+		}
 	})
 
 	t.Run("push empty events", func(t *testing.T) {
+		tenantMgr := &MockTenantManager{data: map[string]metadata.NamespaceMetadata{}}
 		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
 			StartTime: time.Time{},
 			EndTime:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			Tenants:   map[string]*metrics.TenantStatus{},
 		}}
 
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		reporter, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
+		mockProvider := NewMockProvider(t)
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
 
 		err := reporter.pushUsage()
 		require.NoError(t, err)
-		// mocks not called
-		require.Empty(t, mockTenantMgr.Calls)
+		// refreshNamespaceAccounts is never called
+		require.Equal(t, 0, tenantMgr.refreshNamespaceCalls)
+		// no calls should be made to metronome provider
 		require.Empty(t, mockProvider.Calls)
 	})
 
-	t.Run("fails to push events", func(t *testing.T) {
-		ns := &metadata.NamespaceMetadata{
-			Id:    5,
-			StrId: "PushUsageEvent_fails",
-			Name:  "Failure to pushUsage events for this namespace",
-			Accounts: &metadata.AccountIntegrations{
-				Metronome: &metadata.Metronome{
-					Enabled: true,
-					Id:      uuid.New().String(),
-				},
+	t.Run("fails to create metronome account", func(t *testing.T) {
+		nsId := "createAccountFails"
+		namespaces := map[string]metadata.NamespaceMetadata{
+			nsId: {
+				Id:    4,
+				StrId: nsId,
+				Name:  "metronome account creation fails for this user",
 			},
 		}
+		tenantMgr := &MockTenantManager{data: namespaces}
 		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
 			StartTime: time.Time{},
-			EndTime:   time.Time{},
+			EndTime:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			Tenants: map[string]*metrics.TenantStatus{
-				ns.StrId: {
+				nsId: {
 					ReadUnits:   4,
 					WriteUnits:  5,
 					SearchUnits: 6,
@@ -169,275 +185,251 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 			},
 		}}
 
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		reporter, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
+		mockProvider := NewMockProvider(t)
+		// create account fails
+		mockProvider.EXPECT().CreateAccount(mock.Anything, nsId, mock.Anything).
+			Return(uuid.Nil, fmt.Errorf("failed to create account")).
+			Once()
+		// should still push events
+		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
+				require.Len(t, events, 1)
+				require.Equal(t, nsId, events[0].CustomerId)
+				return nil
+			}).
+			Once()
 
-		mockTenantMgr.EXPECT().GetNamespaceMetadata(reporter.ctx, ns.StrId).
-			Return(ns).
-			Times(2)
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+		err := reporter.pushUsage()
+		require.NoError(t, err)
 
+		// refreshNamespaceAccounts is only called once
+		require.Equal(t, 1, tenantMgr.refreshNamespaceCalls)
+	})
+
+	t.Run("fails to add default plan to metronome account", func(t *testing.T) {
+		nsId := "someId"
+		namespaces := map[string]metadata.NamespaceMetadata{
+			nsId: {
+				Id:    4,
+				StrId: nsId,
+				Name:  "Adding default plan fails for this user",
+			},
+		}
+		tenantMgr := &MockTenantManager{data: namespaces}
+		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
+			StartTime: time.Time{},
+			EndTime:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			Tenants: map[string]*metrics.TenantStatus{
+				nsId: {
+					ReadUnits:   4,
+					WriteUnits:  5,
+					SearchUnits: 6,
+				},
+			},
+		}}
+		mockProvider, mId := NewMockProvider(t), uuid.New()
+		// create account succeeds
+		mockProvider.EXPECT().CreateAccount(mock.Anything, nsId, namespaces[nsId].Name).
+			Return(mId, nil).
+			Once()
+		// add default plan fails
+		mockProvider.EXPECT().AddDefaultPlan(mock.Anything, mId).
+			Return(false, fmt.Errorf("failed to add account")).
+			Once()
+		// should still push events
+		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
+				require.Len(t, events, 1)
+				require.Equal(t, nsId, events[0].CustomerId)
+
+				props := *events[0].Properties
+				require.Equal(t, int64(9), props[UsageDbUnits])
+				require.Equal(t, int64(6), props[UsageSearchUnits])
+				return nil
+			}).
+			Once()
+
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+
+		err := reporter.pushUsage()
+		require.NoError(t, err)
+		require.Equal(t, 1, tenantMgr.refreshNamespaceCalls)
+	})
+
+	t.Run("fails to push events", func(t *testing.T) {
+		nsId := "PushUsageEvent_fails"
+		namespaces := map[string]metadata.NamespaceMetadata{
+			nsId: {
+				Id:    5,
+				StrId: nsId,
+				Name:  "Failure to pushUsage events for this namespace",
+				Accounts: &metadata.AccountIntegrations{
+					Metronome: &metadata.Metronome{
+						Enabled: true,
+						Id:      uuid.New().String(),
+					},
+				},
+			},
+		}
+		tenantMgr := &MockTenantManager{data: namespaces}
+		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+			Tenants: map[string]*metrics.TenantStatus{
+				nsId: {
+					ReadUnits:   4,
+					WriteUnits:  5,
+					SearchUnits: 6,
+				},
+			},
+		}}
+
+		mockProvider := NewMockProvider(t)
 		// push usage call fails
 		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
 			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
 				require.Len(t, events, 1)
-				require.Equal(t, ns.StrId, events[0].CustomerId)
+				require.Equal(t, nsId, events[0].CustomerId)
 				require.Equal(t, int64(9), (*events[0].Properties)[UsageDbUnits])
 				require.Equal(t, int64(6), (*events[0].Properties)[UsageSearchUnits])
 
 				return fmt.Errorf("failed to push usage events")
 			}).Once()
 
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+
 		err := reporter.pushUsage()
 		require.ErrorContains(t, err, "failed to push usage events")
 	})
+
+	t.Run("tenant does not exist", func(t *testing.T) {
+		tenantMgr := &MockTenantManager{data: map[string]metadata.NamespaceMetadata{}}
+		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+			Tenants: map[string]*metrics.TenantStatus{
+				"ns1": {
+					SearchUnits: 6,
+				},
+			},
+		}}
+		mockProvider := NewMockProvider(t)
+		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
+				require.Empty(t, events)
+				return nil
+			}).Once()
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+		err := reporter.pushUsage()
+		require.NoError(t, err)
+	})
+
+	t.Run("metronome gets disabled for invalid namespaceId", func(t *testing.T) {
+		nsId := ""
+		namespaces := map[string]metadata.NamespaceMetadata{
+			nsId: {
+				Id:    1,
+				StrId: nsId,
+				Accounts: &metadata.AccountIntegrations{
+					Metronome: &metadata.Metronome{
+						Enabled: true,
+						Id:      uuid.New().String(),
+					},
+				},
+			},
+		}
+		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+			Tenants: map[string]*metrics.TenantStatus{
+				nsId: {
+					SearchUnits: 6,
+				},
+			},
+		}}
+		tenantMgr := &MockTenantManager{data: namespaces}
+
+		mockProvider := NewMockProvider(t)
+		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
+				require.Empty(t, events)
+				return nil
+			}).Once()
+
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+		err := reporter.pushUsage()
+		require.NoError(t, err)
+		updated := tenantMgr.GetNamespaceMetadata(context.TODO(), nsId)
+		require.False(t, updated.Accounts.Metronome.Enabled)
+	})
+
+	t.Run("tenant is skipped if metronome is disabled", func(t *testing.T) {
+		nsId := "ns1"
+		namespaces := map[string]metadata.NamespaceMetadata{
+			nsId: {
+				Id:    1,
+				StrId: nsId,
+				Accounts: &metadata.AccountIntegrations{
+					Metronome: &metadata.Metronome{
+						Enabled: false,
+						Id:      uuid.New().String(),
+					},
+				},
+			},
+		}
+		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+			Tenants: map[string]*metrics.TenantStatus{
+				nsId: {
+					SearchUnits: 6,
+				},
+			},
+		}}
+		tenantMgr := &MockTenantManager{data: namespaces}
+
+		mockProvider := NewMockProvider(t)
+		mockProvider.EXPECT().PushUsageEvents(mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, events []*UsageEvent) error {
+				require.Empty(t, events)
+				return nil
+			}).Once()
+
+		reporter, _ := NewUsageReporter(glbStatus, tenantMgr, tenantMgr, mockProvider, mockTxMgr)
+		err := reporter.pushUsage()
+		require.NoError(t, err)
+	})
 }
 
-func TestUsageReporter_setupBillingAccount(t *testing.T) {
-	glbStatus := &MockGlobalStatus{}
-	mockTxMgr := transaction.NewManager(mockKvStore)
+type MockTenantManager struct {
+	data                  map[string]metadata.NamespaceMetadata
+	refreshNamespaceCalls int
+}
 
-	t.Run("with nil metadata", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
+func (*MockTenantManager) GetTenant(_ context.Context, id string) (*metadata.Tenant, error) {
+	return nil, fmt.Errorf("invalid tenant id %s", id)
+}
 
-		success := r.setupBillingAccount(nil)
-		require.False(t, success)
-	})
+func (*MockTenantManager) AllTenants(_ context.Context) []*metadata.Tenant {
+	return []*metadata.Tenant{}
+}
 
-	t.Run("with default namespace", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
+func (mock *MockTenantManager) GetNamespaceMetadata(_ context.Context, namespaceId string) *metadata.NamespaceMetadata {
+	if ns, ok := mock.data[namespaceId]; ok {
+		return &ns
+	}
+	return nil
+}
 
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: defaults.DefaultNamespaceName,
-			Name:  "test namespace",
-		}
+func (mock *MockTenantManager) UpdateNamespaceMetadata(_ context.Context, meta metadata.NamespaceMetadata) error {
+	mock.data[meta.StrId] = meta
+	return nil
+}
 
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, actual metadata.NamespaceMetadata) error {
-				require.Equal(t, nsMeta.StrId, actual.StrId)
-				require.Equal(t, nsMeta.Id, actual.Id)
-				require.NotNil(t, actual.Accounts)
-				require.NotNil(t, actual.Accounts.Metronome)
-				require.False(t, actual.Accounts.Metronome.Enabled)
-				require.Equal(t, actual.Accounts.Metronome.Id, "")
-				return nil
-			}).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.False(t, success)
-	})
-
-	t.Run("with empty namespaceId", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "",
-			Name:  "test namespace",
-			Accounts: &metadata.AccountIntegrations{Metronome: &metadata.Metronome{
-				Enabled: true,
-				Id:      "123",
-			}},
-		}
-
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, actual metadata.NamespaceMetadata) error {
-				require.Equal(t, "", actual.StrId)
-				require.Equal(t, nsMeta.Id, actual.Id)
-				require.NotNil(t, actual.Accounts)
-				require.NotNil(t, actual.Accounts.Metronome)
-				require.False(t, actual.Accounts.Metronome.Enabled)
-				require.Equal(t, nsMeta.Accounts.Metronome.Id, actual.Accounts.Metronome.Id)
-				return nil
-			}).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.False(t, success)
-	})
-
-	t.Run("when metronome is disabled", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-			Accounts: &metadata.AccountIntegrations{Metronome: &metadata.Metronome{
-				Enabled: false,
-				Id:      "123",
-			}},
-		}
-
-		success := r.setupBillingAccount(nsMeta)
-		require.False(t, success)
-	})
-
-	t.Run("when metronome id exists", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-			Accounts: &metadata.AccountIntegrations{Metronome: &metadata.Metronome{
-				Enabled: true,
-				Id:      "123",
-			}},
-		}
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
-
-	t.Run("when account creation succeeds", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		expectedAccountId := uuid.New()
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).Return(expectedAccountId, nil).Once()
-		mockProvider.EXPECT().AddDefaultPlan(r.ctx, expectedAccountId).Return(true, nil).Once()
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, actual metadata.NamespaceMetadata) error {
-				require.True(t, actual.Accounts.Metronome.Enabled)
-				require.Equal(t, actual.Accounts.Metronome.Id, expectedAccountId.String())
-				return nil
-			}).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
-
-	t.Run("when adding default plan fails", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		expectedAccountId := uuid.New()
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).Return(expectedAccountId, nil).Once()
-		mockProvider.EXPECT().AddDefaultPlan(r.ctx, expectedAccountId).
-			Return(false, fmt.Errorf("failed to add default plan")).
-			Once()
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, actual metadata.NamespaceMetadata) error {
-				require.True(t, actual.Accounts.Metronome.Enabled)
-				require.Equal(t, actual.Accounts.Metronome.Id, expectedAccountId.String())
-				return nil
-			}).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
-
-	t.Run("when creating account fails because of HTTP 409 - conflict", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		expectedAccountId := uuid.New()
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).
-			Return(uuid.Nil, NewMetronomeError(409, []byte("conflict"))).
-			Once()
-		mockProvider.EXPECT().GetAccountId(r.ctx, nsMeta.StrId).Return(expectedAccountId, nil).Once()
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			RunAndReturn(func(ctx context.Context, actual metadata.NamespaceMetadata) error {
-				require.True(t, actual.Accounts.Metronome.Enabled)
-				require.Equal(t, actual.Accounts.Metronome.Id, expectedAccountId.String())
-				return nil
-			}).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
-
-	t.Run("when creating account fails for Bad Request", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).
-			Return(uuid.Nil, NewMetronomeError(400, []byte("bad request"))).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.False(t, success)
-	})
-
-	t.Run("when creating account fails for unexpected error", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).
-			Return(uuid.Nil, fmt.Errorf("remote service error")).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.False(t, success)
-	})
-
-	t.Run("when getting account id from billing service fails", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).
-			Return(uuid.Nil, NewMetronomeError(409, []byte("conflict"))).
-			Once()
-		mockProvider.EXPECT().GetAccountId(r.ctx, nsMeta.StrId).
-			Return(uuid.Nil, NewMetronomeError(403, []byte("Unauthorized"))).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
-
-	t.Run("when updating namespace metadata fails", func(t *testing.T) {
-		mockProvider, mockTenantMgr, mockTenantGetter := NewMockProvider(t), metadata.NewMockNamespaceMetadataMgr(t), metadata.NewMockTenantGetter(t)
-		r, _ := NewUsageReporter(glbStatus, mockTenantMgr, mockTenantGetter, mockProvider, mockTxMgr)
-		nsMeta := &metadata.NamespaceMetadata{
-			Id:    1,
-			StrId: "ns123",
-			Name:  "test namespace",
-		}
-		expectedAccountId := uuid.New()
-		mockProvider.EXPECT().CreateAccount(r.ctx, nsMeta.StrId, nsMeta.Name).Return(expectedAccountId, nil).Once()
-		mockProvider.EXPECT().AddDefaultPlan(r.ctx, expectedAccountId).Return(true, nil).Once()
-		mockTenantMgr.EXPECT().UpdateNamespaceMetadata(r.ctx, mock.Anything).
-			Return(fmt.Errorf("failed to update namespace metadata")).
-			Once()
-
-		success := r.setupBillingAccount(nsMeta)
-		require.True(t, success)
-	})
+func (mock *MockTenantManager) RefreshNamespaceAccounts(_ context.Context) error {
+	mock.refreshNamespaceCalls++
+	return nil
 }
 
 type MockGlobalStatus struct {


### PR DESCRIPTION
This reverts commit 50536f53ca33d24094fb6c6e1992160cca527082.

