### PR TITLE
chore: Add a log when builder not returning an error and keys are empty

### DIFF
--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -15,6 +15,7 @@
 package filter
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/tigrisdata/tigris/errors"
@@ -22,6 +23,10 @@ import (
 	tsort "github.com/tigrisdata/tigris/query/sort"
 	"github.com/tigrisdata/tigris/schema"
 	"github.com/tigrisdata/tigris/value"
+)
+
+var (
+	ErrKeysEmpty = fmt.Errorf("empty keys")
 )
 
 // KeyComposer needs to be implemented to have a custom Compose method with different constraints.
@@ -203,6 +208,10 @@ func (k *KeyBuilder) Build(filters []Filter, indexedKeys []*schema.QueryableFiel
 
 	// PrimaryKey is always a single plan with all the keys
 	if IndexTypePrimary(k.indexType) {
+		if len(allKeys) == 0 {
+			// this is to know in which case error is not triggered but keys are empty.
+			return nil, ErrKeysEmpty
+		}
 		combined := allKeys[0]
 		for _, plan := range allKeys[1:] {
 			combined.Keys = append(combined.Keys, plan.Keys...)

--- a/server/services/v1/database/base_runner.go
+++ b/server/services/v1/database/base_runner.go
@@ -295,6 +295,11 @@ func (runner *BaseQueryRunner) getWriteIterator(ctx context.Context, tx transact
 			metrics.SetWriteType("non-pkey")
 			return iterator, nil
 		}
+	} else if err == filter.ErrKeysEmpty {
+		log.Err(err).
+			Str("collection", collection.Name).
+			Str("filter", string(reqFilter)).
+			Msg("not able to build keys")
 	}
 
 	pkIterator, err := reader.ScanTable(collection.EncodedName, false)

--- a/server/services/v1/database/query_runner.go
+++ b/server/services/v1/database/query_runner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/rs/zerolog/log"
 	api "github.com/tigrisdata/tigris/api/server/v1"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/internal"
@@ -601,7 +602,13 @@ func (runner *BaseQueryRunner) buildReaderOptions(req *api.ReadRequest, collecti
 	if options.plan, err = planner.GeneratePlan(sortPlan, from); err == nil {
 		// plan can be handled by database index
 		return options, nil
+	} else if err == filter.ErrKeysEmpty {
+		log.Err(err).
+			Str("collection", collection.Name).
+			Str("filter", string(req.Filter)).
+			Msg("not able to build keys")
 	}
+
 	if planner.IsPrefixQueryWithSuffixSort(sortPlan) {
 		// case when it is a prefix query with suffix sort
 		options.tablePlan, err = planner.GenerateTablePlan(sortPlan, from)


### PR DESCRIPTION
## Describe your changes
Adding an error log when keys generated are empty but no errors are returned by the API. 

## How best to test these changes

## Issue ticket number and link
