### PR TITLE
Properly generate pointer types in language schema

### DIFF
--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -127,7 +127,7 @@ const (
 	MessagesMethodName          = realtimeMethodPrefix + "Messages"
 	ListSubscriptionsMethodName = realtimeMethodPrefix + "ListSubscriptions"
 
-	// Search
+	// Search.
 	CreateOrUpdateIndexMethodName = searchMethodPrefix + "CreateOrUpdateIndex"
 	GetIndexMethodName            = searchMethodPrefix + "GetIndex"
 	DeleteIndexMethodName         = searchMethodPrefix + "DeleteIndex"

--- a/query/filter/key_builder.go
+++ b/query/filter/key_builder.go
@@ -25,9 +25,7 @@ import (
 	"github.com/tigrisdata/tigris/value"
 )
 
-var (
-	ErrKeysEmpty = fmt.Errorf("empty keys")
-)
+var ErrKeysEmpty = fmt.Errorf("empty keys")
 
 // KeyComposer needs to be implemented to have a custom Compose method with different constraints.
 type KeyComposer interface {

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tigrisdata/tigris/errors"
 	"github.com/tigrisdata/tigris/lib/container"
+	schema "github.com/tigrisdata/tigris/schema/lang"
 	"github.com/tigrisdata/tigris/server/config"
 )
 
@@ -420,83 +421,26 @@ func FindIndex(indexes []*Index, name string) *Index {
 	return nil
 }
 
-type FieldMultiType struct {
-	Type       []string
-	isNullable bool
-}
-
-func (f *FieldMultiType) append(val string) {
-	if val == "null" {
-		f.isNullable = true
-	} else {
-		f.Type = append(f.Type, val)
-	}
-}
-
-func NewMultiType(val string) FieldMultiType {
-	var f FieldMultiType
-
-	f.append(val)
-
-	return f
-}
-
-func (f *FieldMultiType) UnmarshalJSON(b []byte) error {
-	var tp any
-
-	if err := jsoniter.Unmarshal(b, &tp); err != nil {
-		return err
-	}
-
-	switch val := tp.(type) {
-	case string:
-		f.append(val)
-	case []any:
-		for _, v := range val {
-			s, ok := v.(string)
-			if !ok {
-				return ErrInvalidType
-			}
-
-			f.append(s)
-		}
-	}
-
-	if len(f.Type) > 1 {
-		return ErrOnlyOneNonNullTypeAllowed
-	}
-
-	return nil
-}
-
-func (f *FieldMultiType) First() string {
-	if len(f.Type) > 0 {
-		return f.Type[0]
-	}
-
-	return ""
-}
-
 type FieldBuilder struct {
 	FieldName            string
-	Description          string              `json:"description,omitempty"`
-	TypeRaw              FieldMultiType      `json:"type,omitempty"`
-	Format               string              `json:"format,omitempty"`
-	Encoding             string              `json:"contentEncoding,omitempty"`
-	Default              any                 `json:"default,omitempty"`
-	CreatedAt            *bool               `json:"createdAt,omitempty"`
-	UpdatedAt            *bool               `json:"updatedAt,omitempty"`
-	MaxLength            *int32              `json:"maxLength,omitempty"`
-	MaxItems             *int32              `json:"maxItems,omitempty"`
-	Auto                 *bool               `json:"autoGenerate,omitempty"`
-	Sorted               *bool               `json:"sort,omitempty"`
-	Index                *bool               `json:"index,omitempty"`
-	Facet                *bool               `json:"facet,omitempty"`
-	ID                   *bool               `json:"id,omitempty"`
-	SearchIndex          *bool               `json:"searchIndex,omitempty"`
-	Dimensions           *int                `json:"dimensions,omitempty"`
-	Items                *FieldBuilder       `json:"items,omitempty"`
-	Properties           jsoniter.RawMessage `json:"properties,omitempty"`
+	Description          string                `json:"description,omitempty"`
+	TypeRaw              schema.FieldMultiType `json:"type,omitempty"`
+	Format               string                `json:"format,omitempty"`
+	Encoding             string                `json:"contentEncoding,omitempty"`
+	Default              any                   `json:"default,omitempty"`
+	CreatedAt            *bool                 `json:"createdAt,omitempty"`
+	UpdatedAt            *bool                 `json:"updatedAt,omitempty"`
+	MaxLength            *int32                `json:"maxLength,omitempty"`
+	MaxItems             *int32                `json:"maxItems,omitempty"`
+	Auto                 *bool                 `json:"autoGenerate,omitempty"`
+	Sorted               *bool                 `json:"sort,omitempty"`
+	Index                *bool                 `json:"index,omitempty"`
+	Facet                *bool                 `json:"facet,omitempty"`
+	ID                   *bool                 `json:"id,omitempty"`
+	SearchIndex          *bool                 `json:"searchIndex,omitempty"`
+	Dimensions           *int                  `json:"dimensions,omitempty"`
+	Items                *FieldBuilder         `json:"items,omitempty"`
+	Properties           jsoniter.RawMessage   `json:"properties,omitempty"`
 	Primary              *bool
 	Fields               []*Field
 	AdditionalProperties *bool `json:"additionalProperties,omitempty"`

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris/errors"
+	schema "github.com/tigrisdata/tigris/schema/lang"
 )
 
 var boolTrue = true
@@ -39,27 +40,27 @@ func TestFieldBuilder_Build(t *testing.T) {
 			expError error
 		}{
 			{
-				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("boolean")},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: schema.NewMultiType("boolean")},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("bool")},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: schema.NewMultiType("bool")},
 				expError: errors.InvalidArgument("unsupported type detected 'bool'"),
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("string"), Format: "uuid"},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: schema.NewMultiType("string"), Format: "uuid"},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("number")},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: schema.NewMultiType("number")},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "test", TypeRaw: NewMultiType("integer"), Primary: &boolTrue},
+				builder:  &FieldBuilder{FieldName: "test", TypeRaw: schema.NewMultiType("integer"), Primary: &boolTrue},
 				expError: nil,
 			},
 			{
-				builder:  &FieldBuilder{FieldName: "_test", TypeRaw: NewMultiType("integer")},
+				builder:  &FieldBuilder{FieldName: "_test", TypeRaw: schema.NewMultiType("integer")},
 				expError: nil,
 			},
 		}
@@ -105,7 +106,7 @@ func TestFieldBuilder_Build(t *testing.T) {
 	t.Run("test valid field name pattern", func(t *testing.T) {
 		validFieldNames := []string{"a1", "$a1", "$_a1", "$_", "A1", "Z1"}
 		for _, validFieldName := range validFieldNames {
-			_, err := (&FieldBuilder{FieldName: validFieldName, TypeRaw: NewMultiType("string")}).Build(false) // one time builder, thrown away after test concluded
+			_, err := (&FieldBuilder{FieldName: validFieldName, TypeRaw: schema.NewMultiType("string")}).Build(false) // one time builder, thrown away after test concluded
 			require.NoError(t, err)
 		}
 	})

--- a/schema/inference_test.go
+++ b/schema/inference_test.go
@@ -63,47 +63,47 @@ func TestSchemaInference(t *testing.T) {
 			}, &schema.Schema{
 				Name: "types",
 				Fields: map[string]*schema.Field{
-					"uuid_field":   {Type: "string", Format: "uuid"},
-					"time_field":   {Type: "string", Format: "date-time"},
-					"str_field":    {Type: "string"},
-					"bool_field":   {Type: "boolean"},
-					"float_field":  {Type: "number"},
-					"int_field":    {Type: "integer"},
-					"binary_field": {Type: "string", Format: "byte"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field":   {Type: "string", Format: "uuid"},
-						"time_field":   {Type: "string", Format: "date-time"},
-						"str_field":    {Type: "string"},
-						"bool_field":   {Type: "boolean"},
-						"float_field":  {Type: "number"},
-						"int_field":    {Type: "integer"},
-						"binary_field": {Type: "string", Format: "byte"},
+					"uuid_field":   {Type: schema.NewStringType(), Format: "uuid"},
+					"time_field":   {Type: schema.NewStringType(), Format: "date-time"},
+					"str_field":    {Type: schema.NewStringType()},
+					"bool_field":   {Type: schema.NewBooleanType()},
+					"float_field":  {Type: schema.NewFloatType()},
+					"int_field":    {Type: schema.NewIntegerType()},
+					"binary_field": {Type: schema.NewStringType(), Format: "byte"},
+					"object": {Type: schema.NewObjectType(), Fields: map[string]*schema.Field{
+						"uuid_field":   {Type: schema.NewStringType(), Format: "uuid"},
+						"time_field":   {Type: schema.NewStringType(), Format: "date-time"},
+						"str_field":    {Type: schema.NewStringType()},
+						"bool_field":   {Type: schema.NewBooleanType()},
+						"float_field":  {Type: schema.NewFloatType()},
+						"int_field":    {Type: schema.NewIntegerType()},
+						"binary_field": {Type: schema.NewStringType(), Format: "byte"},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewObjectType(),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string", Format: "uuid"},
-								"time_field":   {Type: "string", Format: "date-time"},
-								"str_field":    {Type: "string"},
-								"bool_field":   {Type: "boolean"},
-								"float_field":  {Type: "number"},
-								"int_field":    {Type: "integer"},
-								"binary_field": {Type: "string", Format: "byte"},
+								"uuid_field":   {Type: schema.NewStringType(), Format: "uuid"},
+								"time_field":   {Type: schema.NewStringType(), Format: "date-time"},
+								"str_field":    {Type: schema.NewStringType()},
+								"bool_field":   {Type: schema.NewBooleanType()},
+								"float_field":  {Type: schema.NewFloatType()},
+								"int_field":    {Type: schema.NewIntegerType()},
+								"binary_field": {Type: schema.NewStringType(), Format: "byte"},
 							},
 						},
 					},
 					"prim_array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "string",
+							Type: schema.NewStringType(),
 						},
 					},
 					"array_uuid": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type:   jsonSpecString,
+							Type:   schema.NewStringType(),
 							Format: jsonSpecFormatUUID,
 						},
 					},
@@ -124,8 +124,8 @@ func TestSchemaInference(t *testing.T) {
 			}, &schema.Schema{
 				Name: "empty_obj_arr",
 				Fields: map[string]*schema.Field{
-					"int_field": {Type: "integer"},
-					"str_field": {Type: "string"},
+					"int_field": {Type: schema.NewIntegerType()},
+					"str_field": {Type: schema.NewStringType()},
 				},
 			},
 		},
@@ -171,25 +171,25 @@ func TestSchemaInference(t *testing.T) {
 			}, &schema.Schema{
 				Name: "broaden_type",
 				Fields: map[string]*schema.Field{
-					"uuid_field":   {Type: "string"},
-					"time_field":   {Type: "string"},
-					"int_field":    {Type: "number"},
-					"binary_field": {Type: "string"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field":   {Type: "string"},
-						"time_field":   {Type: "string"},
-						"int_field":    {Type: "number"},
-						"binary_field": {Type: "string"},
+					"uuid_field":   {Type: schema.NewStringType()},
+					"time_field":   {Type: schema.NewStringType()},
+					"int_field":    {Type: schema.NewFloatType()},
+					"binary_field": {Type: schema.NewStringType()},
+					"object": {Type: schema.NewObjectType(), Fields: map[string]*schema.Field{
+						"uuid_field":   {Type: schema.NewStringType()},
+						"time_field":   {Type: schema.NewStringType()},
+						"int_field":    {Type: schema.NewFloatType()},
+						"binary_field": {Type: schema.NewStringType()},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewObjectType(),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string"},
-								"time_field":   {Type: "string"},
-								"int_field":    {Type: "number"},
-								"binary_field": {Type: "string"},
+								"uuid_field":   {Type: schema.NewStringType()},
+								"time_field":   {Type: schema.NewStringType()},
+								"int_field":    {Type: schema.NewFloatType()},
+								"binary_field": {Type: schema.NewStringType()},
 							},
 						},
 					},
@@ -216,14 +216,14 @@ func TestSchemaInference(t *testing.T) {
 				Name: "broaden_array_type",
 				Fields: map[string]*schema.Field{
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewObjectType(),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string"},
-								"time_field":   {Type: "string"},
-								"int_field":    {Type: "number"},
-								"binary_field": {Type: "string"},
+								"uuid_field":   {Type: schema.NewStringType()},
+								"time_field":   {Type: schema.NewStringType()},
+								"int_field":    {Type: schema.NewFloatType()},
+								"binary_field": {Type: schema.NewStringType()},
 							},
 						},
 					},
@@ -253,19 +253,19 @@ func TestSchemaInference(t *testing.T) {
 			}, &schema.Schema{
 				Name: "adding_fields",
 				Fields: map[string]*schema.Field{
-					"uuid_field": {Type: "string", Format: jsonSpecFormatUUID},
-					"int_field":  {Type: "integer"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field": {Type: "string", Format: jsonSpecFormatUUID},
-						"int_field":  {Type: "integer"},
+					"uuid_field": {Type: schema.NewStringType(), Format: jsonSpecFormatUUID},
+					"int_field":  {Type: schema.NewIntegerType()},
+					"object": {Type: schema.NewObjectType(), Fields: map[string]*schema.Field{
+						"uuid_field": {Type: schema.NewStringType(), Format: jsonSpecFormatUUID},
+						"int_field":  {Type: schema.NewIntegerType()},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewObjectType(),
 							Fields: map[string]*schema.Field{
-								"uuid_field": {Type: "string", Format: jsonSpecFormatUUID},
-								"int_field":  {Type: "integer"},
+								"uuid_field": {Type: schema.NewStringType(), Format: jsonSpecFormatUUID},
+								"int_field":  {Type: schema.NewIntegerType()},
 							},
 						},
 					},
@@ -279,12 +279,12 @@ func TestSchemaInference(t *testing.T) {
 				Name: "adding_array_object_fields",
 				Fields: map[string]*schema.Field{
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType("array"),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewObjectType(),
 							Fields: map[string]*schema.Field{
-								"int_field":     {Type: "integer"},
-								"int_field_two": {Type: "integer"},
+								"int_field":     {Type: schema.NewIntegerType()},
+								"int_field_two": {Type: schema.NewIntegerType()},
 							},
 						},
 					},
@@ -417,8 +417,8 @@ func TestSchemaTags(t *testing.T) {
 			&schema.Schema{
 				Name: "pk_autogenerate",
 				Fields: map[string]*schema.Field{
-					"uuid_field":  {Type: "string", Format: "uuid"},
-					"uuid_field1": {Type: "string", Format: "uuid", AutoGenerate: true},
+					"uuid_field":  {Type: schema.NewStringType(), Format: "uuid"},
+					"uuid_field1": {Type: schema.NewStringType(), Format: "uuid", AutoGenerate: true},
 				},
 				PrimaryKey: []string{"uuid_field"},
 			},
@@ -434,8 +434,8 @@ func TestSchemaTags(t *testing.T) {
 			&schema.Schema{
 				Name: "pk_autogenerate_multi",
 				Fields: map[string]*schema.Field{
-					"uuid_field":  {Type: "string", Format: "uuid", AutoGenerate: true},
-					"uuid_field1": {Type: "string", Format: "uuid", AutoGenerate: true},
+					"uuid_field":  {Type: schema.NewStringType(), Format: "uuid", AutoGenerate: true},
+					"uuid_field1": {Type: schema.NewStringType(), Format: "uuid", AutoGenerate: true},
 				},
 				PrimaryKey: []string{"uuid_field", "uuid_field1"},
 			},

--- a/schema/lang/go_test.go
+++ b/schema/lang/go_test.go
@@ -33,11 +33,14 @@ func TestGoSchemaGenerator(t *testing.T) {
 		{
 			"types", typesTest, `
 type Product struct {
+	ArrIntPtrPtrs *[]*int64 ` + "`" + `json:"arrIntPtrPtrs"` + "`" + `
+	ArrIntPtrs *[]int64 ` + "`" + `json:"arrIntPtrs"` + "`" + `
 	ArrInts []int64 ` + "`" + `json:"arrInts"` + "`" + `
 	Bool bool ` + "`" + `json:"bool"` + "`" + `
 	Byte1 []byte ` + "`" + `json:"byte1"` + "`" + `
 	Id int32 ` + "`" + `json:"id"` + "`" + `
 	Int64 int64 ` + "`" + `json:"int64"` + "`" + `
+	Int64Ptr *int64 ` + "`" + `json:"int64Ptr"` + "`" + `
 	// Int64WithDesc field description
 	Int64WithDesc int64 ` + "`" + `json:"int64WithDesc"` + "`" + `
 	Name string ` + "`" + `json:"name"` + "`" + `
@@ -107,7 +110,7 @@ type SubObjectNestedTwo struct {
 type SubArray struct {
 	Field3 int32 ` + "`" + `json:"field_3"` + "`" + `
 	SubArrayNesteds []SubArrayNested ` + "`" + `json:"subArrayNesteds"` + "`" + `
-	SubObjectNested SubObjectNested ` + "`" + `json:"subObjectNested"` + "`" + `
+	SubObjectNested *SubObjectNested ` + "`" + `json:"subObjectNested"` + "`" + `
 	SubObjectNestedOne SubObjectNestedOne ` + "`" + `json:"subObjectNestedOne"` + "`" + `
 	SubObjectNestedReuseTypeByBody SubObjectNested ` + "`" + `json:"subObjectNestedReuseTypeByBody"` + "`" + `
 	SubObjectNestedThree SubObjectNestedThree ` + "`" + `json:"subObjectNestedThree"` + "`" + `

--- a/schema/lang/java.go
+++ b/schema/lang/java.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:dupl
 package schema
 
 import (

--- a/schema/lang/java_test.go
+++ b/schema/lang/java_test.go
@@ -34,11 +34,14 @@ func TestJavaSchemaGenerator(t *testing.T) {
 		{
 			"types", typesTest, `
 class Product {
+    private long[] arrIntPtrPtrs;
+    private long[] arrIntPtrs;
     private long[] arrInts;
     private boolean bool;
     private byte[] byte1;
     private int id;
     private long int64;
+    private long int64Ptr;
     @TigrisField(description = "field description")
     private long int64WithDesc;
     private String name;
@@ -46,6 +49,22 @@ class Product {
     private Date time1;
     private long[] twoDArr;
     private UUID uUID1;
+
+    public long[] getArrIntPtrPtrs() {
+        return arrIntPtrPtrs;
+    }
+
+    public void setArrIntPtrPtrs(long[] arrIntPtrPtrs) {
+        this.arrIntPtrPtrs = arrIntPtrPtrs;
+    }
+
+    public long[] getArrIntPtrs() {
+        return arrIntPtrs;
+    }
+
+    public void setArrIntPtrs(long[] arrIntPtrs) {
+        this.arrIntPtrs = arrIntPtrs;
+    }
 
     public long[] getArrInts() {
         return arrInts;
@@ -85,6 +104,14 @@ class Product {
 
     public void setInt64(long int64) {
         this.int64 = int64;
+    }
+
+    public long getInt64Ptr() {
+        return int64Ptr;
+    }
+
+    public void setInt64Ptr(long int64Ptr) {
+        this.int64Ptr = int64Ptr;
     }
 
     public long getInt64WithDesc() {
@@ -138,11 +165,14 @@ class Product {
     public Product() {};
 
     public Product(
+        long[] arrIntPtrPtrs,
+        long[] arrIntPtrs,
         long[] arrInts,
         boolean bool,
         byte[] byte1,
         int id,
         long int64,
+        long int64Ptr,
         long int64WithDesc,
         String name,
         double price,
@@ -150,11 +180,14 @@ class Product {
         long[] twoDArrs,
         UUID uUID1
     ) {
+        this.arrIntPtrPtrs = arrIntPtrPtrs;
+        this.arrIntPtrs = arrIntPtrs;
         this.arrInts = arrInts;
         this.bool = bool;
         this.byte1 = byte1;
         this.id = id;
         this.int64 = int64;
+        this.int64Ptr = int64Ptr;
         this.int64WithDesc = int64WithDesc;
         this.name = name;
         this.price = price;
@@ -174,11 +207,14 @@ class Product {
 
         Product other = (Product) o;
         return
+            Arrays.equals(arrIntPtrPtrs, other.arrIntPtrPtrs) &&
+            Arrays.equals(arrIntPtrs, other.arrIntPtrs) &&
             Arrays.equals(arrInts, other.arrInts) &&
             bool == other.bool &&
             byte1 == other.byte1 &&
             id == other.id &&
             int64 == other.int64 &&
+            int64Ptr == other.int64Ptr &&
             int64WithDesc == other.int64WithDesc &&
             name == other.name &&
             price == other.price &&
@@ -190,11 +226,14 @@ class Product {
     @Override
     public int hashCode() {
         return Objects.hash(
+            arrIntPtrPtrs,
+            arrIntPtrs,
             arrInts,
             bool,
             byte1,
             id,
             int64,
+            int64Ptr,
             int64WithDesc,
             name,
             price,

--- a/schema/lang/multi_type.go
+++ b/schema/lang/multi_type.go
@@ -1,0 +1,161 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+var (
+	ErrInvalidType               = fmt.Errorf("invalid type. expected string or array of strings")
+	ErrOnlyOneNonNullTypeAllowed = fmt.Errorf("only one non-null type allowed for the field")
+)
+
+type FieldMultiType struct {
+	Type       []string
+	isNullable bool
+}
+
+func (f *FieldMultiType) append(val string) {
+	if val == "null" {
+		f.isNullable = true
+	} else {
+		f.Type = append(f.Type, val)
+	}
+}
+
+func NewMultiType(val string) FieldMultiType {
+	var f FieldMultiType
+
+	f.append(val)
+
+	return f
+}
+
+func NewStringType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeString)
+
+	return f
+}
+
+func NewIntegerType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeInteger)
+
+	return f
+}
+
+func NewFloatType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeNumber)
+
+	return f
+}
+
+func NewBooleanType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeBoolean)
+
+	return f
+}
+
+func NewObjectType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeObject)
+
+	return f
+}
+
+func NewArrayType() FieldMultiType {
+	var f FieldMultiType
+
+	f.append(typeArray)
+
+	return f
+}
+
+func NewNullableMultiType(val string) FieldMultiType {
+	var f FieldMultiType
+
+	f.append(val)
+
+	f.isNullable = true
+
+	return f
+}
+
+func (f *FieldMultiType) UnmarshalJSON(b []byte) error {
+	var tp any
+
+	if err := jsoniter.Unmarshal(b, &tp); err != nil {
+		return err
+	}
+
+	switch val := tp.(type) {
+	case string:
+		f.append(val)
+	case []any:
+		for _, v := range val {
+			s, ok := v.(string)
+			if !ok {
+				return ErrInvalidType
+			}
+
+			f.append(s)
+		}
+	}
+
+	if len(f.Type) > 1 {
+		return ErrOnlyOneNonNullTypeAllowed
+	}
+
+	return nil
+}
+
+func (f *FieldMultiType) MarshalJSON() ([]byte, error) {
+	if !f.isNullable && len(f.Type) == 1 {
+		return jsoniter.Marshal(f.Type[0])
+	}
+
+	if !f.isNullable {
+		return jsoniter.Marshal(f.Type)
+	}
+
+	return jsoniter.Marshal(append(f.Type, "null"))
+}
+
+func (f *FieldMultiType) First() string {
+	if len(f.Type) > 0 {
+		return f.Type[0]
+	}
+
+	return ""
+}
+
+func (f *FieldMultiType) Set(tp string) {
+	f.Type = []string{tp}
+}
+
+func (f *FieldMultiType) SetNullable() {
+	f.isNullable = true
+}

--- a/schema/lang/schema_test.go
+++ b/schema/lang/schema_test.go
@@ -28,12 +28,15 @@ var (
           "id": { "type": "integer", "format": "int32" },
           "name": { "type": "string" },
           "price": { "type": "number" },
+          "int64Ptr": { "type": ["integer","null"], "format": "int64" },
           "int64": { "type": "integer", "format": "int64" },
           "bool": { "type": "boolean"},
           "byte1": { "type": "string", "format": "byte"},
           "time1": { "type": "string", "format": "date-time"},
           "uUID1": { "type": "string", "format": "uuid"},
           "arrInts": { "type": "array", "items" : { "type" : "integer" } },
+          "arrIntPtrs": { "type": ["array","null"], "items" : { "type" : "integer" } },
+          "arrIntPtrPtrs": { "type": ["array","null"], "items" : { "type" : ["integer","null"] } },
           "int64WithDesc": { "type": "integer", "format": "int64", "description": "field description" },
           "twoDArr": { "type": "array", "items" : { "type": "array", "items" : { "type" : "integer" } } }
 		}}`
@@ -90,7 +93,7 @@ var (
                     }
                   },
 				  "subObjectNested": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "properties": { "field_3": { "type": "integer", "format": "int32" } }
                   },
 				  "subObjectNestedReuseTypeByBody": {

--- a/schema/lang/typescript.go
+++ b/schema/lang/typescript.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:dupl
 package schema
 
 import (

--- a/schema/lang/typescript_test.go
+++ b/schema/lang/typescript_test.go
@@ -35,6 +35,12 @@ func TestTypeScriptSchemaGenerator(t *testing.T) {
 			"types", typesTest, `
 export class Product {
   @Field({ elements: TigrisDataTypes.INT64 })
+  arrIntPtrPtrs: Array<string>;
+
+  @Field({ elements: TigrisDataTypes.INT64 })
+  arrIntPtrs: Array<string>;
+
+  @Field({ elements: TigrisDataTypes.INT64 })
   arrInts: Array<string>;
 
   @Field()
@@ -48,6 +54,9 @@ export class Product {
 
   @Field(TigrisDataTypes.INT64)
   int64: string;
+
+  @Field(TigrisDataTypes.INT64)
+  int64Ptr: string;
 
   // field description
   @Field(TigrisDataTypes.INT64)

--- a/server/config/options.go
+++ b/server/config/options.go
@@ -363,8 +363,8 @@ var DefaultConfig = Config{
 		LogFilter:         false,
 	},
 	KV: KVConfig{
-		Chunking:    false,
-		Compression: false,
+		Chunking:             false,
+		Compression:          false,
 		MinCompressThreshold: 0,
 	},
 	SecondaryIndex: SecondaryIndexConfig{
@@ -566,7 +566,7 @@ type KVConfig struct {
 	// Chunking allows us to persist bigger payload in storage.
 	Chunking bool `mapstructure:"chunking" yaml:"chunking" json:"chunking"`
 	// Compression allows us to compress payload before storing in storage.
-	Compression bool `mapstructure:"compression" yaml:"compression" json:"compression"`
+	Compression          bool  `mapstructure:"compression" yaml:"compression" json:"compression"`
 	MinCompressThreshold int32 `mapstructure:"min_compression_threshold" yaml:"min_compression_threshold" json:"min_compression_threshold"`
 }
 

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -42,14 +42,14 @@ const (
 )
 
 // TenantGetter
-// 'make generate' to use mock
+// 'make generate' to use mock.
 type TenantGetter interface {
 	GetTenant(ctx context.Context, id string) (*Tenant, error)
 	AllTenants(ctx context.Context) []*Tenant
 }
 
 // NamespaceMetadataMgr
-// 'make generate' to use mock
+// 'make generate' to use mock.
 type NamespaceMetadataMgr interface {
 	GetNamespaceMetadata(ctx context.Context, namespaceId string) *NamespaceMetadata
 	UpdateNamespaceMetadata(ctx context.Context, meta NamespaceMetadata) error

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -130,7 +130,7 @@ func (r *UsageReporter) pushUsage() error {
 }
 
 // returns false if account cannot be setup, no data should be reported in that case
-// returns true, if billing account already exists or new account was setup
+// returns true, if billing account already exists or new account was setup.
 func (r *UsageReporter) setupBillingAccount(nsMeta *metadata.NamespaceMetadata) bool {
 	if nsMeta == nil {
 		return false

--- a/server/services/v1/billing/reporter_test.go
+++ b/server/services/v1/billing/reporter_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris/server/defaults"
 	"github.com/tigrisdata/tigris/server/metadata"
 	"github.com/tigrisdata/tigris/server/metrics"
 	"github.com/tigrisdata/tigris/server/transaction"
 	"github.com/tigrisdata/tigris/store/kv"
-	"github.com/tigrisdata/tigris/server/defaults"
 )
 
 var mockKvStore kv.TxStore
@@ -70,7 +70,7 @@ func TestUsageReporter_pushUsage(t *testing.T) {
 				},
 			},
 		}
-		//tenantMgr := &MockTenantManager{data: namespaces}
+
 		glbStatus := &MockGlobalStatus{data: metrics.TenantStatusTimeChunk{
 			StartTime: time.Time{},
 			EndTime:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/templates/schema/go/object.gotmpl
+++ b/templates/schema/go/object.gotmpl
@@ -9,7 +9,9 @@ type {{ .Name }} struct {
     {{- if .Description}}
 {{"\t"}}// {{.Name}} {{.Description}}{{end}}
     {{- $jsonTag := ne $v.NameJSON $v.Name }}
-{{"\t"}}{{ $v.Name }} {{ if $v.IsArray -}} [] {{- end -}} {{ $v.Type }}
+{{"\t"}}{{ $v.Name }} {{ if $v.Nullable -}} * {{- end -}}
+    {{ if $v.IsArray -}} [] {{- end -}}
+    {{ if $v.ItemsNullable -}} * {{- end -}} {{ $v.Type }}
 
     {{- $m := false -}}
     {{- $def := $v.Default}}

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -44,3 +44,12 @@ func GetBaseURL2() string {
 	}
 	return "http://localhost:8082"
 }
+
+func GetGotrueURL() string {
+	config.LoadEnvironment()
+
+	if config.GetEnvironment() == config.EnvTest {
+		return "http://tigris_gotrue:8086"
+	}
+	return "http://localhost:8086"
+}


### PR DESCRIPTION
## Describe your changes

if JSON schema type is nullable, for example:

```
SomeField: { "type" : ["integer", "null"] }
```

it is generated as:

```
SomeField *int
```

in the Golang model.


## How best to test these changes

## Issue ticket number and link
