### PR TITLE
fix: enabling metronome and usage reporting by default

### DIFF
--- a/server/config/options.go
+++ b/server/config/options.go
@@ -290,7 +290,7 @@ type Billing struct {
 }
 
 type Metronome struct {
-	Enabled       bool          `json:"enabled"        mapstructure:"enabled"        yaml:"enabled"`
+	Disabled      bool          `json:"disabled"       mapstructure:"disabled"       yaml:"disabled"`
 	URL           string        `json:"url"            mapstructure:"url"            yaml:"url"`
 	ApiKey        string        `json:"api_key"        mapstructure:"api_key"        yaml:"api_key"`
 	DefaultPlan   string        `json:"default_plan"   mapstructure:"default_plan"   yaml:"default_plan"`
@@ -300,7 +300,7 @@ type Metronome struct {
 type BilledMetrics = map[string]string
 
 type BillingReporter struct {
-	Enabled         bool          `json:"enabled"          mapstructure:"enabled"          yaml:"enabled"`
+	Disabled        bool          `json:"disabled"         mapstructure:"disabled"         yaml:"disabled"`
 	RefreshInterval time.Duration `json:"refresh_interval" mapstructure:"refresh_interval" yaml:"refresh_interval"`
 }
 
@@ -354,14 +354,12 @@ var DefaultConfig = Config{
 	},
 	Billing: Billing{
 		Metronome: Metronome{
-			Enabled: false,
-			URL:     "https://api.metronome.com/v1",
-			ApiKey:  "replace_me",
+			URL:    "https://api.metronome.com/v1",
+			ApiKey: "replace_me",
 			// random placeholder UUID and not an actual plan
 			DefaultPlan: "47eda90f-d2e8-4184-8955-cb3a6467782b",
 		},
 		Reporter: BillingReporter{
-			Enabled:         false,
 			RefreshInterval: time.Second * 60, // 60 seconds
 		},
 	},

--- a/server/services/v1/billing/provider.go
+++ b/server/services/v1/billing/provider.go
@@ -64,7 +64,7 @@ func (w WindowSize) String() string {
 }
 
 func NewProvider() Provider {
-	if config.DefaultConfig.Billing.Metronome.Enabled {
+	if !config.DefaultConfig.Billing.Metronome.Disabled {
 		svc, err := NewMetronomeProvider(config.DefaultConfig.Billing.Metronome)
 		if !ulog.E(err) {
 			return svc

--- a/server/services/v1/billing/provider_test.go
+++ b/server/services/v1/billing/provider_test.go
@@ -22,24 +22,27 @@ import (
 )
 
 func TestNewProvider(t *testing.T) {
-	t.Run("billing is disabled", func(t *testing.T) {
+	t.Run("billing is enabled by default", func(t *testing.T) {
+		require.False(t, config.DefaultConfig.Billing.Metronome.Disabled)
 		provider := NewProvider()
 
 		_, ok := provider.(*noop)
-		require.True(t, ok)
+		require.False(t, ok)
 
 		_, ok = provider.(*Metronome)
-		require.False(t, ok)
+		require.True(t, ok)
 	})
 
-	t.Run("billing is enabled", func(t *testing.T) {
-		config.DefaultConfig.Billing.Metronome.Enabled = true
+	t.Run("billing is disabled", func(t *testing.T) {
+		config.DefaultConfig.Billing.Metronome.Disabled = true
 		provider := NewProvider()
 
 		_, ok := provider.(*noop)
-		require.False(t, ok)
+		require.True(t, ok)
 
 		_, ok = provider.(*Metronome)
-		require.True(t, ok)
+		require.False(t, ok)
+		// reset
+		config.DefaultConfig.Billing.Metronome.Disabled = false
 	})
 }

--- a/server/services/v1/billing/reporter.go
+++ b/server/services/v1/billing/reporter.go
@@ -62,7 +62,7 @@ func NewUsageReporter(
 }
 
 func (r *UsageReporter) Start() {
-	if config.DefaultConfig.Billing.Reporter.Enabled {
+	if !config.DefaultConfig.Billing.Reporter.Disabled {
 		go r.refreshLoop()
 	}
 }


### PR DESCRIPTION
## Describe your changes
- Removes `enabled` key from billing config
- And introduces `disabled` key, which by default is false. Existing dev/preview/prod deployments should continue to operate as usual because this key will be false by default.

## Impact
- this will eliminate a few keys from config while still retaining control
- Any new environments would have usage reporting turned on by default

## How best to test these changes
- Unit tests
