### PR TITLE
feat: Persist project limits in project metadata

### DIFF
--- a/api/server/v1/validator.go
+++ b/api/server/v1/validator.go
@@ -166,6 +166,10 @@ func (x *CreateProjectRequest) Validate() error {
 	return isValidDatabase(x.Project)
 }
 
+func (x *UpdateProjectRequest) Validate() error {
+	return isValidDatabase(x.Project)
+}
+
 func (x *DeleteProjectRequest) Validate() error {
 	return isValidDatabase(x.Project)
 }

--- a/server/metadata/namespace.go
+++ b/server/metadata/namespace.go
@@ -60,6 +60,12 @@ type ProjectMetadata struct {
 	CreatedAt      int64
 	CachesMetadata []CacheMetadata
 	SearchMetadata []SearchMetadata
+	Limits         *ProjectLimits
+}
+
+type ProjectLimits struct {
+	MaxCollections   *int32
+	MaxSearchIndexes *int32
 }
 
 type CacheMetadata struct {

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1222,6 +1222,11 @@ func (tenant *Tenant) ListProjects(_ context.Context) []string {
 	return projects
 }
 
+// GetProjectMetadata retrieves the metadata associated with the project
+func (tenant *Tenant) GetProjectMetadata(ctx context.Context, tx transaction.Tx, projName string) (*ProjectMetadata, error) {
+	return tenant.namespaceStore.GetProjectMetadata(ctx, tx, tenant.namespace.Id(), projName)
+}
+
 // DeleteTenant is used to delete tenant and all the content within it.
 // This needs to be followed up with a "restart" of server to clear memory state.
 // Be careful calling this.

--- a/server/metadata/tenant.go
+++ b/server/metadata/tenant.go
@@ -1222,7 +1222,7 @@ func (tenant *Tenant) ListProjects(_ context.Context) []string {
 	return projects
 }
 
-// GetProjectMetadata retrieves the metadata associated with the project
+// GetProjectMetadata retrieves the metadata associated with the project.
 func (tenant *Tenant) GetProjectMetadata(ctx context.Context, tx transaction.Tx, projName string) (*ProjectMetadata, error) {
 	return tenant.namespaceStore.GetProjectMetadata(ctx, tx, tenant.namespace.Id(), projName)
 }

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -522,7 +522,7 @@ func (s *apiService) CreateProject(ctx context.Context, r *api.CreateProjectRequ
 	}, nil
 }
 
-func (s *apiService) UpdateProject(ctx context.Context, r *api.UpdateProjectRequest) (*api.UpdateProjectResponse, error) {
+func (*apiService) UpdateProject(_ context.Context, _ *api.UpdateProjectRequest) (*api.UpdateProjectResponse, error) {
 	return nil, errors.Unimplemented("Update project is not available")
 }
 

--- a/server/services/v1/api.go
+++ b/server/services/v1/api.go
@@ -522,6 +522,10 @@ func (s *apiService) CreateProject(ctx context.Context, r *api.CreateProjectRequ
 	}, nil
 }
 
+func (s *apiService) UpdateProject(ctx context.Context, r *api.UpdateProjectRequest) (*api.UpdateProjectResponse, error) {
+	return nil, errors.Unimplemented("Update project is not available")
+}
+
 func (s *apiService) DeleteProject(ctx context.Context, r *api.DeleteProjectRequest) (*api.DeleteProjectResponse, error) {
 	accessToken, _ := request.GetAccessToken(ctx)
 	runner := s.runnerFactory.GetProjectQueryRunner(accessToken)


### PR DESCRIPTION
## Describe your changes
- Create Project request can include optional metadata:
```shell
$ ➔  echo -n '{"options": {"limits": {"max_search_indexes": 3}}}' | http POST localhost:8081/v1/projects/catalog/create                                      

HTTP/1.1 200 OK
Content-Length: 61
Content-Type: application/json
Date: Tue, 13 Jun 2023 21:24:38 GMT
Server-Timing: total;dur=18,commit;dur=6
Vary: Origin

{
    "message": "project created successfully",
    "status": "created"
}
```

- List projects to include project metadata if exists:
```shell
$ ➔  http GET localhost:8081/v1/projects

HTTP/1.1 200 OK
Content-Length: 124
Content-Type: application/json
Date: Tue, 13 Jun 2023 21:24:41 GMT
Server-Timing: total;dur=13
Vary: Origin

{
    "projects": [
        {
            "limits": {
                "max_search_indexes": 3
            },
            "project": "catalog"
        },
        {
            "limits": {
                "max_collections": 3
            },
            "project": "todo_app"
        }
    ]
}

```

## How best to test these changes
- Integration testing

> Updating project metadata will be included in next PR